### PR TITLE
fix: add basic_list action to EnterpriseCustomerInviteKeyViewSet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.36.10]
+---------
+fix: add `basic_list` action to ``EnterpriseCustomerInviteKeyViewSet`` to return unpaginated set of invite keys.
+
 [3.36.9]
 --------
 feat: new oauth state for multi-lms-configuration

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.9"
+__version__ = "3.36.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1235,7 +1235,7 @@ class EnterpriseCustomerInviteKeyReadOnlySerializer(BaseEnterpriseCustomerInvite
     """
 
     class Meta(BaseEnterpriseCustomerInviteKeySerializer.Meta):
-        fields = BaseEnterpriseCustomerInviteKeySerializer.Meta.fields + ('enterprise_customer_name', 'usage_count')
+        fields = BaseEnterpriseCustomerInviteKeySerializer.Meta.fields + ('enterprise_customer_name', 'usage_count', 'created')
 
     enterprise_customer_uuid = serializers.SerializerMethodField()
     enterprise_customer_name = serializers.SerializerMethodField()

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1235,7 +1235,8 @@ class EnterpriseCustomerInviteKeyReadOnlySerializer(BaseEnterpriseCustomerInvite
     """
 
     class Meta(BaseEnterpriseCustomerInviteKeySerializer.Meta):
-        fields = BaseEnterpriseCustomerInviteKeySerializer.Meta.fields + ('enterprise_customer_name', 'usage_count', 'created')
+        additional_fields = ('enterprise_customer_name', 'usage_count', 'created')
+        fields = BaseEnterpriseCustomerInviteKeySerializer.Meta.fields + additional_fields
 
     enterprise_customer_uuid = serializers.SerializerMethodField()
     enterprise_customer_name = serializers.SerializerMethodField()

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1175,6 +1175,7 @@ class BaseEnterpriseCustomerInviteKeySerializer(serializers.ModelSerializer):
             'usage_limit',
             'expiration_date',
             'is_active',
+            'is_valid',
         )
 
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -1468,6 +1468,17 @@ class EnterpriseCustomerInviteKeyViewSet(EnterpriseReadWriteModelViewSet):
     @permission_required('enterprise.can_access_admin_dashboard')
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
+    
+    @permission_required('enterprise.can_access_admin_dashboard')
+    @action(methods=['get'], detail=False, url_path='basic-list')
+    def basic_list(self, request, *args, **kwargs):
+        """
+        Unpaginated list of all invite keys matching the filters.
+        """
+        queryset = self.get_queryset()
+        queryset = self.filter_queryset(queryset)
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
 
     @permission_required(
         'enterprise.can_access_admin_dashboard',

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -1468,7 +1468,7 @@ class EnterpriseCustomerInviteKeyViewSet(EnterpriseReadWriteModelViewSet):
     @permission_required('enterprise.can_access_admin_dashboard')
     def list(self, request, *args, **kwargs):
         return super().list(request, *args, **kwargs)
-    
+
     @permission_required('enterprise.can_access_admin_dashboard')
     @action(methods=['get'], detail=False, url_path='basic-list')
     def basic_list(self, request, *args, **kwargs):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4909,6 +4909,7 @@ class TestEnterpriseCustomerInviteKeyViewSet(BaseTestEnterpriseAPIViews):
 
     ENTERPRISE_CUSTOMER_INVITE_KEY_ENDPOINT = 'enterprise-customer-invite-key-detail'
     ENTERPRISE_CUSTOMER_INVITE_KEY_LIST_ENDPOINT = 'enterprise-customer-invite-key-list'
+    ENTERPRISE_CUSTOMER_INVITE_KEY_BASIC_LIST_ENDPOINT = 'enterprise-customer-invite-key-basic-list'
     ENTERPRISE_CUSTOMER_INVITE_KEY_ENDPOINT_LINK_USER = 'enterprise-customer-invite-key-link-user'
     USERNAME = "unlinkedtestuser"
 
@@ -5112,3 +5113,15 @@ class TestEnterpriseCustomerInviteKeyViewSet(BaseTestEnterpriseAPIViews):
             )
         )
         self.assertEqual(response.status_code, 404)
+
+    def test_basic_list_no_pagination_200(self):
+        """
+        Test that basic-list endpoint returns unpaginated response.
+        """
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, str(self.enterprise_customer_1.uuid))
+        response = self.client.get(
+            settings.TEST_SERVER + reverse(
+                self.ENTERPRISE_CUSTOMER_INVITE_KEY_BASIC_LIST_ENDPOINT,
+            )
+        )
+        self.assertEqual(response.status_code, 200)


### PR DESCRIPTION
# Description

The Admin Portal displays all EnterprisecustomerinviteKeys for a specific enterprise customer in an **unpaginated** table. However, the existing API only supports providing data in a paginated response. This limits the frontend's ability to fetch all invite keys quickly without needing to traverse over the existing `list` endpoint, which won't be great for frontend performance or user experience.

Instead, this PR adds a `basic_list` endpoint that returns the same thing as `list` but without pagination. This `basic_list` endpoint will be used by the Admin Portal.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
