### PR TITLE
fix: handle invalid start/end dates in duration calc ENT-5292

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.36.11]
+---------
+fix: Integrated channels Degreed2 exporter now handles invalid start/end date in content metadata item
+
 [3.36.10]
 ---------
 fix: add `basic_list` action to ``EnterpriseCustomerInviteKeyViewSet`` to return unpaginated set of invite keys.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.10"
+__version__ = "3.36.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1115,9 +1115,13 @@ def parse_datetime_handle_invalid(datetime_value):
     """
     Return the parsed version of a datetime string. If the string is invalid, return None.
     """
+    if not datetime_value:
+        return None
     try:
         if not isinstance(datetime_value, datetime.datetime):
             datetime_value = parse_datetime(datetime_value)
+        if not datetime_value:
+            return None
         return datetime_value.replace(tzinfo=pytz.UTC)
     except TypeError:
         return None

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -76,8 +76,22 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
                 return 0
         else:
             return 0
+
         start_date = parse_datetime_handle_invalid(start)
         end_date = parse_datetime_handle_invalid(end)
+        if not start_date or not end_date:
+            LOGGER.error(
+                generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    self.enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    None,
+                    'Failed to find valid start/end dates, so duration is going to be set to 0. '
+                    f'Course item was {content_metadata_item} '
+                    f'Parsed Start was: {start_date}, End was: {end_date}'
+                )
+            )
+            return 0
         return (end_date - start_date).days
 
     def transform_description(self, content_metadata_item):

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -37,7 +37,6 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
 
     def transform_duration(self, content_metadata_item):
         """
-        TODO
         Returns: duration in days
         """
         if content_metadata_item.get('content_type') == 'courserun':

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
@@ -172,3 +172,35 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
         }
         assert exporter.transform_duration(content_metadata_item) == 92
+
+    def test_transform_duration_with_invalid_dates(self):
+        """
+        want to return 0 instead of fail with invalid dates
+        """
+        exporter = Degreed2ContentMetadataExporter('fake-user', self.config)
+        content_metadata_item = {
+            "content_type": "courserun",
+            "key": "course-v1:edX+0089786+3T2021",
+            "start": "2021-10-01T16:00:00Z",
+            "end": None,
+            "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+        }
+        assert exporter.transform_duration(content_metadata_item) == 0
+
+        content_metadata_item = {
+            "content_type": "courserun",
+            "key": "course-v1:edX+0089786+3T2021",
+            "start": "00:00Z",
+            "end": None,
+            "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+        }
+        assert exporter.transform_duration(content_metadata_item) == 0
+
+        content_metadata_item = {
+            "content_type": "courserun",
+            "key": "course-v1:edX+0089786+3T2021",
+            "start": None,
+            "end": "2021-10-01T16:00:00Z",
+            "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+        }
+        assert exporter.transform_duration(content_metadata_item) == 0


### PR DESCRIPTION
ENT-5292

Return 0 duration instead of erroring, when either start or end or both are not valid dates (meaning None or strings that are not formatted correctly). This allows continued processing of the remaining content metadata items instead of interrupting the flow

And yeah, also log the content metadata item and start_date and end_date parsed values for better diagnostics

There is a proposed idea that we skip invalid content metadata items entirely (how we define 'invalid' is up for discussion) but is not included in this PR

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
