### PR TITLE
Adds toggle_universal_link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,7 +17,7 @@ Unreleased
 ----------
 * Nothing
 
-[3.37.00]
+[3.37.0]
 ---------
 feat: Adds toggle_universal_link endpoint
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.37.00]
+---------
+feat: Adds toggle_universal_link endpoint
+
 [3.36.11]
 ---------
 fix: Integrated channels Degreed2 exporter now handles invalid start/end date in content metadata item

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.36.11"
+__version__ = "3.37.00"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1247,3 +1247,12 @@ class EnterpriseCustomerInviteKeyReadOnlySerializer(BaseEnterpriseCustomerInvite
 
     def get_enterprise_customer_name(self, obj):
         return obj.enterprise_customer.name
+
+
+class EnterpriseCustomerToggleUniversalLinkSerializer(serializers.Serializer):
+    """
+    Serializer for toggling an EnterpriseCustomer enable_universal_link field
+    """
+
+    enable_universal_link = serializers.BooleanField(required=True)
+    expiration_date = serializers.DateTimeField(required=False)

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -406,7 +406,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             self.queryset = self.queryset.filter(name__icontains=enterprise_name)
         return self.list(request, *args, **kwargs)
 
-    @action(methods=['patch'], detail=True, url_path='toggle-universal-link', permission_classes=[permissions.IsAuthenticated])
+    @action(methods=['patch'], detail=True, permission_classes=[permissions.IsAuthenticated])
     @permission_required('enterprise.can_access_admin_dashboard')
     def toggle_universal_link(self, request, pk=None):
         """

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -406,6 +406,40 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             self.queryset = self.queryset.filter(name__icontains=enterprise_name)
         return self.list(request, *args, **kwargs)
 
+    @action(methods=['patch'], detail=True, url_path='toggle-universal-link', permission_classes=[permissions.IsAuthenticated])
+    @permission_required('enterprise.can_access_admin_dashboard')
+    def toggle_universal_link(self, request, pk=None):
+        """
+        Enables/Disables universal link config.
+        """
+
+        enterprise_customer = self.get_object()
+        serializer = serializers.EnterpriseCustomerToggleUniversalLinkSerializer(
+            data=request.data,
+            context={
+                'enterprise_customer': enterprise_customer,
+                'request_user': request.user,
+            }
+        )
+
+        if not serializer.is_valid():
+            return Response(serializer.errors, status=HTTP_400_BAD_REQUEST)
+
+        enable_universal_link = serializer.data.get('enable_universal_link')
+        link_expiration_date = serializer.data.get('expiration_date')
+
+        if enterprise_customer.enable_universal_link == enable_universal_link:
+            return Response({"detail": "No changes"}, status=HTTP_200_OK)
+
+        enterprise_customer.toggle_universal_link(
+            enable_universal_link,
+            link_expiration_date,
+        )
+
+        response_body = {"enable_universal_link": enable_universal_link}
+        headers = self.get_success_headers(response_body)
+        return Response(response_body, status=HTTP_200_OK, headers=headers)
+
 
 class EnterpriseCourseEnrollmentViewSet(EnterpriseReadWriteModelViewSet):
     """

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -413,7 +413,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         Enables/Disables universal link config.
         """
 
-        enterprise_customer = self.get_object()
+        enterprise_customer = get_object_or_404(models.EnterpriseCustomer, uuid=pk)
         serializer = serializers.EnterpriseCustomerToggleUniversalLinkSerializer(
             data=request.data,
             context={

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -713,12 +713,13 @@ class EnterpriseCustomer(TimeStampedModel):
         )
         send_enterprise_email_notification.delay(self.uuid, admin_enrollment, email_items)
 
-    def toggle_universal_link(self, enable_universal_link, link_expiration_date):
+    def toggle_universal_link(self, enable_universal_link, link_expiration_date=None):
         """
         Sets enable_universal_link
-
+        Args: 
+            enable_universal_link: new value
+            link_expiration_date: if passed when enable_universal_link is true new link will be created
         If there is no change to be made, return
-
         When enable_universal_link changes to;
             True: a new link is created
             False: all links are deactivate

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -716,7 +716,7 @@ class EnterpriseCustomer(TimeStampedModel):
     def toggle_universal_link(self, enable_universal_link, link_expiration_date=None):
         """
         Sets enable_universal_link
-        Args: 
+        Args:
             enable_universal_link: new value
             link_expiration_date: if passed when enable_universal_link is true new link will be created
         If there is no change to be made, return

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -739,7 +739,7 @@ class EnterpriseCustomer(TimeStampedModel):
             ).update(is_active=False)
         # If universal link is being enabled and a date is passed
         elif link_expiration_date:
-            # Create a new link
+            # Create a new EnterpriseCustomerInviteKey
             EnterpriseCustomerInviteKey.objects.create(
                 enterprise_customer=self,
                 expiration_date=link_expiration_date

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -721,8 +721,8 @@ class EnterpriseCustomer(TimeStampedModel):
             link_expiration_date: if passed when enable_universal_link is true new link will be created
         If there is no change to be made, return
         When enable_universal_link changes to;
-            True: a new link is created
-            False: all links are deactivate
+            True: a new EnterpriseCustomerInviteKey is created
+            False: all EnterpriseCustomerInviteKey are deactivate
         """
         if self.enable_universal_link == enable_universal_link:
             return
@@ -738,7 +738,7 @@ class EnterpriseCustomer(TimeStampedModel):
                 is_active=True,
             ).update(is_active=False)
         # If universal link is being enabled and a date is passed
-        elif bool(link_expiration_date):
+        elif link_expiration_date:
             # Create a new link
             EnterpriseCustomerInviteKey.objects.create(
                 enterprise_customer=self,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1155,7 +1155,7 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
             }],
             [{
                 'id': 1, 'user_id': 0, 'user': None, 'active': True, 'created': '2021-10-20T19:01:31Z',
-                'invite_key': None, 'data_sharing_consent_records': [], 'groups': [],
+                'invite_key': None, 'role_assignments': [], 'data_sharing_consent_records': [], 'groups': [],
                 'enterprise_customer': {
                     'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                     'active': True, 'enable_data_sharing_consent': True,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -9,8 +9,6 @@ from datetime import datetime, timedelta
 from operator import itemgetter
 from smtplib import SMTPException
 
-from django.http import response
-
 import ddt
 import mock
 import responses
@@ -1157,7 +1155,7 @@ class TestEnterpriseCustomerListViews(BaseTestEnterpriseAPIViews):
             }],
             [{
                 'id': 1, 'user_id': 0, 'user': None, 'active': True, 'created': '2021-10-20T19:01:31Z',
-                'invite_key': None, 'role_assignments': [], 'data_sharing_consent_records': [], 'groups': [],
+                'invite_key': None, 'data_sharing_consent_records': [], 'groups': [],
                 'enterprise_customer': {
                     'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
                     'active': True, 'enable_data_sharing_consent': True,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -9,6 +9,8 @@ from datetime import datetime, timedelta
 from operator import itemgetter
 from smtplib import SMTPException
 
+from django.http import response
+
 import ddt
 import mock
 import responses
@@ -5125,3 +5127,162 @@ class TestEnterpriseCustomerInviteKeyViewSet(BaseTestEnterpriseAPIViews):
             )
         )
         self.assertEqual(response.status_code, 200)
+
+
+@ddt.ddt
+@mark.django_db
+class TestEnterpriseCustomerToggleUniversalLinkView(BaseTestEnterpriseAPIViews):
+    """
+    Test toggle_universal_link in EnterpriseCustomerViewSet
+    """
+    TOGGLE_UNIVERSAL_LINK_ENDPOINT = 'enterprise-customer-toggle-universal-link'
+    REQUEST_BODY_TRUE = json.dumps({'enable_universal_link': 'true'})
+    REQUEST_BODY_FALSE = json.dumps({'enable_universal_link': 'false'})
+
+    def setUp(self):
+        super().setUp()
+        self.enterprise_customer = factories.EnterpriseCustomerFactory(name="test_enterprise")
+        self.user = factories.UserFactory(
+            is_active=True,
+            is_staff=False,
+        )
+        self.user.set_password(TEST_PASSWORD)
+        self.user.save()
+
+        feature_role_object, __ = EnterpriseFeatureRole.objects.get_or_create(name=ENTERPRISE_DASHBOARD_ADMIN_ROLE)
+        EnterpriseFeatureUserRoleAssignment.objects.create(user=self.user, role=feature_role_object)
+        self.client = APIClient()
+        self.client.login(username=self.user.username, password=TEST_PASSWORD)
+
+    def tearDown(self):
+        super().tearDown()
+        EnterpriseCustomer.objects.all().delete()
+        EnterpriseCustomerInviteKey.objects.all().delete()
+
+    def test_permissions(self):
+        """
+        Tests permissions work as expected
+        """
+
+        non_admin_user = factories.UserFactory(
+            is_active=True,
+            is_staff=False,
+        )
+        non_admin_user.set_password(TEST_PASSWORD)
+        non_admin_user.save()
+
+        non_admin_client = APIClient()
+        non_admin_client.login(username=non_admin_user.username, password=TEST_PASSWORD)
+
+        forbidden_response = non_admin_client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                kwargs={'pk': self.enterprise_customer.uuid}
+            )
+        )
+        self.assertEqual(forbidden_response.status_code, 403)
+
+        allowed_response = self.client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                kwargs={'pk': self.enterprise_customer.uuid}
+            ),
+            data=self.REQUEST_BODY_TRUE,
+            content_type='application/json',
+        )
+        self.assertEqual(allowed_response.status_code, 200)
+
+    def test_toggle(self):
+        # Toggle to True with date should create a link
+        response = self.client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                kwargs={'pk': self.enterprise_customer.uuid}
+            ),
+            data=json.dumps({
+                'enable_universal_link': 'true',
+                'expiration_date': str(datetime.utcnow())
+            }),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        assert EnterpriseCustomer.objects.get(
+            uuid=self.enterprise_customer.uuid
+        ).enable_universal_link
+
+        assert EnterpriseCustomerInviteKey.objects.filter(
+            enterprise_customer=self.enterprise_customer,
+            is_active=True,
+        ).count() == 1
+
+        # Toggle to False should disable link
+        response = self.client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                kwargs={'pk': self.enterprise_customer.uuid}
+            ),
+            data=json.dumps({'enable_universal_link': 'false'}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+
+        assert not EnterpriseCustomer.objects.get(
+            uuid=self.enterprise_customer.uuid
+        ).enable_universal_link
+
+        assert EnterpriseCustomerInviteKey.objects.filter(
+            enterprise_customer=self.enterprise_customer,
+            is_active=True,
+        ).count() == 0
+
+    def test_enterprise_user_not_found(self):
+        """
+        Test invalid uuid
+        """
+        response = self.client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                (str(uuid.uuid4()),),
+            ),
+            data=json.dumps({'enable_universal_link': 'true'}),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 404)
+
+    @ddt.data(
+        {'enable_universal_link': 'foo'},
+        {'expiration_date': 'bar'},
+        {'enable_universal_link': 'foo', 'expiration_date': 'bar'},
+        {'enable_universal_link': 'foo', 'expiration_date': str(datetime.utcnow())},
+        {'enable_universal_link': 'true', 'expiration_date': 'bar'},
+    )
+    def test_invalid_data(self, data):
+        """
+        Test invalid json data
+        """
+        response = self.client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                kwargs={'pk': self.enterprise_customer.uuid}
+            ),
+            data=json.dumps(data),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 400)
+
+    def test_same_enable_universal_link(self):
+        """
+        Test toggling to same value returns "No Changes" message
+        """
+        response = self.client.patch(
+            settings.TEST_SERVER + reverse(
+                self.TOGGLE_UNIVERSAL_LINK_ENDPOINT,
+                kwargs={'pk': self.enterprise_customer.uuid}
+            ),
+            data=self.REQUEST_BODY_FALSE,
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, 200)
+        response = response.json()
+        self.assertEqual(response['detail'], 'No changes')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -333,6 +333,32 @@ class TestEnterpriseCustomer(unittest.TestCase):
         enterprise_customer.save()
         assert user_preference_mock.objects.filter.call_count == 2
 
+    def test_enterprise_customer_user_toggle_universal_link(self):
+        enterprise_customer = factories.EnterpriseCustomerFactory()
+        # Toggle to True creates with no date, does not create a new link
+        enterprise_customer.toggle_universal_link(True)
+        assert enterprise_customer.enable_universal_link
+        # No links should have been made since a date was not passed
+        assert EnterpriseCustomerInviteKey.objects.filter(
+            enterprise_customer=enterprise_customer,
+            is_active=True,
+        ).count() == 0
+        # Toggle to False
+        enterprise_customer.toggle_universal_link(False)
+        assert not enterprise_customer.enable_universal_link
+        # Toggle to True, with date passed, link should be generated
+        enterprise_customer.toggle_universal_link(True, localized_utcnow() + timedelta(seconds=1))
+        assert EnterpriseCustomerInviteKey.objects.filter(
+            enterprise_customer=enterprise_customer,
+            is_active=True,
+        ).count() == 1
+        # Toggle to False, links should be disabled
+        enterprise_customer.toggle_universal_link(False)
+        assert EnterpriseCustomerInviteKey.objects.filter(
+            enterprise_customer=enterprise_customer,
+            is_active=True,
+        ).count() == 0
+
 
 @mark.django_db
 @ddt.ddt


### PR DESCRIPTION
### [1 of 2 PRs to close 5177](https://openedx.atlassian.net/browse/ENT-5177)


This PR adds the ability to easily toggle the `enable_universal_link` feature in the `EnterpriseCustomer` model. 

Toggling this has side affects as outlined in the ticket.

Test are WIP

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
