### PR TITLE
fix: fix broken django admin search

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.38.2]
+---------
+fix: Django Admin bugfix
+
 [3.38.1]
 ---------
 feat: New crud viewset for IC degreed2 configurations

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.38.1"
+__version__ = "3.38.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -13,4 +13,4 @@ class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
     Admin for the ContentMetadataItemTransmission audit table
     """
     list_display = ('enterprise_customer', 'integrated_channel_code', 'content_id', 'channel_metadata')
-    search_fields = ('enterprise_customer', 'integrated_channel_code', 'content_id')
+    search_fields = ('enterprise_customer__name', 'enterprise_customer__uuid', 'integrated_channel_code', 'content_id')

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -44,7 +44,7 @@ class ContentMetadataTransmitter(Transmitter):
         )
 
     def _log_error(self, msg):
-        LOGGER.info(
+        LOGGER.error(
             generate_formatted_log(
                 self.enterprise_configuration.channel_code(),
                 self.enterprise_configuration.enterprise_customer.uuid,


### PR DESCRIPTION
- fix for when searching contentmetadataitemtransmission results in:

`django.core.exceptions.FieldError: Related Field got invalid lookup: icontains`

- also fixing logging typo
