### PR TITLE
fix: more logging to debug missing completion record

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.38.3]
+---------
+fix: more logging to debug missing completion records
+
 [3.38.2]
 ---------
 fix: Django Admin bugfix

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.38.2"
+__version__ = "3.38.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -86,7 +86,7 @@ class BlackboardLearnerExporter(LearnerExporter):
                 self.enterprise_configuration.channel_code(),
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
-                None,
+                enterprise_enrollment.course_id,
                 ('get_learner_assessment_data_records finished. No learner data was sent for this LMS User Id because'
                  ' Blackboard User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -90,7 +90,7 @@ class CanvasLearnerExporter(LearnerExporter):
                 'canvas',
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
-                None,
+                enterprise_enrollment.course_id,
                 ('get_learner_assessment_data_records finished. No learner data was sent for this LMS User Id because '
                  'Canvas User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -57,7 +57,7 @@ class CornerstoneLearnerExporter(LearnerExporter):
                 self.enterprise_configuration.channel_code(),
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
-                None,
+                enterprise_enrollment.course_id,
                 ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
                  'Cornerstone User ID not found for [{name}]'.format(
                      name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -62,7 +62,7 @@ class DegreedLearnerExporter(LearnerExporter):
             self.enterprise_configuration.channel_code(),
             enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
             enterprise_enrollment.enterprise_customer_user.user_id,
-            None,
+            enterprise_enrollment.course_id,
             ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
              'Degreed User ID not found for [{name}]'.format(
                  name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name

--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -62,7 +62,7 @@ class Degreed2LearnerExporter(LearnerExporter):
             self.enterprise_configuration.channel_code(),
             enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
             enterprise_enrollment.enterprise_customer_user.user_id,
-            None,
+            enterprise_enrollment.course_id,
             ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
              'Degreed2 User ID not found for [{name}]'.format(
                  name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -424,7 +424,10 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             )
 
             LOGGER.info(generate_formatted_log(
-                channel_name, enterprise_customer_uuid, lms_user_id, course_run_id,
+                channel_name,
+                enterprise_customer_uuid,
+                lms_user_id,
+                enterprise_enrollment.course_id,
                 f'kwargs completed_date: '
                 f' {completed_date} '
                 f'api completed_date: '


### PR DESCRIPTION
## Description

Further investigating "pending" progress in customer integrated LMS (Cornerstone).

 - use more consistently available course id's when logging
 - add missing course id's to log lines where applicable

Example, when an LMS user has more than 1 course enrollment, these log messages are ambiguous without a proper course id:

```2022-01-19 20:57:56,664 INFO 1431 [integrated_channels.cornerstone.exporters.learner_data] [user None] [ip None] learner_data.py:56 - integrated_channel=CSOD, integrated_channel_enterprise_customer_uuid=6ee70f0d-3d21-4c03-9578-8eaaef273e4b, integrated_channel_lms_user=41551739, integrated_channel_course_key=None, get_learner_data_records finished. No learner data was sent for this LMS User Id because Cornerstone User ID not found for [Hera Group]```

## References

- [ENT-5255](https://openedx.atlassian.net/browse/ENT-5255)