### PR TITLE
fix: Cornerstone missing completion records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.38.4]
+---------
+fix: bugfix for Cornerstone missing completion records
+
 [3.38.3]
 ---------
 fix: more logging to debug missing completion records

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.38.3"
+__version__ = "3.38.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/cornerstone/client.py
+++ b/integrated_channels/cornerstone/client.py
@@ -93,7 +93,7 @@ class CornerstoneAPIClient(IntegratedChannelApiClient):
         # set them to uuids to comply with Cornerstone standards
         course_id = json_payload['data'].get('courseId')
         key_mapping = get_or_create_key_pair(course_id)
-        json_payload['data']['courseId'] = key_mapping.internal_course_id
+        json_payload['data']['courseId'] = key_mapping.external_course_id
         url = '{base_url}{callback_url}{completion_path}?sessionToken={session_token}'.format(
             base_url=self.enterprise_configuration.cornerstone_base_url,
             callback_url=callback_url,

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -39,11 +39,14 @@ class CornerstoneLearnerExporter(LearnerExporter):
         )
 
         try:
+            # get the proper internal representation of the course key
             course_id = get_course_id_for_enrollment(enterprise_enrollment)
-            key_mapping = get_or_create_key_pair(course_id)
+            # because CornerstoneLearnerDataTransmissionAudit records are created with a click-through
+            # the internal edX course_id is always used on the CornerstoneLearnerDataTransmissionAudit records
+            # rather than the external_course_id mapped via CornerstoneCourseKey
             csod_learner_data_transmission = CornerstoneLearnerDataTransmissionAudit.objects.get(
                 user_id=enterprise_enrollment.enterprise_customer_user.user.id,
-                course_id=key_mapping.external_course_id,
+                course_id=course_id,
             )
             csod_learner_data_transmission.enterprise_course_enrollment_id = enterprise_enrollment.id
             csod_learner_data_transmission.grade = grade

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -7,7 +7,6 @@ from logging import getLogger
 from django.apps import apps
 
 from integrated_channels.catalog_service_utils import get_course_id_for_enrollment
-from integrated_channels.cornerstone.utils import get_or_create_key_pair
 from integrated_channels.integrated_channel.exporters.learner_data import LearnerExporter
 from integrated_channels.utils import generate_formatted_log
 

--- a/integrated_channels/cornerstone/utils.py
+++ b/integrated_channels/cornerstone/utils.py
@@ -10,14 +10,14 @@ from django.apps import apps
 
 def cornerstone_learner_data_transmission_audit():
     """
-    Returns the ``CornerstoneLearnerDataTransmissionAudit`` class.
+        Returns the ``CornerstoneLearnerDataTransmissionAudit`` class.
     """
     return apps.get_model('cornerstone', 'CornerstoneLearnerDataTransmissionAudit')
 
 
 def cornerstone_course_key_model():
     """
-    Returns the ``CornerstoneCourseKey`` class.
+        Returns the ``CornerstoneCourseKey`` class.
     """
     return apps.get_model('cornerstone', 'CornerstoneCourseKey')
 

--- a/integrated_channels/cornerstone/utils.py
+++ b/integrated_channels/cornerstone/utils.py
@@ -13,14 +13,14 @@ from integrated_channels.utils import encode_course_key_into_base64
 
 def cornerstone_learner_data_transmission_audit():
     """
-    Returns the ``EnterpriseCustomer`` class.
+    Returns the ``CornerstoneLearnerDataTransmissionAudit`` class.
     """
     return apps.get_model('cornerstone', 'CornerstoneLearnerDataTransmissionAudit')
 
 
 def cornerstone_course_key_model():
     """
-    Returns the ``EnterpriseCustomer`` class.
+    Returns the ``CornerstoneCourseKey`` class.
     """
     return apps.get_model('cornerstone', 'CornerstoneCourseKey')
 
@@ -53,23 +53,18 @@ def create_cornerstone_learner_data(request, course_id):
 
 def convert_invalid_course_id(course_id):
     """
-    Regex check a course ID to see if it contains any invalid chars. If it does then encode the string, otherwise
-    return the original course ID.
+        upsert a CornerstoneCourseKey object, return the external_course_id
     """
-    safe_course_id = course_id
-    re2 = re.compile(r"[|<>.&%\s\\/\“]+")
-    if re2.search(safe_course_id):
-        # If the course key contains any of the invalid chars, encode the key
-        safe_course_id = encode_course_key_into_base64(course_id)
-    # If the encoded or unencoded version of the key are over 50 characters, they will error out
-    # in cornerstone, so we convert them to a uuid.
-    if len(safe_course_id) > 50:
-        safe_course_id = str(uuid4())
-    return safe_course_id
+    key_mapping = get_or_create_key_pair(course_id)
+    return key_mapping.external_course_id
 
 
 def get_or_create_key_pair(course_id):
+    """
+        upsert and return a CornerstoneCourseKey object, always use uuid4 for new external_course_id records
+        old records may contain: an internal course_id, a base64 encoded internal course_id, a non-hyphenated uuid4
+    """
     key_mapping, ___ = cornerstone_course_key_model().objects.get_or_create(
         internal_course_id=course_id, defaults={
-            'external_course_id': convert_invalid_course_id(course_id)})
+            'external_course_id': str(uuid4())})
     return key_mapping

--- a/integrated_channels/cornerstone/utils.py
+++ b/integrated_channels/cornerstone/utils.py
@@ -2,13 +2,10 @@
 Utilities for Cornerstone integrated channels.
 """
 
-import re
 from logging import getLogger
 from uuid import uuid4
 
 from django.apps import apps
-
-from integrated_channels.utils import encode_course_key_into_base64
 
 
 def cornerstone_learner_data_transmission_audit():

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -206,51 +206,53 @@ class TestCornerstoneContentMetadataExporter(unittest.TestCase, EnterpriseMockMi
     @ddt.data(
         (
             {'key': 'edx+181'},
-            'edx+181',
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+.'},
-            encode_course_key_into_base64('edx+.'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+ '},
-            encode_course_key_into_base64('edx+ '),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+<>'},
-            encode_course_key_into_base64('edx+<>'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+&'},
-            encode_course_key_into_base64('edx+&'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+%'},
-            encode_course_key_into_base64('edx+%'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+|'},
-            encode_course_key_into_base64('edx+|'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'edx+/'},
-            encode_course_key_into_base64('edx+/'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': '..edx+'},
-            encode_course_key_into_base64('..edx+'),
+            FAKE_UUIDS[4],
         ),
         (
             {'key': 'ed%%x+'},
-            encode_course_key_into_base64('ed%%x+'),
+            FAKE_UUIDS[4],
         ),
     )
     @responses.activate
     @ddt.unpack
-    def test_encode_course_key(self, item_key, expected_id):
+    @mock.patch('integrated_channels.cornerstone.utils.uuid4')
+    def test_encode_course_key(self, item_key, expected_id, mock_uuid):
         """
         Transforming a course key encodes the string if and only if invalid chars are present, otherwise it's a noop
         """
+        mock_uuid.return_value = FAKE_UUIDS[4]
         item_content_metadata = merge_dicts(FAKE_SEARCH_ALL_COURSE_RESULT_3, item_key)
         exporter = CornerstoneContentMetadataExporter('fake-user', self.config)
         assert exporter.transform_course_key(item_content_metadata) == expected_id

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_content_metadata.py
@@ -15,7 +15,6 @@ from pytest import mark
 
 from integrated_channels.cornerstone.exporters.content_metadata import CornerstoneContentMetadataExporter
 from integrated_channels.integrated_channel.constants import ISO_8601_DATE_FORMAT
-from integrated_channels.utils import encode_course_key_into_base64
 from test_utils import FAKE_UUIDS, factories
 from test_utils.fake_catalog_api import (
     FAKE_COURSE,

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -20,7 +20,7 @@ from enterprise.api_client import lms as lms_api
 from integrated_channels.cornerstone.exporters.learner_data import CornerstoneLearnerExporter
 from integrated_channels.cornerstone.models import CornerstoneLearnerDataTransmissionAudit
 from integrated_channels.integrated_channel.tasks import transmit_single_learner_data
-from test_utils import factories
+from test_utils import FAKE_UUIDS, factories
 from test_utils.fake_catalog_api import setup_course_catalog_api_client_mock
 from test_utils.integrated_channels_utils import mock_course_overview
 
@@ -191,6 +191,7 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
 
     @responses.activate
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
+    @mock.patch('integrated_channels.cornerstone.utils.uuid4')
     @mock.patch('integrated_channels.cornerstone.client.requests.post')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
@@ -200,7 +201,8 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
         mock_is_course_completed,
         mock_get_course_details,
         mock_get_course_certificate,
-        mock_post_request
+        mock_post_request,
+        mock_uuid
     ):
         """
         Test sending of course completion data to cornerstone progress API
@@ -210,6 +212,8 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
             pacing="instructor",
             end="2022-06-21T12:58:17.428373Z",
         )
+
+        mock_uuid.return_value = FAKE_UUIDS[4]
 
         # Enrollment API
         responses.add(
@@ -241,7 +245,7 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
         expected_payload = {
             "status": "Completed",
             "completionDate": "2019-06-21T12:58:17+00:00",
-            "courseId": self.course_key,
+            "courseId": str(FAKE_UUIDS[4]),
             "successStatus": "Pass",
             "userGuid": self.user_guid,
         }


### PR DESCRIPTION
## Description

To work around some encoding and string-length limitations with Cornerstone, we've gone through a few iterations of mapping internal course_ids to external cornerstone course ids. Sometimes they were the same, sometimes base64 encoded, sometimes some form of a uuid4. Meanwhile, because of the way they're created via a click-through, CornerstoneLearnerDataTransmissionAudit would always contain the internal course_id - I checked the data and the code. The way audit records were being looked-up for course-completion events was flawed in such a way that only courses who had the same internal and external course id representation would end up getting transmitted. In other words, newer mappings who were base64 encoded, or using a uuid4, would never find the appropraite audit record to transmit and fail to send completion events. This PR cleans up that lookup logic, always uses a string uuid for external mappings (to simplify logic), and cleans up and adds some comments.

- correct how CornerstoneLearnerDataTransmissionAudit are looked up
when sending completion events
- clean up how course_id to external_course_id records are mapped

## References

- [ENT-5255](https://openedx.atlassian.net/browse/ENT-5255)
- [ENT-4954](https://openedx.atlassian.net/browse/ENT-4954)
