### PR TITLE
fix: update link_learners action to respond with error when payload i…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.38.5]
+---------
+fix: update link_learners action to respond with error when payload is empty.
+
 [3.38.4]
 ---------
 fix: bugfix for Cornerstone missing completion records

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.38.4"
+__version__ = "3.38.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -911,6 +911,12 @@ class PendingEnterpriseCustomerUserEnterpriseAdminViewSet(PendingEnterpriseCusto
 
         Returns 201 if any users were created, 204 if no users were created.
         """
+        if not request.data:
+            LOGGER.error('Empty user email payload in link_learners for enterprise: %s', enterprise_uuid)
+            return Response(
+                'At least one user email is required.',
+                status=HTTP_400_BAD_REQUEST,
+            )
         context = {'enterprise_customer__uuid': enterprise_uuid}
         serializer = self.get_serializer(
             data=request.data,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -945,6 +945,25 @@ class TestPendingEnterpriseCustomerUserEnterpriseAdminViewSet(BaseTestEnterprise
         )
         assert response.status_code == 403
 
+    def test_post_pending_enterprise_customer_empty_bulk_payload(self):
+        # create user making the request
+        self.setup_admin_user()
+
+        # Create fake enterprise
+        ent_uuid = fake.uuid4()
+        factories.EnterpriseCustomerFactory(uuid=ent_uuid)
+        # Fake enterprise admin permissions
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, ent_uuid)
+
+        route = reverse('link-pending-enterprise-learner', kwargs={'enterprise_uuid': ent_uuid})
+        response = self.client.post(
+            settings.TEST_SERVER + route,
+            data=[],
+            format='json',
+        )
+        assert response.status_code == 400
+        assert response.json() == 'At least one user email is required.'
+
     def test_post_pending_enterprise_customer_user_authorized_for_different_enterprise(self):
         # create user making the request
         self.setup_admin_user()


### PR DESCRIPTION
…s empty.

This change would help us proactively identify UI defects as found in
https://openedx.atlassian.net/browse/ENT-5194

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
