### PR TITLE
feat: add created to enterprise course enrollment serializer fields

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,9 @@ Unreleased
 ----------
 * Nothing
 
+[3.38.6]
+feat: add created to enterprise course enrollment serializer fields
+
 [3.38.5]
 ---------
 fix: update link_learners action to respond with error when payload is empty.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.38.5"
+__version__ = "3.38.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -58,6 +58,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
             certificate_info,
             instance
         )
+        representation['created'] = instance.created.isoformat()
         representation['start_date'] = course_overview['start']
         representation['end_date'] = course_overview['end']
         representation['display_name'] = course_overview['display_name_with_default']

--- a/tests/test_enterprise_learner_portal/api/test_serializers.py
+++ b/tests/test_enterprise_learner_portal/api/test_serializers.py
@@ -84,6 +84,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             ('emails_enabled', True),
             ('course_run_id', course_run_id),
             ('course_run_status', 'completed'),
+            ('created', enterprise_enrollment.created.isoformat()),
             ('start_date', 'a datetime object'),
             ('end_date', 'a datetime object'),
             ('display_name', 'a default name'),
@@ -93,7 +94,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             ('org_name', 'my university'),
             ('is_revoked', False),
             ('is_enrollment_active', True),
-            ('mode', 'verified')
+            ('mode', 'verified'),
         ])
         actual = serializer.data[0]
         self.assertDictEqual(actual, expected)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-5135

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
