### PR TITLE
chore: add reserved keywords linter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.8']
-        toxenv: [quality, docs, pii-annotations, django22, django30, django31, django32]
+        toxenv: [quality, docs, pii-annotations, django22, django30, django31, django32, check_keywords]
     env:
       RUNJSHINT: true
     steps:

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ pii_clean:
 isort: ## call isort on packages/files that are checked in quality tests
 	isort --skip migrations --recursive tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py
 
+check_keywords: ## Scan the Django models in all installed apps in this project for restricted field names
+	python manage.py check_reserved_keywords --override_file db_keyword_overrides.yml
+
 .PHONY: clean clean.static compile_translations coverage docs dummy_translations extract_translations \
 	fake_translations help pull_translations push_translations requirements test test-all upgrade validate isort \
-	static static.dev static.watch
+	static static.dev static.watch check_keywords

--- a/db_keyword_overrides.yml
+++ b/db_keyword_overrides.yml
@@ -1,0 +1,10 @@
+# This file is used by the 'check_reserved_keywords' management command to allow specific field names to be overridden
+# when checking for conflicts with lists of restricted keywords used in various database/data warehouse tools.
+# For more information, see: https://github.com/edx/edx-django-release-util/release_util/management/commands/check_reserved_keywords.py
+#
+# overrides should be added in the following format:
+#   - ModelName.field_name
+---
+MYSQL:
+SNOWFLAKE:
+STITCH:

--- a/tox.ini
+++ b/tox.ini
@@ -97,3 +97,12 @@ deps =
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage
 
+[testenv:check_keywords]
+setenv =
+    DJANGO_SETTINGS_MODULE = enterprise.settings.test
+whitelist_externals =
+    make
+deps =
+    -r{toxinidir}/requirements/test.txt
+commands =
+    make check_keywords


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
