### PR TITLE
feat: docker-based local work without lms

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,52 @@
+lms_mongo_dump/
+
+### Python artifacts
+**/*.pyc
+
+### artifacts
+**/*.bak
+
+### Logging artifacts
+**/log/
+**/logs
+**/*.log
+
+### Installation artifacts
+**/*.egg-info
+**/.prereqs_cache
+**/node_modules
+**/bin/
+
+**/dist/
+**/build
+**/eggs
+**/parts
+**/bin
+**/var
+**/sdist
+**/develop-eggs
+**/.installed.cfg
+**/lib
+**/lib64
+**/__pycache__
+
+
+### Internationalization artifacts
+**/*.mo
+**/*.po
+**/*.prob
+**/*.dup
+!**/django.po
+!**/django.mo
+!**/djangojs.po
+!**/djangojs.mo
+conf/locale/en/LC_MESSAGES/*.mo
+conf/locale/fake*/LC_MESSAGES/*.po
+conf/locale/fake*/LC_MESSAGES/*.mo
+
+# Unit test / coverage reports
+**/.coverage
+**/htmlcov
+**/.tox
+**/nosetests.xml
+**/unittests.xml

--- a/.dockerignore
+++ b/.dockerignore
@@ -2,6 +2,16 @@ lms_mongo_dump/
 
 ### Python artifacts
 **/*.pyc
+.pytest_cache
+
+# Unit test / coverage reports
+.cache/
+.coverage
+.coverage.*
+.tox
+coverage.xml
+htmlcov/
+pii_report/
 
 ### artifacts
 **/*.bak

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,91 @@
+FROM ubuntu:focal as app
+MAINTAINER sre@edx.org
+
+
+# Packages installed:
+# git; Used to pull in particular requirements from github rather than pypi,
+# and to check the sha of the code checkout.
+
+# build-essentials; so we can use make with the docker container
+
+# language-pack-en locales; ubuntu locale support so that system utilities have a consistent
+# language and time zone.
+
+# python; ubuntu doesnt ship with python, so this is the python we will use to run the application
+
+# python3-pip; install pip to install application requirements.txt files
+
+# libmysqlclient-dev; to install header files needed to use native C implementation for
+# MySQL-python for performance gains.
+
+# libssl-dev; # mysqlclient wont install without this.
+
+# python3-dev; to install header files for python extensions; much wheel-building depends on this
+
+# gcc; for compiling python extensions distributed with python packages like mysql-client
+
+# If you add a package here please include a comment above describing what it is used for
+RUN apt-get update && apt-get -qy install --no-install-recommends \
+ language-pack-en \
+ locales \
+ python3.8 \
+ python3-pip \
+ python3.8-venv \
+ libmysqlclient-dev \
+ libssl-dev \
+ python3-dev \
+ gcc \
+ build-essential \
+ git
+
+
+RUN pip install --upgrade pip setuptools
+# delete apt package lists because we do not need them inflating our image
+RUN rm -rf /var/lib/apt/lists/*
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN locale-gen en_US.UTF-8
+ENV LANG en_US.UTF-8
+ENV LANGUAGE en_US:en
+ENV LC_ALL en_US.UTF-8
+ENV DJANGO_SETTINGS_MODULE enterprise.settings.test
+
+# Env vars: path
+ENV VIRTUAL_ENV='/edx/app/edx-enterprise/venvs/edxapp'
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+ENV PATH="/edx/app/edx-enterprise/node_modules/.bin:${PATH}"
+ENV PATH="/edx/app/edx-enterprise/bin:${PATH}"
+ENV PATH="/edx/app/edx-enterprise/nodeenv/bin:${PATH}"
+
+RUN useradd -m --shell /bin/false app
+
+WORKDIR /edx/app/edx-enterprise
+
+RUN python3.8 -m venv $VIRTUAL_ENV
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+
+# Copy the requirements explicitly even though we copy everything below
+# this prevents the image cache from busting unless the dependencies have changed.
+COPY requirements/ /edx/app/edx-enterprise/requirements/
+
+# Dependencies are installed as root so they cannot be modified by the application user.
+RUN pip install -r requirements/dev.txt
+RUN pip install nodeenv
+
+# Set up a Node environment and install Node requirements.
+# Must be done after Python requirements, since nodeenv is installed
+# via pip.
+# The node environment is already 'activated' because its .../bin was put on $PATH.
+RUN nodeenv /edx/app/edx-enterprise/nodeenv --node=12.11.1 --prebuilt
+
+RUN mkdir -p /edx/var/log
+
+# Code is owned by root so it cannot be modified by the application user.
+# So we copy it before changing users.
+USER app
+
+# This line is after the requirements so that changes to the code will not
+# bust the image cache
+COPY . /edx/app/edx-enterprise
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -36,7 +36,8 @@ RUN apt-get update && apt-get -qy install --no-install-recommends \
  python3-dev \
  gcc \
  build-essential \
- git
+ git \
+ curl
 
 
 RUN pip install --upgrade pip setuptools

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
+# Docker in this repo is only supported for running tests locally
+# as an alternative to virtualenv natively - johnnagro 2022-02-11
 FROM ubuntu:focal as app
 MAINTAINER sre@edx.org
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -55,11 +55,11 @@ ENV LC_ALL en_US.UTF-8
 ENV DJANGO_SETTINGS_MODULE enterprise.settings.test
 
 # Env vars: path
-ENV VIRTUAL_ENV='/edx/app/edx-enterprise/venvs/edxapp'
+ENV VIRTUAL_ENV='/edx/app/venvs/edx-enterprise'
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 ENV PATH="/edx/app/edx-enterprise/node_modules/.bin:${PATH}"
 ENV PATH="/edx/app/edx-enterprise/bin:${PATH}"
-ENV PATH="/edx/app/edx-enterprise/nodeenv/bin:${PATH}"
+ENV PATH="/edx/app/nodeenv/bin:${PATH}"
 
 RUN useradd -m --shell /bin/false app
 
@@ -80,7 +80,7 @@ RUN pip install nodeenv
 # Must be done after Python requirements, since nodeenv is installed
 # via pip.
 # The node environment is already 'activated' because its .../bin was put on $PATH.
-RUN nodeenv /edx/app/edx-enterprise/nodeenv --node=12.11.1 --prebuilt
+RUN nodeenv /edx/app/nodeenv --node=12.11.1 --prebuilt
 
 RUN mkdir -p /edx/var/log
 

--- a/Makefile
+++ b/Makefile
@@ -173,8 +173,8 @@ isort: ## call isort on packages/files that are checked in quality tests
 
 ## Docker in this repo is only supported for running tests locally
 ## as an alternative to virtualenv natively - johnnagro 2022-02-11
-%-shell: ## Run a shell, as root, on the specified service container
-	docker-compose run -u 0 $* env TERM=$(TERM) /bin/bash
+test-shell: ## Run a shell, as root, on the specified service container
+	docker-compose run -u 0 test-shell env TERM=$(TERM) /bin/bash
 
 .PHONY: clean clean.static compile_translations coverage docs dummy_translations extract_translations \
 	fake_translations help pull_translations push_translations requirements test test-all upgrade validate isort \

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,9 @@ pii_clean:
 isort: ## call isort on packages/files that are checked in quality tests
 	isort --skip migrations --recursive tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py
 
+%-shell: ## Run a shell, as root, on the specified service container
+	docker-compose run -u 0 $* env TERM=$(TERM) /bin/bash
+
 .PHONY: clean clean.static compile_translations coverage docs dummy_translations extract_translations \
 	fake_translations help pull_translations push_translations requirements test test-all upgrade validate isort \
 	static static.dev static.watch

--- a/Makefile
+++ b/Makefile
@@ -171,6 +171,8 @@ pii_clean:
 isort: ## call isort on packages/files that are checked in quality tests
 	isort --skip migrations --recursive tests test_utils enterprise enterprise_learner_portal consent integrated_channels manage.py setup.py
 
+## Docker in this repo is only supported for running tests locally
+## as an alternative to virtualenv natively - johnnagro 2022-02-11
 %-shell: ## Run a shell, as root, on the specified service container
 	docker-compose run -u 0 $* env TERM=$(TERM) /bin/bash
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,23 @@
+version: "2.1"
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    container_name: enterprise.test.app
+    hostname: app.test.enterprise
+    volumes:
+      - .:/edx/app/enterprise_catalog/enterprise_catalog
+      - ../src:/edx/src:cached
+
+    networks:
+      - devstack_default
+    # Allows attachment to this container using 'docker attach <containerID>'.
+    stdin_open: true
+    tty: true
+    environment:
+      DJANGO_SETTINGS_MODULE: enterprise.settings.test
+
+networks:
+  devstack_default:
+    external: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,5 @@
+# Docker in this repo is only supported for running tests locally
+# as an alternative to virtualenv natively - johnnagro 2022-02-11
 version: "2.1"
 services:
   app:
@@ -7,7 +9,7 @@ services:
     container_name: enterprise.test.app
     hostname: app.test.enterprise
     volumes:
-      - .:/edx/app/enterprise_catalog/enterprise_catalog
+      - .:/edx/app/edx-enterprise
       - ../src:/edx/src:cached
 
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@
 # as an alternative to virtualenv natively - johnnagro 2022-02-11
 version: "2.1"
 services:
-  app:
+  test-shell:
     build:
       context: .
       dockerfile: Dockerfile

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,6 @@ services:
     hostname: app.test.enterprise
     volumes:
       - .:/edx/app/edx-enterprise
-      - ../src:/edx/src:cached
 
     networks:
       - devstack_default

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -43,6 +43,15 @@ below is executed within the virtualenv.
 
 .. _virtualenv: https://virtualenvwrapper.readthedocs.org/en/latest/
 
+Alternatively, `docker`_ can be used to provide a containerized shell to run the commands below inside.
+
+.. _docker: https://www.docker.com/
+
+.. code-block:: bash
+
+    $ make test-shell
+
+
 Install dependencies
 ^^^^^^^^^^^^^^^^^^^^
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -27,6 +27,14 @@ If you have not already done so, create/activate a `virtualenv`_.
 
 .. _virtualenv: https://virtualenvwrapper.readthedocs.org/en/latest/
 
+Alternatively, `docker`_ can be used to provide a containerized shell to run tests with.
+
+.. _docker: https://www.docker.com/
+
+.. code-block:: bash
+
+    $ make test-shell
+
 Dependencies can be installed via the command below.
 
 .. code-block:: bash

--- a/docs/testing.rst
+++ b/docs/testing.rst
@@ -8,7 +8,15 @@ checks to catch potential problems during development.
 
 Running all of the python tests
 -------------------------------
-To run all unit tests and quality checks in the version of Python you chose for your virtualenv:
+To run all unit tests and quality checks in the version of Python you chose for your virtualenv.
+
+Alternatively, `docker`_ can be used to provide a containerized shell to run the commands below inside.
+
+.. _docker: https://www.docker.com/
+
+.. code-block:: bash
+
+    $ make test-shell
 
 .. code-block:: bash
 


### PR DESCRIPTION
## Description

There are sometimes benefits and conveniences to having a containerized local environment versus setting up and maintaining python, virtualenv, and system dependencies (mysql-dev, etc) natively. Sometimes installing your code into the LMS container extends your testing cycle past your patience. Here is some docker/makefile config to enable `make test-shell` to launch a containerized environment containing your local development code so you can `make test` / `make upgrade` / 'profit' / etc inside a container. 

Does not run the web-service nor workers (still need to install your code into an LMS container for that), just wraps local development & dependency management inside docker to make it easier to develop - think of it as dockerized `virtualenv` for your native development system.

## Want to try?

Check this branch out, then run `make test-shell` which should build the `Dockerfile` then drop you into a bash prompt with `dev.txt` dependencies already installed. Then you can run commands such as `make test` or `make upgrade` inside the container.

## References

- [ENT-3934](https://openedx.atlassian.net/browse/ENT-3934)