### PR TITLE
feat: Add duration to the schedule of payload for SAP content metadata exporter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.40.6]
+---------
+feat: SAPSF content metadata transmission now also sends course schedule
+
 [3.40.5]
 ---------
 feat: adding CornerstoneLearnerDataTransmissionAudit admin view

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.40.5"
+__version__ = "3.40.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1141,6 +1141,7 @@ def get_course_run_duration_info(course_run):
         )
     return duration_info
 
+
 def get_duration_of_course_or_courserun(content_metadata_item):
     """
     Returns duration start, end dates given a piece of content_metadata item

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1141,6 +1141,35 @@ def get_course_run_duration_info(course_run):
         )
     return duration_info
 
+def get_duration_of_course_or_courserun(content_metadata_item):
+    """
+    Returns duration start, end dates given a piece of content_metadata item
+    If course item, extracts start, end dates of closest course run based on current timestamp
+    Returns:
+        duration: in days or 0
+        start: start field of closest course run item, or None
+        end: end field of closest course run item, or None
+    """
+    start = None
+    end = None
+    if content_metadata_item.get('content_type') == 'courserun':
+        start = content_metadata_item.get('start')
+        end = content_metadata_item.get('end')
+    elif content_metadata_item.get('content_type') == 'course':
+        course_runs = content_metadata_item.get('course_runs')
+        if course_runs:
+            course_run = get_closest_course_run(course_runs)
+            if course_run:
+                start = course_run.get('start')
+                end = course_run.get('end')
+    if not start:
+        return 0, None, None
+    start_date = parse_datetime_handle_invalid(start)
+    end_date = parse_datetime_handle_invalid(end)
+    if not start_date or not end_date:
+        return 0, None, None
+    return (end_date - start_date).days, start, end
+
 
 def is_course_run_enrollable(course_run):
     """

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -6,7 +6,12 @@ from logging import getLogger
 
 from django.utils.translation import gettext_lazy as _
 
-from enterprise.utils import get_closest_course_run, get_duration_of_course_or_courserun, is_course_run_available_for_enrollment, parse_lms_api_datetime
+from enterprise.utils import (
+    get_closest_course_run,
+    get_duration_of_course_or_courserun,
+    is_course_run_available_for_enrollment,
+    parse_lms_api_datetime,
+)
 from enterprise.views import CourseEnrollmentView
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.sap_success_factors.exporters.utils import transform_language_code

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -152,7 +152,6 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
             'duration': f"{duration} days",
         }]
 
-
     def transform_price(self, content_metadata_item):
         """
         Return the current course run's price.

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -142,9 +142,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         """
         Return the schedule of the content item.
         """
-
         duration, start, end = get_duration_of_course_or_courserun(content_metadata_item)
-
         return [{
             'startDate': parse_datetime_to_epoch_millis(start) if start else '',
             'endDate': parse_datetime_to_epoch_millis(end) if end else '',

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -6,7 +6,7 @@ from logging import getLogger
 
 from django.utils.translation import gettext_lazy as _
 
-from enterprise.utils import get_closest_course_run, is_course_run_available_for_enrollment, parse_lms_api_datetime
+from enterprise.utils import get_closest_course_run, get_duration_of_course_or_courserun, is_course_run_available_for_enrollment, parse_lms_api_datetime
 from enterprise.views import CourseEnrollmentView
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.sap_success_factors.exporters.utils import transform_language_code
@@ -133,11 +133,20 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         """
         return 1
 
-    def transform_schedule(self, content_metadata_item):  # pylint: disable=unused-argument
+    def transform_schedule(self, content_metadata_item):
         """
         Return the schedule of the content item.
         """
-        return []
+
+        duration, start, end = get_duration_of_course_or_courserun(content_metadata_item)
+
+        return [{
+            'startDate': parse_datetime_to_epoch_millis(start) if start else '',
+            'endDate': parse_datetime_to_epoch_millis(end) if end else '',
+            'active': current_time_is_in_interval(start, end) if start else False,
+            'duration': f"{duration} days",
+        }]
+
 
     def transform_price(self, content_metadata_item):
         """

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -223,7 +223,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         ),
         (
             {},
-            [{'startDate': '', 'endDate': '', 'active': False, 'duration': 0}]
+            [{'startDate': '', 'endDate': '', 'active': False, 'duration': '0 days'}]
         )
     )
     @ddt.unpack

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -11,6 +11,7 @@ from pytest import mark
 
 from enterprise.utils import parse_lms_api_datetime
 from integrated_channels.sap_success_factors.exporters.content_metadata import SapSuccessFactorsContentMetadataExporter
+from integrated_channels.utils import parse_datetime_to_epoch_millis
 from test_utils import factories
 from test_utils.fake_enterprise_api import EnterpriseMockMixin
 
@@ -180,6 +181,55 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 'locale': 'English',
                 'value': course_run['title']
             }]
+
+    @ddt.data(
+        (
+            {
+            'content_type': 'courserun',
+            'start': '2013-02-05T05:00:00Z',
+            'end': '2013-05-05T05:00:00Z',
+            },
+            [{
+                'startDate': parse_datetime_to_epoch_millis('2013-02-05T05:00:00Z'),
+                'endDate': parse_datetime_to_epoch_millis('2013-05-05T05:00:00Z'),
+                'active': False,
+                'duration': '89 days',
+            }]
+        ),
+        (
+            {
+                "content_type": "course",
+                "key": "CatalystX+IL-BSL.S1x",
+                "title": "Cómo Convertirse en un Líder Exitoso (Entrenamiento de Liderazgo Inclusivo)",
+                "course_runs": [
+                    {
+                        "key": "course-v1:CatalystX+IL-BSL.S1x+2T2017",
+                        "start": "2017-05-16T16:00:00Z",
+                        "end": "2017-06-30T23:59:00Z",
+                    },
+                    {
+                        "key": "course-v1:CatalystX+IL-BSL.S1x+2T2018",
+                        "start": "2018-05-16T16:00:00Z",
+                        "end": "2018-06-30T23:59:00Z",
+                    }
+                ],
+            },
+            [{
+                'startDate': parse_datetime_to_epoch_millis('2018-05-16T16:00:00Z'),
+                'endDate': parse_datetime_to_epoch_millis('2018-06-30T23:59:00Z'),
+                'active': False,
+                'duration': '45 days',
+            }]
+        )
+    )
+    @ddt.unpack
+    def test_transform_schedule_course_run(self, metadata, expected_schedules):
+        """
+        Transforming a course run returns an array with one courserun element, for schedule
+        or the most recent courserun, if procesing a course
+        """
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        assert exporter.transform_schedule(metadata) == expected_schedules
 
     @ddt.data(
         {

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -185,9 +185,9 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
     @ddt.data(
         (
             {
-            'content_type': 'courserun',
-            'start': '2013-02-05T05:00:00Z',
-            'end': '2013-05-05T05:00:00Z',
+                'content_type': 'courserun',
+                'start': '2013-02-05T05:00:00Z',
+                'end': '2013-05-05T05:00:00Z',
             },
             [{
                 'startDate': parse_datetime_to_epoch_millis('2013-02-05T05:00:00Z'),
@@ -220,6 +220,10 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
                 'active': False,
                 'duration': '45 days',
             }]
+        ),
+        (
+            {},
+            [{'startDate': '', 'endDate': '', 'active': False, 'duration': 0}]
         )
     )
     @ddt.unpack


### PR DESCRIPTION
Based on reading this doc, it seems the 'schedule' field is what we want
https://help.sap.com/viewer/9d4c9e0d04304afdbe8f1b4480d71403/2111/en-US/2be70bfe31e64399be709de794f639ee.html


### JIRA
https://openedx.atlassian.net/browse/ENT-5367

This PR includes AC no. 2 of that ticket


### What this change does
This change populates the schedule array from one of these:

 - the closes course run if we are processing a course itme
 - the course run items itself

it extracts the values to produce schedule as follows:

```
[{
            'startDate': parse_datetime_to_epoch_millis(start) if start else '',
            'endDate': parse_datetime_to_epoch_millis(end) if end else '',
            'active': current_time_is_in_interval(start, end) if start else False,
            'duration': f"{duration} days",
}
]
```


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
