### PR TITLE
fix: broken Canvas oauth authorization url

### DIFF
--- a/integrated_channels/canvas/models.py
+++ b/integrated_channels/canvas/models.py
@@ -109,7 +109,7 @@ class CanvasEnterpriseCustomerConfiguration(EnterpriseCustomerPluginConfiguratio
                 being rendered with this admin form.
         """
         if self.canvas_base_url and self.client_id:
-            return (f'{self.canvas_base_url}/learn/api/public/v1/oauth2/authorizationcode'
+            return (f'{self.canvas_base_url}/login/oauth2/auth'
                     f'?redirect_uri={LMS_OAUTH_REDIRECT_URL}&'
                     f'response_type=code&'
                     f'client_id={self.client_id}&state={self.uuid}')


### PR DESCRIPTION
## Description

- incorrect path for authorization link

## References

- [ENT-5479](https://openedx.atlassian.net/browse/ENT-5479)
