### PR TITLE
fix: Degreed: Missing Learner Data Audit Records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.40.12]
+---------
+fix: Degreed2 Missing Learner Data Audit Records
+
 [3.40.11]
 ---------
 feat: New integrated channels Blackboard api endpoint to fetch global config creds

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.40.11"
+__version__ = "3.40.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -109,22 +109,11 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                  }
         Returns: status_code, response_text
         """
-        completion_audit_item = json.loads(payload)
-        json_payload = {
-            "data": {
-                "attributes": {
-                    "user-id": user_id,
-                    "user-identifier-type": "Email",
-                    "content-id": completion_audit_item.get('course_id'),
-                    "content-id-type": "externalId",
-                    "content-type": "course",
-                    "completed-at": completion_audit_item.get('completed_timestamp'),
-                }
-            }
-        }
+        json_payload = json.loads(payload)
         LOGGER.info(self.make_log_msg(
-            completion_audit_item.get('course_id'),
-            f'Attempting find course via url: {self.get_completions_url()}')
+            json_payload.get('data').get('attributes').get('content-id'),
+            f'Attempting find course via url: {self.get_completions_url()}'),
+            user_id
         )
         return self._post(
             self.get_completions_url(),

--- a/integrated_channels/degreed2/models.py
+++ b/integrated_channels/degreed2/models.py
@@ -209,3 +209,26 @@ class Degreed2LearnerDataTransmissionAudit(models.Model):
         Return uniquely identifying string representation.
         """
         return self.__str__()
+
+    def serialize(self, *args, **kwargs):
+        """
+        Return a JSON-serialized representation.
+
+        Sort the keys so the result is consistent and testable.
+
+        Can take the following keyword arguments:
+            - `enterprise_configuration`
+        """
+        json_payload = {
+            "data": {
+                "attributes": {
+                    "user-id": self.degreed_user_email,
+                    "user-identifier-type": "Email",
+                    "content-id": self.course_id,
+                    "content-id-type": "externalId",
+                    "content-type": "course",
+                    "completed-at": self.completed_timestamp,
+                }
+            }
+        }
+        return json.dumps(json_payload, sort_keys=True)

--- a/integrated_channels/degreed2/models.py
+++ b/integrated_channels/degreed2/models.py
@@ -3,6 +3,7 @@
 Database models for Enterprise Integrated Channel Degreed.
 """
 
+import json
 from logging import getLogger
 
 from simple_history.models import HistoricalRecords

--- a/tests/test_integrated_channels/test_degreed2/test_client.py
+++ b/tests/test_integrated_channels/test_degreed2/test_client.py
@@ -103,13 +103,18 @@ class TestDegreed2ApiClient(unittest.TestCase):
         )
 
         payload = {
-            'completions': [{
-                'employeeId': 'abc123',
-                'id': "course-v1:ColumbiaX+DS101X+1T2016",
-                'completionDate': NOW_TIMESTAMP_FORMATTED,
-            }]
+            "data": {
+                "attributes": {
+                    "user-id": 'test-learner@example.com',
+                    "user-identifier-type": "Email",
+                    "content-id": 'DemoX',
+                    "content-id-type": "externalId",
+                    "content-type": "course",
+                    "completed-at": NOW_TIMESTAMP_FORMATTED,
+                }
+            }
         }
-        output = degreed_api_client.create_course_completion('fake-user', json.dumps(payload))
+        output = degreed_api_client.create_course_completion('test-learner@example.com', json.dumps(payload))
 
         assert output == (200, '"{}"')
         assert len(responses.calls) == 2


### PR DESCRIPTION
## Description

- degreed2 seems to be unable to successfully send learner audit records
- looks like we were serializing data in the client rather than the model
- integrated channel transmitter was expecing serialization in model
- test tweaks but there is more we can add to tests

Associated Splunk logs:
```
2022-03-09 14:59:48,232 ERROR 1450 [celery.app.trace] [user None] [ip None] trace.py:265 - Task integrated_channels.integrated_channel.tasks.transmit_learner_data[f5628262-9285-4ad3-864a-6d958cc8e920] raised unexpected: AttributeError("'Degreed2LearnerDataTransmissionAudit' object has no attribute 'serialize'")
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 99, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 193, in new_function
    return wrapped_function(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/tasks.py", line 109, in transmit_learner_data
    integrated_channel.transmit_learner_data(api_user)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/models.py", line 197, in transmit_learner_data
    transmitter.transmit(exporter)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/degreed2/transmitters/learner_data.py", line 35, in transmit
    super().transmit(payload, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/transmitters/learner_data.py", line 260, in transmit
    serialized_payload = learner_data.serialize(enterprise_configuration=self.enterprise_configuration)
AttributeError: 'Degreed2LearnerDataTransmissionAudit' object has no attribute 'serialize'
```


## References

- [ENT-5558](https://openedx.atlassian.net/browse/ENT-5558)
