### PR TITLE
fix: CornerstoneLearnerDataTransmissionAudit admin view timeout

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.40.14]
+---------
+fix: CornerstoneLearnerDataTransmissionAudit admin view timeout
+
 [3.40.13]
 ---------
 fix: Degreed2 Missing Learner Data Audit Records

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.40.13"
+__version__ = "3.40.14"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -6,34 +6,12 @@ from config_models.admin import ConfigurationModelAdmin
 
 from django.apps import apps
 from django.contrib import admin
-from django.core.exceptions import ObjectDoesNotExist
 
 from integrated_channels.cornerstone.models import (
     CornerstoneEnterpriseCustomerConfiguration,
     CornerstoneGlobalConfiguration,
     CornerstoneLearnerDataTransmissionAudit,
 )
-
-
-def enterprise_course_enrollment_model():
-    """
-    Returns the ``EnterpriseCourseEnrollment`` class.
-    """
-    return apps.get_model('enterprise', 'EnterpriseCourseEnrollment')
-
-
-def enterprise_customer_user_model():
-    """
-    Returns the ``EnterpriseCustomerUser`` class.
-    """
-    return apps.get_model('enterprise', 'EnterpriseCustomerUser')
-
-
-def enterprise_customer_model():
-    """
-    Returns the ``EnterpriseCustomer`` class.
-    """
-    return apps.get_model('enterprise', 'EnterpriseCustomer')
 
 
 @admin.register(CornerstoneGlobalConfiguration)
@@ -99,10 +77,6 @@ class CornerstoneLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
         "status",
     )
 
-    readonly_fields = (
-        "enterprise_customer_name",
-    )
-
     class Meta:
         model = CornerstoneLearnerDataTransmissionAudit
 
@@ -115,25 +89,3 @@ class CornerstoneLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.user.email
-
-    def enterprise_customer_name(self, obj):
-        """
-        Returns: the name for the attached EnterpriseCustomer.
-
-        Args:
-            obj: The instance of CornerstoneEnterpriseCustomerConfiguration
-                being rendered with this admin form.
-        """
-
-        # a direct foreign key relationship is missing
-        # multiple queries here so, avoid adding it to list_display fields
-        EnterpriseCourseEnrollment = enterprise_course_enrollment_model()
-        EnterpriseCustomerUser = enterprise_customer_user_model()
-        EnterpriseCustomer = enterprise_customer_model()
-        try:
-            ece = EnterpriseCourseEnrollment.objects.get(pk=obj.enterprise_course_enrollment_id)
-            ecu = EnterpriseCustomerUser.objects.get(pk=ece.enterprise_customer_user_id)
-            ec = EnterpriseCustomer.objects.get(pk=ecu.enterprise_customer_id)
-            return ec.name
-        except ObjectDoesNotExist:
-            return None


### PR DESCRIPTION
## Description

I had attempted to pull in associated objects (non-foreign keys) for some added info on this admin screen but it seems to be breaking (timing out) in prod (works locally). I want to use this view, i don't need this extra info. I wanna dump it for now.

## References

- [ENT-5565](https://openedx.atlassian.net/browse/ENT-5565)
