### PR TITLE
fix: CSOD Learner Audit Django Admin Timeouts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.40.16]
+---------
+fix: CSOD Learner Audit Django Admin Timeouts
+
 [3.40.15]
 ---------
 fix: Use correct completions URL for Degreed2

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.40.15"
+__version__ = "3.40.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -76,6 +76,9 @@ class CornerstoneLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
         "course_id",
         "status",
     )
+    raw_id_fields = (
+        'user',
+    )
 
     class Meta:
         model = CornerstoneLearnerDataTransmissionAudit

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -6,12 +6,34 @@ from config_models.admin import ConfigurationModelAdmin
 
 from django.apps import apps
 from django.contrib import admin
+from django.core.exceptions import ObjectDoesNotExist
 
 from integrated_channels.cornerstone.models import (
     CornerstoneEnterpriseCustomerConfiguration,
     CornerstoneGlobalConfiguration,
     CornerstoneLearnerDataTransmissionAudit,
 )
+
+
+def enterprise_course_enrollment_model():
+    """
+    Returns the ``EnterpriseCourseEnrollment`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCourseEnrollment')
+
+
+def enterprise_customer_user_model():
+    """
+    Returns the ``EnterpriseCustomerUser`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCustomerUser')
+
+
+def enterprise_customer_model():
+    """
+    Returns the ``EnterpriseCustomer`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCustomer')
 
 
 @admin.register(CornerstoneGlobalConfiguration)
@@ -76,8 +98,13 @@ class CornerstoneLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
         "course_id",
         "status",
     )
+
     raw_id_fields = (
-        'user',
+        "user",
+    )
+
+    readonly_fields = (
+        "enterprise_customer_name",
     )
 
     class Meta:
@@ -92,3 +119,24 @@ class CornerstoneLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.user.email
+
+    def enterprise_customer_name(self, obj):
+        """
+        Returns: the name for the attached EnterpriseCustomer.
+        Args:
+            obj: The instance of CornerstoneEnterpriseCustomerConfiguration
+                being rendered with this admin form.
+        """
+
+        # a direct foreign key relationship is missing
+        # multiple queries here so, avoid adding it to list_display fields
+        EnterpriseCourseEnrollment = enterprise_course_enrollment_model()
+        EnterpriseCustomerUser = enterprise_customer_user_model()
+        EnterpriseCustomer = enterprise_customer_model()
+        try:
+            ece = EnterpriseCourseEnrollment.objects.get(pk=obj.enterprise_course_enrollment_id)
+            ecu = EnterpriseCustomerUser.objects.get(pk=ece.enterprise_customer_user_id)
+            ec = EnterpriseCustomer.objects.get(pk=ecu.enterprise_customer_id)
+            return ec.name
+        except ObjectDoesNotExist:
+            return None


### PR DESCRIPTION
## Description

- timeout is likely due to django admin trying to create/populate a select drop-down for the user field
- mark user as a 'raw id field'
- add back the enterprise name read-only since it wasnt the issue

## References

- [ENT-5565](https://openedx.atlassian.net/browse/ENT-5565)