### PR TITLE
feat: allow enterprise customer partial update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.41.0]
+---------
+feat: Allow partial_update on `EnterpriseCustomerViewSet`
+
 [3.40.16]
 ---------
 fix: CSOD Learner Audit Django Admin Timeouts

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.40.16"
+__version__ = "3.41.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -155,6 +155,12 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     filterset_fields = FIELDS
     ordering_fields = FIELDS
 
+    def get_permissions(self):
+        if self.action == 'partial_update':
+            return [permissions.IsAuthenticated()]
+        else:
+            return [permission() for permission in self.permission_classes]
+
     def get_serializer_class(self):
         if self.action == 'basic_list':
             return serializers.EnterpriseCustomerBasicSerializer
@@ -172,6 +178,10 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             queryset = queryset.filter(name__istartswith=startswith)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
+
+    @permission_required('enterprise.can_access_admin_dashboard', fn=lambda request, pk: pk)
+    def partial_update(self, request, *args, **kwargs):
+        return super().partial_update(request, *args, **kwargs)
 
     @method_decorator(require_at_least_one_query_parameter('course_run_ids', 'program_uuids'))
     @action(detail=True)


### PR DESCRIPTION
https://openedx.atlassian.net/browse/ENT-5400

- We need to be able to patch `EnterpriseCustomer` to change enterprise settings
- `permissions.DjangoModelPermissions` doesn't work with @permission_required decorator so we need to override `get_permissions` 
- Only touching partial_update to minimize changes


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
