### PR TITLE
fix: chunk cornerstone content updates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.41.1]
+---------
+fix: chunk cornerstone content updates
+
 [3.41.0]
 ---------
 feat: Allow partial_update on `EnterpriseCustomerViewSet`

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.41.0"
+__version__ = "3.41.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -111,25 +111,10 @@ class EnterpriseCatalogApiClient(JwtLmsApiClient):
             content_keys (list): List of string content keys
             should_raise_exception (Bool): Optional param for whether or not api response exceptions should be raised.
 
-        Response:
-            items_to_create: [{
-               "course_key": <content key>>
-            }, {
-            ..
-            }]
-
-            items_to_delete: [{
-               "course_key": <content key>>
-            }, {
-            ..
-            }]
-
-            items_found: [{
-                "course_key": <content key>>,
-                "date_updated": <content last modified datetime>
-            }, {
-                ...
-            }]
+        Returns:
+            items_to_create (list): dictionaries of content_keys to create
+            items_to_delete (list): dictionaries of content_keys to delete
+            items_found (list): dictionaries of content_keys and date_updated datetimes of content to update
         """
         catalog_uuid = enterprise_customer_catalog.uuid
         endpoint = getattr(self.client, self.CATALOG_DIFF_ENDPOINT.format(catalog_uuid))

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -51,7 +51,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
 
     def export_for_web_polling(self, max_payload_count=MAX_PAYLOAD_COUNT):
         """
-        Return the exported and transformed content metadata as a dictionary regardless if there is an update needed.
+        Return the exported and transformed content metadata as a dictionary for CSDO web pull.
         """
         return self.export(max_payload_count=max_payload_count)
 

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -8,6 +8,7 @@ from logging import getLogger
 import pytz
 
 from django.apps import apps
+from django.conf import settings
 
 from enterprise.utils import get_closest_course_run, get_language_code
 from integrated_channels.cornerstone.utils import convert_invalid_course_id
@@ -46,6 +47,13 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
         'Subjects': 'subjects',
     }
     SKIP_KEY_IF_NONE = True
+    MAX_PAYLOAD_COUNT = getattr(settings, "CORNERSTONE_MAX_CONTENT_PAYLOAD_COUNT", 1000)
+
+    def export_for_web_polling(self, max_payload_count=MAX_PAYLOAD_COUNT):
+        """
+        Return the exported and transformed content metadata as a dictionary regardless if there is an update needed.
+        """
+        return self.export(max_payload_count=max_payload_count)
 
     def export_force_all_catalogs(self):
         """

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -47,7 +47,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
         'Subjects': 'subjects',
     }
     SKIP_KEY_IF_NONE = True
-    MAX_PAYLOAD_COUNT = getattr(settings, "CORNERSTONE_MAX_CONTENT_PAYLOAD_COUNT", 1000)
+    MAX_PAYLOAD_COUNT = getattr(settings, "ENTERPRISE_CORNERSTONE_MAX_CONTENT_PAYLOAD_COUNT", 1000)
 
     def export_for_web_polling(self, max_payload_count=MAX_PAYLOAD_COUNT):
         """

--- a/integrated_channels/cornerstone/urls.py
+++ b/integrated_channels/cornerstone/urls.py
@@ -4,13 +4,10 @@ URL definitions for Cornerstone API.
 
 from django.urls import path
 
-from integrated_channels.cornerstone.views import CornerstoneCoursesListView, CornerstoneCoursesUpdates
+from integrated_channels.cornerstone.views import CornerstoneCoursesListView
 
 urlpatterns = [
     path('course-list', CornerstoneCoursesListView.as_view(),
          name='cornerstone-course-list'
-         ),
-    path('course-updates', CornerstoneCoursesUpdates.as_view(),
-         name='cornerstone-course-updates'
          )
 ]

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -2,16 +2,21 @@
 Views containing APIs for cornerstone integrated channel
 """
 
+import datetime
 from logging import getLogger
 
+from dateutil import parser
 from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthentication
 from rest_framework import generics, permissions, renderers, status
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
+from django.utils.http import parse_http_date_safe
+
 from enterprise.api.throttles import ServiceUserThrottle
 from enterprise.utils import get_enterprise_customer, get_enterprise_worker_user, get_oauth2authentication_class
 from integrated_channels.cornerstone.models import CornerstoneEnterpriseCustomerConfiguration
+from integrated_channels.integrated_channel.constants import ISO_8601_DATE_FORMAT
 
 logger = getLogger(__name__)
 
@@ -30,96 +35,6 @@ class BaseViewSet(generics.ListAPIView):
 
     throttle_classes = (ServiceUserThrottle,)
     renderer_classes = [renderers.JSONRenderer]
-
-
-class CornerstoneCoursesUpdates(BaseViewSet):
-    """
-        **Use Cases**
-
-            Get a list of courses that need updated to share on cornerstone filtered by an enterprise customer.
-
-        **Example Requests**
-
-            GET /cornerstone/course-updates?ciid={customer_uuid}
-
-        **Query Parameters for GET**
-
-            * ciid: Filters the result to courses available in catalogs corresponding to the
-              given ciid where value of ciid should be uuid of any enterprise customer.
-
-        **Response Values**
-
-            If the request for information about the course updates is successful, an HTTP 200 "OK" response
-            is returned.
-
-            The HTTP 200 response has the following values.
-
-            * JSON response with a list of the course objects. Each course object has these fields
-
-                * ID: Unique Course id.
-
-                * Title: Title of course.
-
-                * Description: Course overview.
-
-                * URL: URL where user is redirected to.
-
-                * Thumbnail: Url of the course thumbnail image.
-
-                * IsActive: Boolean value indicating if course is active and available.
-
-                * LastModifiedUTC: Time of the last modification made.
-
-                * Duration: Course duration.
-
-                * Partners: List of organizations that are course owners.
-
-                * Languages: List of available languages for a course.
-
-                * Subjects: List of subjects for course.
-
-            If the user is not logged in, a 401 error is returned.
-
-            If the user is not global staff, a 403 error is returned.
-
-            If ciid parameter is not provided, a 400 error is returned.
-
-            If the specified ciid is not valid or any of registered enterprise customers
-            a 404 error is returned.
-
-            If the specified enterprise does not have course catalog an HTTP 200 "OK" response is returned with an
-            empty result.
-    """
-
-    def get(self, request, *args, **kwargs):
-        enterprise_customer_uuid = request.GET.get('ciid')
-        if not enterprise_customer_uuid:
-            return Response(
-                status=status.HTTP_400_BAD_REQUEST,
-                data={
-                    "message": (
-                        "Cornerstone course list API expects ciid parameter."
-                    )
-                })
-
-        enterprise_customer = get_enterprise_customer(enterprise_customer_uuid)
-        if not enterprise_customer:
-            return Response(
-                status=status.HTTP_404_NOT_FOUND,
-                data={
-                    "message": (
-                        "No enterprise data found for given ciid."
-                    )
-                })
-
-        worker_user = get_enterprise_worker_user()
-        enterprise_config = CornerstoneEnterpriseCustomerConfiguration.objects.get(
-            enterprise_customer=enterprise_customer
-        )
-        exporter = enterprise_config.get_content_metadata_exporter(worker_user)
-        transmitter = enterprise_config.get_content_metadata_transmitter()
-        data = transmitter.transmit(*exporter.export())
-        return Response(data)
 
 
 class CornerstoneCoursesListView(BaseViewSet):
@@ -209,20 +124,32 @@ class CornerstoneCoursesListView(BaseViewSet):
         )
         exporter = enterprise_config.get_content_metadata_exporter(worker_user)
         transmitter = enterprise_config.get_content_metadata_transmitter()
-        data = transmitter.transmit(*exporter.export_force_all_catalogs())
+
+        get_count = int(request.GET.get('count', exporter.MAX_PAYLOAD_COUNT))
+        content_item_count = min(get_count, exporter.MAX_PAYLOAD_COUNT)
+        data = transmitter.transmit(*exporter.export_for_web_polling(max_payload_count=content_item_count))
 
         logger.info(f'integrated_channel=CSOD, '
                     f'integrated_channel_enterprise_customer_uuid={enterprise_customer_uuid}, '
                     f'transmitting {len(data)} items.')
 
-        if len(data) > 0:
-            minLastModifiedContent = min(data, key=lambda x: x['LastModifiedUTC'])
-            maxLastModifiedContent = max(data, key=lambda x: x['LastModifiedUTC'])
-            # If-Modified-Since compared to content logging
-            logger.info(f'integrated_channel=CSOD, '
-                        f'integrated_channel_enterprise_customer_uuid={enterprise_customer_uuid}, '
-                        f'If-Modified-Since={request.headers.get("If-Modified-Since")}, '
-                        f'minLastModifiedUTC={minLastModifiedContent.get("LastModifiedUTC")}, '
-                        f'maxLastModifiedUTC={maxLastModifiedContent.get("LastModifiedUTC")}')
+        if_modified_since = request.headers.get("If-Modified-Since")
+        if_modified_since = if_modified_since and parse_http_date_safe(if_modified_since)
+
+        # our CSOD imp. only supports creates/updates, no deletes
+        # fib and make it appear like all creates/updates are past if-modified-since
+        if if_modified_since:
+            for item in data:
+                this_last_modified = parser.parse(item['LastModifiedUTC'])
+                if if_modified_since > int(this_last_modified.timestamp()):
+                    # log when we find an incorrect modified date, then "fix" it
+                    logger.info(f'integrated_channel=CSOD, '
+                                f'integrated_channel_enterprise_customer_uuid={enterprise_customer_uuid}, '
+                                f'If-Modified-Since={request.headers.get("If-Modified-Since")}, '
+                                f'integrated_channel_course_key={item["ID"]}, '
+                                f'LastModifiedUTC={item["LastModifiedUTC"]} '
+                                f'fixing modified/header mismatch')
+                    if_modified_since_dt = datetime.datetime.fromtimestamp(if_modified_since)
+                    item['LastModifiedUTC'] = if_modified_since_dt.strftime(ISO_8601_DATE_FORMAT)
 
         return Response(data)

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -1348,7 +1348,6 @@ def get_fake_catalog_diff_w_one_each():
     Returns a fake response from the EnterpriseCatalogApiClient.get_catalog_diff where two courses and a program are
     returned, one in each change-type bucket
     """
-    # items_to_create, items_to_delete, matched_items
     items_to_create = [{'content_key': FAKE_COURSE_RUN['key']}]
     items_to_delete = [{'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}]
     matched_items = [{'content_key': FAKE_COURSE['key'], 'date_updated': datetime.datetime.now()}]

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -3,6 +3,7 @@ Fake responses for course catalog api.
 """
 
 import copy
+import datetime
 from collections import OrderedDict
 from functools import reduce
 from unittest import mock
@@ -1340,6 +1341,18 @@ def get_fake_catalog_diff_create_w_program():
         {'content_key': FAKE_COURSE['key']},
         {'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}
     ], [], []
+
+
+def get_fake_catalog_diff_w_one_each():
+    """
+    Returns a fake response from the EnterpriseCatalogApiClient.get_catalog_diff where two courses and a program are
+    returned, one in each change-type bucket
+    """
+    # items_to_create, items_to_delete, matched_items
+    items_to_create = [{'content_key': FAKE_COURSE_RUN['key']}]
+    items_to_delete = [{'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}]
+    matched_items = [{'content_key': FAKE_COURSE['key'], 'date_updated': datetime.datetime.now()}]
+    return items_to_create, items_to_delete, matched_items
 
 
 def get_fake_catalog_diff_create_with_invalid_key():


### PR DESCRIPTION
## Description

A customer cannot setup their CSOD integration because the initial pull of their content by CSOD times out. This specific customer has multiple "all-content" catalogs but in theory even smaller catalogs have the potential to timeout since we do a full send every time. 

This set of changes is to add a configurable "max changes to send" size (defaulting to 1000). Whenever CSOD polls, we'll doll out the next N changes based on what our catalog diff tells us. Prioritizing creates over updates. If we have more than N changes to send, the audit records for only those first N will get updated and thus the remaining changes will be sent on the next poll by CSOD.

I tried to implement this will the least number of architectural changes possible. Also tried to keep in mind how/where the proper support for the `If-Modified-Since` header changes would be made.

- set max chunk size to send in one request
- 'correct' modified times when if-modified-since
- add testing, comments


## Considerations

- the request marks the records as transmitted, we'll need to avoid using the endpoint for debugging
- we're about to implement proper support of `If-Modified-Since` which may improve on how we track what needs to be transmitted/re-transmitted


## References
- [ENT-5521](https://openedx.atlassian.net/browse/ENT-5521)
