### PR TITLE
add logging of grades api call

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.41.5]
+---------
+feat: add missing logging for grades api results in integrated channels exporter
+
 [3.41.4]
 ---------
 feat: added html pages for oauth authorization success/failure

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.41.4"
+__version__ = "3.41.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -305,6 +305,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 channel_name, enterprise_customer_uuid, lms_user_id, course_id,
                 f'_collect_certificate_data finished with CompletedDate: {completed_date_from_api},'
                 f' Grade: {grade_from_api}, IsPassing: {is_passing_from_api},'
+                f' Grade Percent: {grade_percent}'
             ))
         # For self-paced courses, check the Grades API
         else:
@@ -314,6 +315,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 channel_name, enterprise_customer_uuid, lms_user_id, course_id,
                 f'collect_grades_data finished with CompletedDate: {completed_date_from_api},'
                 f' Grade: {grade_from_api}, IsPassing: {is_passing_from_api},'
+                f' Grade Percent: {grade_percent}'
             ))
 
         # there is a case for audit enrollment, we are reporting completion based on

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -310,6 +310,11 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         else:
             completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent = \
                 self.collect_grades_data(enterprise_enrollment, course_details, channel_name)
+            LOGGER.info(generate_formatted_log(
+                channel_name, enterprise_customer_uuid, lms_user_id, course_id,
+                f'collect_grades_data finished with CompletedDate: {completed_date_from_api},'
+                f' Grade: {grade_from_api}, IsPassing: {is_passing_from_api},'
+            ))
 
         # there is a case for audit enrollment, we are reporting completion based on
         # content count cmopleted, so we may not get a completed_date_from_api


### PR DESCRIPTION
We don't seem to be logging the results of grades api call, only the cert api call

There are some cases where we want to inspect if we are indeed getting correct info by calling grades api call. Since we have a task on hand to try and use cert api call as much as possible

for now I want to at least log this and see if we are getting accurate completion results

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
