### PR TITLE
ENT-5632 completions fix for non audit to base on passed_timestamp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.42.4]
+---------
+feat: updated logic for completions in integrated channels
+
 [3.42.3]
 ---------
 feat: additional fk data backfill performance improvements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.42.3"
+__version__ = "3.42.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -299,6 +299,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         enterprise_customer_uuid = enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid
         course_id = enterprise_enrollment.course_id
 
+        # breakpoint()
         if is_audit_enrollment:
             completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent, passed_timestamp = \
                 self.collect_grades_data(enterprise_enrollment, course_details, channel_name)
@@ -627,6 +628,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         lms_user_id = enterprise_enrollment.enterprise_customer_user.user_id
         enterprise_customer_uuid = enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid
         user = User.objects.get(pk=lms_user_id)
+        passed_timestamp = None
 
         completed_date = None
         grade = self.grade_incomplete
@@ -644,7 +646,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             ))
 
         if not certificate:
-            return completed_date, grade, is_passing, percent_grade
+            return completed_date, grade, is_passing, percent_grade, passed_timestamp
 
         completed_date = certificate.get('created_date')
         if completed_date:
@@ -654,7 +656,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
 
         # also get passed_timestamp which is used to line up completion logic with analytics
         persistent_grade = get_persistent_grade(course_id, user)
-        passed_timestamp = persistent_grade.passed_timestamp
+        passed_timestamp = persistent_grade.passed_timestamp if persistent_grade is not None else None
 
         # For consistency with _collect_grades_data, we only care about Pass/Fail grades. This could change.
         is_passing = certificate.get('is_passing')
@@ -745,11 +747,11 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 .format(
                     enterprise_enrollment=enterprise_enrollment,
                 )))
-            return None, None, None, None
+            return None, None, None, None, None
 
         # also get passed_timestamp which is used to line up completion logic with analytics
         persistent_grade = get_persistent_grade(course_id, user)
-        passed_timestamp = persistent_grade.passed_timestamp
+        passed_timestamp = persistent_grade.passed_timestamp if persistent_grade is not None else None
 
         # Prepare to process the course end date and pass/fail grade
         course_end_date = course_details.end

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -310,10 +310,10 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 completed_date_from_api = timezone.now()
         else:
             completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent, passed_timestamp = \
-                self._collect_certificate_data(enterprise_enrollment, channel_name)
+                self.collect_certificate_data(enterprise_enrollment, channel_name)
             LOGGER.info(generate_formatted_log(
                 channel_name, enterprise_customer_uuid, lms_user_id, course_id,
-                f'_collect_certificate_data finished with CompletedDate: {completed_date_from_api},'
+                f'collect_certificate_data finished with CompletedDate: {completed_date_from_api},'
                 f' Grade: {grade_from_api}, IsPassing: {is_passing_from_api},'
                 f' Passed timestamp: {passed_timestamp}'
             ))
@@ -601,7 +601,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             )
         ]
 
-    def _collect_certificate_data(self, enterprise_enrollment, channel_name):
+    def collect_certificate_data(self, enterprise_enrollment, channel_name):
         """
         Collect the learner completion data from the course certificate.
 

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -299,7 +299,6 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         enterprise_customer_uuid = enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid
         course_id = enterprise_enrollment.course_id
 
-        # breakpoint()
         if is_audit_enrollment:
             completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent, passed_timestamp = \
                 self.collect_grades_data(enterprise_enrollment, course_details, channel_name)

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -322,7 +322,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 # we will try getting grades info using the alternative api in this case
                 # if that also does not exist then we have nothing to report
                 completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent, passed_timestamp = \
-                  self.collect_grades_data(enterprise_enrollment, course_details, channel_name)
+                    self.collect_grades_data(enterprise_enrollment, course_details, channel_name)
                 LOGGER.info(generate_formatted_log(
                     channel_name, enterprise_customer_uuid, lms_user_id, course_id,
                     f'No certificate found, obtained grading data from grades api.'

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -740,14 +740,13 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         grades_data = get_single_user_grade(course_id, user)
 
         if grades_data is None:
-            LOGGER.error(generate_formatted_log(
+            LOGGER.warning(generate_formatted_log(
                 channel_name, enterprise_customer_uuid, lms_user_id, course_id,
-                'get_single_user_grade failed. Grades data not found for'
-                '  EnterpriseCourseEnrollment: {enterprise_enrollment}.'
-                .format(
-                    enterprise_enrollment=enterprise_enrollment,
-                )))
-            return None, None, None, None, None
+                f'No grade found for '
+                f'EnterpriseCourseEnrollment: {enterprise_enrollment}.'
+            ))
+            # if enrollment found, but no grades, we can safely mark as incomplete/in progress
+            return None, LearnerExporter.GRADE_INCOMPLETE, None, None, None
 
         # also get passed_timestamp which is used to line up completion logic with analytics
         persistent_grade = get_persistent_grade(course_id, user)

--- a/integrated_channels/integrated_channel/models.py
+++ b/integrated_channels/integrated_channel/models.py
@@ -295,12 +295,12 @@ class LearnerDataTransmissionAudit(TimeStampedModel):
         Return a human-readable string representation of the object.
         """
         return (
-            '<LearnerDataTransmissionAudit {transmission_id} for enterprise enrollment {enrollment}, '
-            'and course {course_id}>'.format(
-                transmission_id=self.id,
-                enrollment=self.enterprise_course_enrollment_id,
-                course_id=self.course_id
-            )
+            f'<LearnerDataTransmissionAudit {self.id} for enterprise enrollment {self.enterprise_course_enrollment_id}, '
+            f', course_id: {self.course_id}>'
+            f', grade: {self.grade}'
+            f', completed_timestamp: {self.completed_timestamp}'
+            f', enterprise_customer_uuid: {self.enterprise_customer_uuid}'
+            f', course_completed: {self.course_completed}'
         )
 
     def __repr__(self):

--- a/integrated_channels/integrated_channel/models.py
+++ b/integrated_channels/integrated_channel/models.py
@@ -295,7 +295,8 @@ class LearnerDataTransmissionAudit(TimeStampedModel):
         Return a human-readable string representation of the object.
         """
         return (
-            f'<LearnerDataTransmissionAudit {self.id} for enterprise enrollment {self.enterprise_course_enrollment_id}, '
+            f'<LearnerDataTransmissionAudit {self.id}'
+            f' for enterprise enrollment {self.enterprise_course_enrollment_id}, '
             f', course_id: {self.course_id}>'
             f', grade: {self.grade}'
             f', completed_timestamp: {self.completed_timestamp}'

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -272,8 +272,7 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
                     enterprise_customer_uuid,
                     lms_user_id,
                     learner_data.course_id,
-                    f'Skipping in-progress enterprise enrollment:: id: {enterprise_enrollment_id}'
-                    f', course_id: {learner_data.course_id}'
+                    f'Skipping in-progress enterprise enrollment record:: {learner_data}'
                 ))
                 continue
 

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -7,6 +7,7 @@ from opaque_keys.edx.keys import CourseKey
 try:
     from lms.djangoapps.certificates.api import get_certificate_for_user
     from lms.djangoapps.grades.course_grade_factory import CourseGradeFactory
+    from lms.djangoapps.grades.models import PersistentCourseGrade
     from openedx.core.djangoapps.content.course_overviews.models import CourseOverview
 except ImportError:
     get_certificate_for_user = None
@@ -20,6 +21,15 @@ except ImportError:
 
 from enterprise.utils import NotConnectedToOpenEdX
 
+def get_persistent_grade(course_key, user):
+    """
+    Get the persistent course grade record for this course and user, or None
+    """
+    try:
+        grade = PersistentCourseGrade.read(user.id, course_key)
+    except PersistentCourseGrade.DoesNotExist:
+        return None
+    return grade
 
 def get_course_certificate(course_key, user):
     """
@@ -71,7 +81,7 @@ def get_single_user_grade(course_key, user):
             'installed in an Open edX environment.'
         )
     course_id = CourseKey.from_string(course_key)
-    course_grade = CourseGradeFactory().read(user, course_key=course_id)
+    course_grade = CourseGradeFactory().read(user, course_key=course_id, create_if_needed=False)
     return course_grade
 
 

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -22,6 +22,7 @@ except ImportError:
 
 from enterprise.utils import NotConnectedToOpenEdX
 
+
 def get_persistent_grade(course_key, user):
     """
     Get the persistent course grade record for this course and user, or None
@@ -31,6 +32,7 @@ def get_persistent_grade(course_key, user):
     except PersistentCourseGrade.DoesNotExist:
         return None
     return grade
+
 
 def get_course_certificate(course_key, user):
     """

--- a/integrated_channels/lms_utils.py
+++ b/integrated_channels/lms_utils.py
@@ -13,6 +13,7 @@ except ImportError:
     get_certificate_for_user = None
     CourseGradeFactory = None
     CourseOverview = None
+    PersistentCourseGrade = None
 
 try:
     from lms.djangoapps.courseware.courses import get_course_blocks_completion_summary

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -338,9 +338,9 @@ def get_upgrade_deadline(course_run):
     return None
 
 
-def is_course_completed(enterprise_enrollment, completed_date, is_passing, incomplete_count):
+def is_course_completed(enterprise_enrollment, is_passing, incomplete_count, passed_timestamp=None):
     '''
-    For non audit, this requires passing and completed_date
+    For non audit, this requires passing and passed_timestamp
     For audit enrollment, returns True if:
      - for non upgradable course:
         - no more non-gated content is left
@@ -358,7 +358,7 @@ def is_course_completed(enterprise_enrollment, completed_date, is_passing, incom
             # for upgradable course check deadline passed as well
             now = datetime.now(pytz.UTC)
             return incomplete_count == 0 and upgrade_deadline < now
-    return completed_date is not None and is_passing
+    return passed_timestamp is not None and is_passing
 
 
 def is_valid_url(url):

--- a/test_utils/integrated_channels_utils.py
+++ b/test_utils/integrated_channels_utils.py
@@ -40,6 +40,7 @@ def mock_single_learner_grade(percent=0.0, passing=False):
     }
     return namedtuple("CourseGrade", dictionary.keys())(*dictionary.values())
 
+
 def mock_persistent_course_grade(user_id, course_id, passed_timestamp):
     """Generate an object matching the PersistentCourseGrade from edx-platform"""
     dictionary = {

--- a/test_utils/integrated_channels_utils.py
+++ b/test_utils/integrated_channels_utils.py
@@ -39,3 +39,12 @@ def mock_single_learner_grade(percent=0.0, passing=False):
         'passed': passing,
     }
     return namedtuple("CourseGrade", dictionary.keys())(*dictionary.values())
+
+def mock_persistent_course_grade(user_id, course_id, passed_timestamp):
+    """Generate an object matching the PersistentCourseGrade from edx-platform"""
+    dictionary = {
+        'user_id': user_id,
+        'course_id': course_id,
+        'passed_timestamp': passed_timestamp,
+    }
+    return namedtuple("PersistentCourseGrade", dictionary.keys())(*dictionary.values())

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -22,7 +22,7 @@ from integrated_channels.cornerstone.models import CornerstoneLearnerDataTransmi
 from integrated_channels.integrated_channel.tasks import transmit_single_learner_data
 from test_utils import FAKE_UUIDS, factories
 from test_utils.fake_catalog_api import setup_course_catalog_api_client_mock
-from test_utils.integrated_channels_utils import mock_course_overview
+from test_utils.integrated_channels_utils import mock_course_overview, mock_persistent_course_grade
 
 
 @mark.django_db
@@ -198,8 +198,10 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.is_course_completed')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_persistent_grade')
     def test_api_client_called_with_appropriate_payload(
         self,
+        mock_get_persistent_grade,
         mock_is_course_completed,
         mock_get_course_details,
         mock_get_course_certificate,
@@ -209,6 +211,11 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
         """
         Test sending of course completion data to cornerstone progress API
         """
+        mock_get_persistent_grade.return_value = mock_persistent_course_grade(
+            user_id='a-user-id',
+            course_id=self.course_id,
+            passed_timestamp="2019-05-21T12:58:17+00:00",
+        )
         mock_is_course_completed.return_value = True
         mock_get_course_details.return_value = mock_course_overview(
             pacing="instructor",

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -138,8 +138,10 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.is_course_completed')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_persistent_grade')
     def test_api_client_uses_config_session_tokens(
         self,
+        mock_get_persistent_grade,
         mock_is_course_completed,
         mock_get_course_details,
         mock_get_course_certificate,
@@ -151,6 +153,12 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
 
         self.config.session_token = 'test_value'
         self.config.save()
+
+        mock_get_persistent_grade.return_value = mock_persistent_course_grade(
+            user_id='a-user-id',
+            course_id=self.course_id,
+            passed_timestamp="2018-05-21T12:58:17+00:00",
+        )
 
         mock_is_course_completed.return_value = True
         mock_get_course_details.return_value = mock_course_overview(
@@ -275,8 +283,10 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.api_client.lms.JwtBuilder', mock.Mock())
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_persistent_grade')
     def test_transmit_single_learner_data_performs_only_one_transmission(
         self,
+        mock_get_persistent_grade,
         mock_get_course_details,
         mock_get_course_certificate
     ):
@@ -291,6 +301,12 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
         course_details = mock_course_overview(
             pacing="instructor",
             end="2038-06-21T12:58:17.428373Z",
+        )
+
+        mock_get_persistent_grade.return_value = mock_persistent_course_grade(
+            user_id='a-user-id',
+            course_id=self.course_id,
+            passed_timestamp="2018-05-21T12:58:17+00:00",
         )
 
         mock_get_course_details.return_value = course_details

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -835,7 +835,7 @@ class TestLearnerExporter(unittest.TestCase):
         enterprise_enrollment = create_ent_enrollment_mock()
         incomplete_count = 0
 
-        exporter.collect_grades_data = MagicMock(return_value=(None, None, None, None, None ))
+        exporter.collect_grades_data = MagicMock(return_value=(None, None, None, None, None))
         completed_date_from_api, _, _, _, _ = exporter.get_grades_summary(
             course_details,
             enterprise_enrollment,

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -211,8 +211,10 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_persistent_grade')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_single_user_grade')
     def test_learner_data_instructor_paced_no_certificate(
             self,
+            mock_get_single_user_grade,
             mock_get_persistent_grade,
             mock_get_course_certificate,
             mock_course_catalog_api,
@@ -222,6 +224,7 @@ class TestLearnerExporter(unittest.TestCase):
         mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
         mock_get_course_certificate.return_value = None
         mock_get_persistent_grade.return_value = None
+        mock_get_single_user_grade.return_value = None
 
         enrollment = factories.EnterpriseCourseEnrollmentFactory(
             enterprise_customer_user=self.enterprise_customer_user,
@@ -402,7 +405,7 @@ class TestLearnerExporter(unittest.TestCase):
             assert report.enterprise_course_enrollment_id == enrollment.id
             assert not report.course_completed
             assert report.completed_timestamp is None
-            assert report.grade is None
+            assert report.grade is LearnerExporter.GRADE_INCOMPLETE
 
     @ddt.data(
         # passing grade with no course end date

--- a/tests/test_integrated_channels/test_lms_utils.py
+++ b/tests/test_integrated_channels/test_lms_utils.py
@@ -53,7 +53,8 @@ class TestLMSUtils(unittest.TestCase):
         assert single_user_grade == expected_grade
         mock_course_grade_factory.return_value.read.assert_called_with(
             self.user,
-            course_key=CourseKey.from_string(A_GOOD_COURSE_ID)
+            course_key=CourseKey.from_string(A_GOOD_COURSE_ID),
+            create_if_needed=False,
         )
 
     @mock.patch('integrated_channels.lms_utils.CourseGradeFactory')

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -115,7 +115,8 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         }]}
         mock_get_course_run_for_enrollment.return_value = course_run_verify_expired
         enterprise_enrollment = ent_enrollment(is_audit_enrollment=True)
-        assert utils.is_course_completed(enterprise_enrollment, None, True, 0)
+        assert not utils.is_course_completed(enterprise_enrollment, None, True, 0)
+        assert utils.is_course_completed(enterprise_enrollment, True, 0, None)
 
     @mock.patch('integrated_channels.utils.get_course_run_for_enrollment')
     def test_is_course_completed_audit_incomplete(self, mock_get_course_run_for_enrollment):
@@ -125,7 +126,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         }]}
         mock_get_course_run_for_enrollment.return_value = course_run_verify_non_expired
         enterprise_enrollment = ent_enrollment(is_audit_enrollment=True)
-        assert not utils.is_course_completed(enterprise_enrollment, None, True, 0)
+        assert not utils.is_course_completed(enterprise_enrollment, False, 1, None)
 
     @mock.patch('integrated_channels.utils.get_course_run_for_enrollment')
     def test_is_course_completed_nonaudit_complete(self, mock_get_course_run_for_enrollment):
@@ -135,7 +136,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         }]}
         mock_get_course_run_for_enrollment.return_value = course_run_verify_expired
         enterprise_enrollment = ent_enrollment(is_audit_enrollment=False)
-        assert utils.is_course_completed(enterprise_enrollment, '2000-10-13T13:11:04Z', True, 0)
+        assert utils.is_course_completed(enterprise_enrollment, True, 0, '2000-10-13T13:11:04Z')
 
     @mock.patch('integrated_channels.utils.get_course_run_for_enrollment')
     def test_is_course_completed_nonaudit_incomplete(self, mock_get_course_run_for_enrollment):
@@ -145,7 +146,8 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         }]}
         mock_get_course_run_for_enrollment.return_value = course_run_verify_expired
         enterprise_enrollment = ent_enrollment(is_audit_enrollment=False)
-        assert not utils.is_course_completed(enterprise_enrollment, None, False, 0)
+        assert not utils.is_course_completed(enterprise_enrollment, True, 0, None)
+        assert not utils.is_course_completed(enterprise_enrollment, False, 0, '2000-10-13T13:11:04Z')
 
     @ddt.data((True, True,), (False, False,))
     @ddt.unpack


### PR DESCRIPTION
Change of logic is basically:

- if audit track: no change of behavior. Still send completions as long as incomplete_count = 0
- if non audit track: only send completion if passed_timestamp is not Null and is_passed=True. This matches with how the analytics tools report completions. This should also fix the bug where we incorrectly sent non audit tracks as completed, solely based on this other completed_date that we calculate, that does _not_ match with analytics logic. We may be able to remove that field in the future but for now I left it there, I just don't use it to calculate is_completed anymore :)
- specifically call CourseGradeFactory with create_if_needed=False, since I don't see why we need to use the get_or_create pattern here, we are simply wanting to read existing grade records


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
