### PR TITLE
fix: guard backfill job

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.42.5]
+---------
+fix: improve guards on fk data backfill job
+
 [3.42.4]
 ---------
 feat: updated logic for completions in integrated channels

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.42.4"
+__version__ = "3.42.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/management/commands/backfill_missing_foreign_keys.py
+++ b/integrated_channels/integrated_channel/management/commands/backfill_missing_foreign_keys.py
@@ -132,6 +132,8 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
                         if audit_record.enterprise_customer is None:
                             continue
                         config = ConfigModel.objects.filter(enterprise_customer=audit_record.enterprise_customer).first()  # pylint: disable=line-too-long
+                        if config is None:
+                            continue
                         LOGGER.info(f'ContentMetadataItemTransmission {channel_code} <{audit_record.pk}> '
                                     f'plugin_configuration_id={config.id}')
                         audit_record.plugin_configuration_id = config.id

--- a/tests/test_integrated_channels/test_moodle/test_client.py
+++ b/tests/test_integrated_channels/test_moodle/test_client.py
@@ -149,8 +149,8 @@ class TestMoodleApiClient(unittest.TestCase):
 
         client = MoodleAPIClient(self.enterprise_config)
         client._post = unittest.mock.MagicMock(name='_post', return_value=SUCCESSFUL_RESPONSE)  # pylint: disable=protected-access
-        client._get_course_id = unittest.mock.MagicMock(name='_get_course_id')
-        client._get_course_id.return_value = self.moodle_course_id
+        client._get_course_id = unittest.mock.MagicMock(name='_get_course_id')  # pylint: disable=protected-access
+        client._get_course_id.return_value = self.moodle_course_id  # pylint: disable=protected-access
         client.update_content_metadata(SERIALIZED_DATA)
         client._post.assert_called_once_with(expected_data)  # pylint: disable=protected-access
 

--- a/tests/test_integrated_channels/test_moodle/test_client.py
+++ b/tests/test_integrated_channels/test_moodle/test_client.py
@@ -149,8 +149,8 @@ class TestMoodleApiClient(unittest.TestCase):
 
         client = MoodleAPIClient(self.enterprise_config)
         client._post = unittest.mock.MagicMock(name='_post', return_value=SUCCESSFUL_RESPONSE)  # pylint: disable=protected-access
-        client.get_course_id = unittest.mock.MagicMock(name='_get_course_id')
-        client.get_course_id.return_value = self.moodle_course_id
+        client._get_course_id = unittest.mock.MagicMock(name='_get_course_id')
+        client._get_course_id.return_value = self.moodle_course_id
         client.update_content_metadata(SERIALIZED_DATA)
         client._post.assert_called_once_with(expected_data)  # pylint: disable=protected-access
 


### PR DESCRIPTION
## Description

- handle orphaned content metadata lacking a config
```
Apr  7 19:45:34 ip-10-2-70-191 [service_variant=lms][integrated_channels.integrated_channel.management.commands.backfill_missing_foreign_keys][env:prod-edx-edxapp] ERROR [ip-10-2-70-191  2424] [user None] [ip None] [backfill_missing_foreign_keys.py:140] - backfill_missing_foreign_keys failed
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/management/commands/backfill_missing_foreign_keys.py", line 135, in backfill_join_keys
    LOGGER.info(f'ContentMetadataItemTransmission {channel_code} <{audit_record.pk}> '
AttributeError: 'NoneType' object has no attribute 'id'
```

- let moodle recreate courses it think should exist
```
2022-04-07 20:22:19,615 ERROR 1475 [integrated_channels.integrated_channel.transmitters.content_metadata] [user None] [ip None] content_metadata.py:47 - integrated_channel=MOODLE, integrated_channel_enterprise_customer_uuid=b49c5f53-6070-4a37-a630-042c5fa10983, integrated_channel_lms_user=None, integrated_channel_course_key=None, Failed to update [1] content metadata items for integrated channel [Live Publishing Japan] [MOODLE]. Task failed with message [MoodleAPIClient request failed: 404 Course key "Wharton+ConnectedStrategyCapstone" not found in Moodle.] and status code [404]
```

## References

- ENT-5605

