### PR TITLE
fix: override get_assignments() so that the order matters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,14 @@ Unreleased
 ----------
 * nothing
 
+[3.44.0]
+--------
+fix: override get_assignments() so that active enterprise uuids come first.
+
+Overrides the SystemWideEnterpriseUserRoleAssignment.get_assignments() method to return
+a list of (role, context) assignments, where the first item in the list corresponds
+to the currently active enterprise for the user.
+
 [3.43.1]
 ---------
 chore: replace enterprise customer drop-downs in django admin

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.43.1"
+__version__ = "3.44.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -3,6 +3,7 @@ Database models for enterprise.
 """
 
 import collections
+import itertools
 import json
 import os
 from decimal import Decimal
@@ -1268,11 +1269,27 @@ class EnterpriseCustomerUser(TimeStampedModel):
     @classmethod
     def inactivate_other_customers(cls, user_id, enterprise_customer):
         """
-        Inactive all the enterprise customers of given user except the given enterprise_customer.
+        Mark as inactive all the enterprise customers of given user except the given enterprise_customer.
         """
         EnterpriseCustomerUser.objects.filter(
             user_id=user_id
         ).exclude(enterprise_customer=enterprise_customer).update(active=False)
+
+    @classmethod
+    def get_active_enterprise_users(cls, user_id, enterprise_customer_uuids=None):
+        """
+        Return a queryset of all active enterprise users to which the given user is related.
+        Or, if ``enterprise_customer_uuids`` is non-null, only the enterprise users
+        related to the list of given ``enterprise_customer_uuids``.
+        """
+        kwargs = {
+            'user_id': user_id,
+            'active': True,
+        }
+        if enterprise_customer_uuids:
+            kwargs['enterprise_customer__in'] = enterprise_customer_uuids
+
+        return EnterpriseCustomerUser.objects.filter(**kwargs)
 
 
 class PendingEnterpriseCustomerUser(TimeStampedModel):
@@ -2869,6 +2886,72 @@ class SystemWideEnterpriseUserRoleAssignment(EnterpriseRoleAssignmentContextMixi
             return [str(self.enterprise_customer.uuid)]
 
         return super().get_context()
+
+    @classmethod
+    def get_distinct_assignments_by_role_name(cls, user, role_names=None):
+        """
+        Returns a mapping of role names to sets of enterprise customer uuids
+        for which the user is assigned that role.
+        """
+        # super().get_assignments() returns pairs of (role name, contexts), where
+        # contexts is a list of 1 or more enterprise uuids (or the ALL_ACCESS_CONTEXT token)
+        assigned_customers_by_role = collections.defaultdict(set)
+        for role_name, customer_uuids in super().get_assignments(user, role_names):
+            assigned_customers_by_role[role_name].update(customer_uuids)
+        return assigned_customers_by_role
+
+    @classmethod
+    def get_assignments(cls, user, role_names=None):
+        """
+        Return an iterator of (rolename, [enterprise customer uuids]) for the given
+        user (and maybe role_names).
+
+        Differs from super().get_assignments(...) in that it yields (role name, customer uuid list) pairs
+        such that the first item in the customer uuid list for each role
+        corresponds to the currently *active* EnterpriseCustomerUser for the user.
+
+        The resulting generated pairs are sorted by role name, and within role_name, by (active, customer uuid).
+        For example:
+
+          ('enterprise_admin', ['active-enterprise-uuid', 'inactive-enterprise-uuid', 'other-inactive-enterprise-uuid'])
+          ('enterprise_learner', ['active-enterprise-uuid', 'inactive-enterprise-uuid']),
+          ('enterprise_openedx_operator', ['*'])
+        """
+        customers_by_role = cls.get_distinct_assignments_by_role_name(user, role_names)
+        if not customers_by_role:
+            return
+
+        # Filter for a set of only the *active* enterprise uuids for which the user is assigned a role.
+        # A user should typically only have one active enterprise user at a time, but we'll
+        # use sets to cover edge cases.
+        all_customer_uuids_for_user = set(itertools.chain(*customers_by_role.values()))
+
+        # ALL_ACCESS_CONTEXT is not a value UUID on which to filter enterprise customer uuids.
+        all_customer_uuids_for_user.discard(ALL_ACCESS_CONTEXT)
+
+        active_enterprise_uuids_for_user = set(
+            str(customer_uuid) for customer_uuid in
+            EnterpriseCustomerUser.get_active_enterprise_users(
+                user.id,
+                enterprise_customer_uuids=all_customer_uuids_for_user,
+            ).values_list('enterprise_customer', flat=True)
+        )
+
+        for role_name in sorted(customers_by_role):
+            customer_uuids_for_role = customers_by_role[role_name]
+
+            # Determine the *active* enterprise uuids assigned for this role.
+            active_enterprises_for_role = sorted(
+                customer_uuids_for_role.intersection(active_enterprise_uuids_for_user)
+            )
+            # Determine the *inactive* enterprise uuids assigned for this role,
+            # could include the ALL_ACCESS_CONTEXT token.
+            inactive_enterprises_for_role = sorted(
+                customer_uuids_for_role.difference(active_enterprise_uuids_for_user)
+            )
+            ordered_enterprises = active_enterprises_for_role + inactive_enterprises_for_role
+
+            yield (role_name, ordered_enterprises)
 
     def __str__(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,6 +9,7 @@ import shutil
 import unittest
 from datetime import timedelta
 from unittest import mock
+from uuid import UUID
 
 import ddt
 from edx_rest_api_client.exceptions import HttpClientError
@@ -31,7 +32,12 @@ from consent.errors import InvalidProxyConsent
 from consent.helpers import get_data_sharing_consent
 from consent.models import DataSharingConsent, ProxyDataSharingConsent
 from enterprise import roles_api
-from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE, ENTERPRISE_OPERATOR_ROLE
+from enterprise.constants import (
+    ALL_ACCESS_CONTEXT,
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
+)
 from enterprise.errors import LinkUserToEnterpriseError
 from enterprise.models import (
     EnrollmentNotificationEmailTemplate,
@@ -2184,7 +2190,7 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
     Tests SystemWideEnterpriseUserRoleAssignment.
     """
 
-    def _create_and_link_user(self, user_email, *enterprise_customers):
+    def _create_and_link_user(self, user_email, *enterprise_customers, **kwargs):
         """
         Helper that creates a User with the given email, then links that user
         to each of the given EnterpriseCustomers.
@@ -2192,9 +2198,15 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
         should also create some role assignments.
         """
         user = factories.UserFactory(email=user_email)
-        for enterprise_customer in enterprise_customers:
-            EnterpriseCustomerUser.objects.link_user(enterprise_customer, user_email)
+        self._link_user(user_email, *enterprise_customers, **kwargs)
         return user
+
+    def _link_user(self, user_email, *enterprise_customers, **kwargs):
+        """
+        Helper to link a given test user to 1 or more enterprises.
+        """
+        for enterprise_customer in enterprise_customers:
+            EnterpriseCustomerUser.objects.link_user(enterprise_customer, user_email, **kwargs)
 
     @ddt.data(
         {
@@ -2286,6 +2298,55 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
         )
 
         assert expected_context == enterprise_role_assignment.get_context()
+
+    def test_get_assignments_many_assignments(self):
+        """
+        Tests that get_assignments orders context such that active enterprise uuids
+        are listed first for a given role.
+        """
+        alpha_customer = factories.EnterpriseCustomerFactory(uuid=UUID('aaaaaaaa-0000-0000-0000-000000000000'))
+        beta_customer = factories.EnterpriseCustomerFactory(uuid=UUID('bbbbbbbb-0000-0000-0000-000000000000'))
+        delta_customer = factories.EnterpriseCustomerFactory(uuid=UUID('dddddddd-0000-0000-0000-000000000000'))
+
+        test_user = factories.UserFactory(email='test@example.com')
+
+        # The order matters: because delta is most recently linked (and active), all other linked
+        # enterprise users will get active=False, leaving only delta as the active, linked enterprise.
+        # Remember that link_user() creates or updates an ECU record, which will automatically
+        # assign the enterprise_learner role via a Django signal.
+        self._link_user(test_user.email, alpha_customer)
+        self._link_user(test_user.email, beta_customer)
+        self._link_user(test_user.email, delta_customer)
+
+        # Create admin role assignments explicitly.
+        for customer in (alpha_customer, delta_customer):
+            SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+                user=test_user, role=roles_api.admin_role(),
+                enterprise_customer=customer, applies_to_all_contexts=False,
+            )
+
+        SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+            user=test_user,
+            role=roles_api.openedx_operator_role(),
+            applies_to_all_contexts=True,
+        )
+
+        expected_assignments = [
+            (
+                ENTERPRISE_ADMIN_ROLE, [
+                    str(delta_customer.uuid), str(alpha_customer.uuid),
+                ],
+            ),
+            (
+                ENTERPRISE_LEARNER_ROLE, [
+                    str(delta_customer.uuid), str(alpha_customer.uuid), str(beta_customer.uuid)
+                ],
+            ),
+            (ENTERPRISE_OPERATOR_ROLE, [ALL_ACCESS_CONTEXT]),
+        ]
+
+        actual_assignments = list(SystemWideEnterpriseUserRoleAssignment.get_assignments(test_user))
+        self.assertEqual(expected_assignments, actual_assignments)
 
     def test_unique_together_constraint(self):
         """


### PR DESCRIPTION
Overrides the [SystemWideEnterpriseUserRoleAssignment.get_assignments()](https://github.com/openedx/edx-enterprise/blob/9753181f1efee616affac216efe56eec9dc2a9b6/enterprise/models.py#L2802) method to return list of (role, context) assignments where the first item in the list corresponds to the currently active enterprise for the user.

This approach should allow us to remedy the problem without changing behavior of the consumers of JWT-stored roles (e.g. in ecommerce).

https://openedx.atlassian.net/browse/ENT-5700

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
