### PR TITLE
chore: replace enterprise customer drop-downs in django admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing
 
+[3.43.1]
+---------
+chore: replace enterprise customer drop-downs in django admin
+
 [3.43.0]
 ---------
 feat: allow admins to remove learners from org

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.43.0"
+__version__ = "3.43.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -44,6 +44,10 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         "transmission_chunk_size",
     )
 
+    raw_id_fields = (
+        "enterprise_customer",
+    )
+
     search_fields = ("enterprise_customer_name",)
 
     class Meta:

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -29,6 +29,10 @@ class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         "transmission_chunk_size",
     )
 
+    raw_id_fields = (
+        "enterprise_customer",
+    )
+
     search_fields = ("enterprise_customer_name",)
 
     class Meta:

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -68,6 +68,10 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         "enterprise_customer_name",
     )
 
+    raw_id_fields = (
+        "enterprise_customer",
+    )
+
     list_filter = ("active",)
 
     search_fields = ("enterprise_customer_name",)

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -47,6 +47,10 @@ class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         "enterprise_customer_name",
     )
 
+    raw_id_fields = (
+        "enterprise_customer",
+    )
+
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
 

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -28,6 +28,10 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         "transmission_chunk_size",
     )
 
+    raw_id_fields = (
+        "enterprise_customer",
+    )
+
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
 

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -12,5 +12,20 @@ class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
     """
     Admin for the ContentMetadataItemTransmission audit table
     """
-    list_display = ('enterprise_customer', 'integrated_channel_code', 'content_id', 'channel_metadata')
-    search_fields = ('enterprise_customer__name', 'enterprise_customer__uuid', 'integrated_channel_code', 'content_id')
+    list_display = (
+        'enterprise_customer',
+        'integrated_channel_code',
+        'content_id',
+        'channel_metadata'
+    )
+    
+    search_fields = (
+        'enterprise_customer__name',
+        'enterprise_customer__uuid',
+        'integrated_channel_code',
+        'content_id'
+    )
+
+    raw_id_fields = (
+        'enterprise_customer',
+    )

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -18,7 +18,7 @@ class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
         'content_id',
         'channel_metadata'
     )
-    
+
     search_fields = (
         'enterprise_customer__name',
         'enterprise_customer__uuid',

--- a/integrated_channels/moodle/admin/__init__.py
+++ b/integrated_channels/moodle/admin/__init__.py
@@ -35,4 +35,8 @@ class MoodleEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     Django admin model for MoodleEnterpriseCustomerConfiguration.
     """
 
+    raw_id_fields = (
+        'enterprise_customer',
+    )
+
     form = MoodleEnterpriseCustomerConfigurationForm

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -71,6 +71,10 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
         'transmission_chunk_size',
     )
 
+    raw_id_fields = (
+        'enterprise_customer',
+    )
+
     list_filter = ('active',)
     search_fields = ('enterprise_customer__name',)
 

--- a/integrated_channels/xapi/admin/__init__.py
+++ b/integrated_channels/xapi/admin/__init__.py
@@ -27,6 +27,11 @@ class XAPILRSConfigurationAdmin(admin.ModelAdmin):
         'endpoint',
         'modified',
     )
+
+    raw_id_fields = (
+        'enterprise_customer',
+    )
+
     ordering = ('enterprise_customer__name', )
     list_filter = ('active', )
     search_fields = ('enterprise_customer__name',)


### PR DESCRIPTION
## Description

- improve performance & safety of the django admin pages by replacing drop-downs for enterprise customer fields

## Reference

- ENT-5609
- https://github.com/openedx/edx-enterprise/pull/1495
