### PR TITLE
fix: accept duplicate course id on create

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Change Log
 
 Unreleased
 ----------
-* nothing
+fix: Moodle client should accept treat duplicate course id on create as a success
 
 [3.44.1]
 --------

--- a/integrated_channels/moodle/client.py
+++ b/integrated_channels/moodle/client.py
@@ -370,6 +370,8 @@ class MoodleAPIClient(IntegratedChannelApiClient):
             # set chunk size settings to 1 if youre seeing a lot of these errors
             if error.moodle_error == 'shortnametaken' and not more_than_one_course:
                 return True
+            elif error.moodle_error == 'courseidnumbertaken' and not more_than_one_course:
+                return True
             else:
                 raise error
         return True

--- a/tests/test_integrated_channels/test_moodle/test_client.py
+++ b/tests/test_integrated_channels/test_moodle/test_client.py
@@ -54,6 +54,7 @@ COURSEIDNUMBERTAKEN_RESPONSE.json.return_value = {
 }
 COURSEIDNUMBERTAKEN_RESPONSE.status_code = 200
 
+
 @pytest.mark.django_db
 class TestMoodleApiClient(unittest.TestCase):
     """


### PR DESCRIPTION
## Description

- while creating, accept a `courseidnumbertaken` error as success
- similar behavior for `shortnametaken` already exists

```
Apr 13 17:59:34 ip-10-2-71-73 [service_variant=lms][integrated_channels.integrated_channel.transmitters.content_metadata][env:prod-edx-edxapp] ERROR [ip-10-2-71-73  11441] [user None] [ip None] [content_metadata.py:117] - Moodle API Client Task "_wrapped_post" failed with error code "courseidnumbertaken" and message: "ID number is already used for another course (NYIF+ECS-IBFx)" 
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/transmitters/content_metadata.py", line 109, in _transmit_create
    self.client.create_content_metadata(serialized_chunk)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/moodle/client.py", line 374, in create_content_metadata
    raise error
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/moodle/client.py", line 367, in create_content_metadata
    self._wrapped_post(serialized_data)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/moodle/client.py", line 75, in inner
    raise MoodleClientError(
integrated_channels.moodle.client.MoodleClientError: Moodle API Client Task "_wrapped_post" failed with error code "courseidnumbertaken" and message: "ID number is already used for another course (NYIF+ECS-IBFx)" 
```

## References

- ENT-5722
