### PR TITLE
Revert "fix: override get_assignments() so that active enterprise uui…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,14 +17,6 @@ Unreleased
 ----------
 * nothing
 
-[3.44.0]
---------
-fix: override get_assignments() so that active enterprise uuids come first.
-
-Overrides the SystemWideEnterpriseUserRoleAssignment.get_assignments() method to return
-a list of (role, context) assignments, where the first item in the list corresponds
-to the currently active enterprise for the user.
-
 [3.43.1]
 ---------
 chore: replace enterprise customer drop-downs in django admin

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.44.0"
+__version__ = "3.43.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -9,7 +9,6 @@ import shutil
 import unittest
 from datetime import timedelta
 from unittest import mock
-from uuid import UUID
 
 import ddt
 from edx_rest_api_client.exceptions import HttpClientError
@@ -32,12 +31,7 @@ from consent.errors import InvalidProxyConsent
 from consent.helpers import get_data_sharing_consent
 from consent.models import DataSharingConsent, ProxyDataSharingConsent
 from enterprise import roles_api
-from enterprise.constants import (
-    ALL_ACCESS_CONTEXT,
-    ENTERPRISE_ADMIN_ROLE,
-    ENTERPRISE_LEARNER_ROLE,
-    ENTERPRISE_OPERATOR_ROLE,
-)
+from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE, ENTERPRISE_OPERATOR_ROLE
 from enterprise.errors import LinkUserToEnterpriseError
 from enterprise.models import (
     EnrollmentNotificationEmailTemplate,
@@ -2190,7 +2184,7 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
     Tests SystemWideEnterpriseUserRoleAssignment.
     """
 
-    def _create_and_link_user(self, user_email, *enterprise_customers, **kwargs):
+    def _create_and_link_user(self, user_email, *enterprise_customers):
         """
         Helper that creates a User with the given email, then links that user
         to each of the given EnterpriseCustomers.
@@ -2198,15 +2192,9 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
         should also create some role assignments.
         """
         user = factories.UserFactory(email=user_email)
-        self._link_user(user_email, *enterprise_customers, **kwargs)
-        return user
-
-    def _link_user(self, user_email, *enterprise_customers, **kwargs):
-        """
-        Helper to link a given test user to 1 or more enterprises.
-        """
         for enterprise_customer in enterprise_customers:
-            EnterpriseCustomerUser.objects.link_user(enterprise_customer, user_email, **kwargs)
+            EnterpriseCustomerUser.objects.link_user(enterprise_customer, user_email)
+        return user
 
     @ddt.data(
         {
@@ -2298,55 +2286,6 @@ class TestSystemWideEnterpriseUserRoleAssignment(unittest.TestCase):
         )
 
         assert expected_context == enterprise_role_assignment.get_context()
-
-    def test_get_assignments_many_assignments(self):
-        """
-        Tests that get_assignments orders context such that active enterprise uuids
-        are listed first for a given role.
-        """
-        alpha_customer = factories.EnterpriseCustomerFactory(uuid=UUID('aaaaaaaa-0000-0000-0000-000000000000'))
-        beta_customer = factories.EnterpriseCustomerFactory(uuid=UUID('bbbbbbbb-0000-0000-0000-000000000000'))
-        delta_customer = factories.EnterpriseCustomerFactory(uuid=UUID('dddddddd-0000-0000-0000-000000000000'))
-
-        test_user = factories.UserFactory(email='test@example.com')
-
-        # The order matters: because delta is most recently linked (and active), all other linked
-        # enterprise users will get active=False, leaving only delta as the active, linked enterprise.
-        # Remember that link_user() creates or updates an ECU record, which will automatically
-        # assign the enterprise_learner role via a Django signal.
-        self._link_user(test_user.email, alpha_customer)
-        self._link_user(test_user.email, beta_customer)
-        self._link_user(test_user.email, delta_customer)
-
-        # Create admin role assignments explicitly.
-        for customer in (alpha_customer, delta_customer):
-            SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
-                user=test_user, role=roles_api.admin_role(),
-                enterprise_customer=customer, applies_to_all_contexts=False,
-            )
-
-        SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
-            user=test_user,
-            role=roles_api.openedx_operator_role(),
-            applies_to_all_contexts=True,
-        )
-
-        expected_assignments = [
-            (
-                ENTERPRISE_ADMIN_ROLE, [
-                    str(delta_customer.uuid), str(alpha_customer.uuid),
-                ],
-            ),
-            (
-                ENTERPRISE_LEARNER_ROLE, [
-                    str(delta_customer.uuid), str(alpha_customer.uuid), str(beta_customer.uuid)
-                ],
-            ),
-            (ENTERPRISE_OPERATOR_ROLE, [ALL_ACCESS_CONTEXT]),
-        ]
-
-        actual_assignments = list(SystemWideEnterpriseUserRoleAssignment.get_assignments(test_user))
-        self.assertEqual(expected_assignments, actual_assignments)
 
     def test_unique_together_constraint(self):
         """


### PR DESCRIPTION
…ds come first."

This reverts commit 6f0075902615d1d34789f5a3507a5bfcb63f53a4.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
