### PR TITLE
fix: Revert "Revert "fix: override get_assignments() so that active enterprise uuids come first.""

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,10 +17,24 @@ Unreleased
 ----------
 fix: Moodle client should accept treat duplicate course id on create as a success
 
+[3.44.2]
+--------
+fix: Undoes revert of 3.44.0, while also ensuring that
+``SystemWideEnterpriseUserRoleAssignment.get_assignments()`` can handle and respect any null values returned
+from ``get_context()``.
+
 [3.44.1]
 --------
 fix: no-op version bump (skipping 3.44.0) to account for a revert:
 https://github.com/openedx/edx-enterprise/pull/1534
+
+[3.44.0]
+--------
+fix: [REVERTED] override get_assignments() so that active enterprise uuids come first.
+
+Overrides the SystemWideEnterpriseUserRoleAssignment.get_assignments() method to return
+a list of (role, context) assignments, where the first item in the list corresponds
+to the currently active enterprise for the user.
 
 [3.43.1]
 ---------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.44.1"
+__version__ = "3.44.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"


### PR DESCRIPTION
Ensure that EnterpriseSystemWideUserRoleAssignment.get_assignments() can handle null values that might be returned by get_context().  See https://openedx.atlassian.net/browse/ENT-4346 for open technical debt and partial explanation of how `None` is a meaningful context.

This reverts commit 6927277aad53f2497a336730e8af52372ee316cf.

https://openedx.atlassian.net/browse/ENT-5700

Screenshots from manually testing the specific null-pointer defect:
Create a new user with no enterprise link, but _with_ an assignment record where the enterprise id is null and they don't have wildcard access:
<img width="1058" alt="image" src="https://user-images.githubusercontent.com/2307986/163437583-e04bb4c1-b05f-4d9a-b6eb-e917101bd58b.png">


Login and verify that there are no errors, and the user's JWT should have `roles` with a role name but no context:
![image](https://user-images.githubusercontent.com/2307986/163437454-aa09c103-b510-4e75-a221-43f67a6d5554.png)


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
