### PR TITLE
fix: implement back-off and retry for degreed2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,7 @@ Change Log
 
 Unreleased
 ----------
-None
+fix: implement back-off and retry for degreed2
 
 [3.44.3]
 --------

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -85,6 +85,7 @@ class Degreed2LearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
         "enterprise_course_enrollment_id",
         "course_id",
         "status",
+        "modified",
     )
 
     readonly_fields = (

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -5,6 +5,7 @@ Client for connecting to Degreed2.
 
 import json
 import logging
+import time
 
 import requests
 from six.moves.urllib.parse import urljoin
@@ -324,7 +325,23 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         - `CONTENT_READ_SCOPE`
         """
         self._create_session(scope)
-        response = self.session.get(url)
+        tries = 0
+        while True:
+            tries = tries + 1
+            response = self.session.get(url)
+            if tries <= 3 and response.status_code == 429:
+                    LOGGER.warning(
+                        generate_formatted_log(
+                            self.enterprise_configuration.channel_code(),
+                            self.enterprise_configuration.enterprise_customer.uuid,
+                            None,
+                            None,
+                            "429 detected, backing-off before retrying..."
+                        )
+                    )
+                    time.sleep((2 ^ (tries - 1)))
+            else:
+                break
         return response.status_code, response.text
 
     def _post(self, url, data, scope):
@@ -339,7 +356,23 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         - `CONTENT_READ_SCOPE`
         """
         self._create_session(scope)
-        response = self.session.post(url, json=data)
+        tries = 0
+        while True:
+            tries = tries + 1
+            response = self.session.post(url, json=data)
+            if tries <= 3 and response.status_code == 429:
+                    LOGGER.warning(
+                        generate_formatted_log(
+                            self.enterprise_configuration.channel_code(),
+                            self.enterprise_configuration.enterprise_customer.uuid,
+                            None,
+                            None,
+                            "429 detected, backing-off before retrying..."
+                        )
+                    )
+                    time.sleep((2 ^ (tries - 1)))
+            else:
+                break
         return response.status_code, response.text
 
     def _patch(self, url, data, scope):
@@ -354,7 +387,23 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         - `CONTENT_READ_SCOPE`
         """
         self._create_session(scope)
-        response = self.session.patch(url, json=data)
+        tries = 0
+        while True:
+            tries = tries + 1
+            response = self.session.patch(url, json=data)
+            if tries <= 3 and response.status_code == 429:
+                    LOGGER.warning(
+                        generate_formatted_log(
+                            self.enterprise_configuration.channel_code(),
+                            self.enterprise_configuration.enterprise_customer.uuid,
+                            None,
+                            None,
+                            "429 detected, backing-off before retrying..."
+                        )
+                    )
+                    time.sleep((2 ^ (tries - 1)))
+            else:
+                break
         return response.status_code, response.text
 
     def _delete(self, url, data, scope):
@@ -369,7 +418,23 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         - `COMPLETION_PROVIDER_SCOPE`
         """
         self._create_session(scope)
-        response = self.session.delete(url, json=data) if data else self.session.delete(url)
+        tries = 0
+        while True:
+            tries = tries + 1
+            response = self.session.delete(url, json=data) if data else self.session.delete(url)
+            if tries <= 3 and response.status_code == 429:
+                    LOGGER.warning(
+                        generate_formatted_log(
+                            self.enterprise_configuration.channel_code(),
+                            self.enterprise_configuration.enterprise_customer.uuid,
+                            None,
+                            None,
+                            "429 detected, backing-off before retrying..."
+                        )
+                    )
+                    time.sleep((2 ^ (tries - 1)))
+            else:
+                break
         return response.status_code, response.text
 
     def _create_session(self, scope):

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -31,6 +31,8 @@ class Degreed2APIClient(IntegratedChannelApiClient):
     CONTENT_WRITE_SCOPE = "content:write"
     ALL_DESIRED_SCOPES = "content:read,content:write,completions:write,completions:read"
     SESSION_TIMEOUT = 60
+    MAX_RETRIES = 3
+    BACKOFF_FACTOR = 1
 
     def __init__(self, enterprise_configuration):
         """
@@ -329,7 +331,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         while True:
             tries = tries + 1
             response = self.session.get(url)
-            if tries <= 3 and response.status_code == 429:
+            if tries <= self.MAX_RETRIES and response.status_code == 429:
                 LOGGER.warning(
                     generate_formatted_log(
                         self.enterprise_configuration.channel_code(),
@@ -339,7 +341,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         "429 detected, backing-off before retrying..."
                     )
                 )
-                time.sleep((2 ^ (tries - 1)))
+                time.sleep((self.BACKOFF_FACTOR * (2 ^ (tries - 1))))
             else:
                 break
         return response.status_code, response.text
@@ -360,7 +362,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         while True:
             tries = tries + 1
             response = self.session.post(url, json=data)
-            if tries <= 3 and response.status_code == 429:
+            if tries <= self.MAX_RETRIES and response.status_code == 429:
                 LOGGER.warning(
                     generate_formatted_log(
                         self.enterprise_configuration.channel_code(),
@@ -370,7 +372,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         "429 detected, backing-off before retrying..."
                     )
                 )
-                time.sleep((2 ^ (tries - 1)))
+                time.sleep((self.BACKOFF_FACTOR * (2 ^ (tries - 1))))
             else:
                 break
         return response.status_code, response.text
@@ -391,7 +393,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         while True:
             tries = tries + 1
             response = self.session.patch(url, json=data)
-            if tries <= 3 and response.status_code == 429:
+            if tries <= self.MAX_RETRIES and response.status_code == 429:
                 LOGGER.warning(
                     generate_formatted_log(
                         self.enterprise_configuration.channel_code(),
@@ -401,7 +403,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         "429 detected, backing-off before retrying..."
                     )
                 )
-                time.sleep((2 ^ (tries - 1)))
+                time.sleep((self.BACKOFF_FACTOR * (2 ^ (tries - 1))))
             else:
                 break
         return response.status_code, response.text
@@ -422,7 +424,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         while True:
             tries = tries + 1
             response = self.session.delete(url, json=data) if data else self.session.delete(url)
-            if tries <= 3 and response.status_code == 429:
+            if tries <= self.MAX_RETRIES and response.status_code == 429:
                 LOGGER.warning(
                     generate_formatted_log(
                         self.enterprise_configuration.channel_code(),
@@ -432,7 +434,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                         "429 detected, backing-off before retrying..."
                     )
                 )
-                time.sleep((2 ^ (tries - 1)))
+                time.sleep((self.BACKOFF_FACTOR * (2 ^ (tries - 1))))
             else:
                 break
         return response.status_code, response.text

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -330,16 +330,16 @@ class Degreed2APIClient(IntegratedChannelApiClient):
             tries = tries + 1
             response = self.session.get(url)
             if tries <= 3 and response.status_code == 429:
-                    LOGGER.warning(
-                        generate_formatted_log(
-                            self.enterprise_configuration.channel_code(),
-                            self.enterprise_configuration.enterprise_customer.uuid,
-                            None,
-                            None,
-                            "429 detected, backing-off before retrying..."
-                        )
+                LOGGER.warning(
+                    generate_formatted_log(
+                        self.enterprise_configuration.channel_code(),
+                        self.enterprise_configuration.enterprise_customer.uuid,
+                        None,
+                        None,
+                        "429 detected, backing-off before retrying..."
                     )
-                    time.sleep((2 ^ (tries - 1)))
+                )
+                time.sleep((2 ^ (tries - 1)))
             else:
                 break
         return response.status_code, response.text
@@ -361,16 +361,16 @@ class Degreed2APIClient(IntegratedChannelApiClient):
             tries = tries + 1
             response = self.session.post(url, json=data)
             if tries <= 3 and response.status_code == 429:
-                    LOGGER.warning(
-                        generate_formatted_log(
-                            self.enterprise_configuration.channel_code(),
-                            self.enterprise_configuration.enterprise_customer.uuid,
-                            None,
-                            None,
-                            "429 detected, backing-off before retrying..."
-                        )
+                LOGGER.warning(
+                    generate_formatted_log(
+                        self.enterprise_configuration.channel_code(),
+                        self.enterprise_configuration.enterprise_customer.uuid,
+                        None,
+                        None,
+                        "429 detected, backing-off before retrying..."
                     )
-                    time.sleep((2 ^ (tries - 1)))
+                )
+                time.sleep((2 ^ (tries - 1)))
             else:
                 break
         return response.status_code, response.text
@@ -392,16 +392,16 @@ class Degreed2APIClient(IntegratedChannelApiClient):
             tries = tries + 1
             response = self.session.patch(url, json=data)
             if tries <= 3 and response.status_code == 429:
-                    LOGGER.warning(
-                        generate_formatted_log(
-                            self.enterprise_configuration.channel_code(),
-                            self.enterprise_configuration.enterprise_customer.uuid,
-                            None,
-                            None,
-                            "429 detected, backing-off before retrying..."
-                        )
+                LOGGER.warning(
+                    generate_formatted_log(
+                        self.enterprise_configuration.channel_code(),
+                        self.enterprise_configuration.enterprise_customer.uuid,
+                        None,
+                        None,
+                        "429 detected, backing-off before retrying..."
                     )
-                    time.sleep((2 ^ (tries - 1)))
+                )
+                time.sleep((2 ^ (tries - 1)))
             else:
                 break
         return response.status_code, response.text

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -423,16 +423,16 @@ class Degreed2APIClient(IntegratedChannelApiClient):
             tries = tries + 1
             response = self.session.delete(url, json=data) if data else self.session.delete(url)
             if tries <= 3 and response.status_code == 429:
-                    LOGGER.warning(
-                        generate_formatted_log(
-                            self.enterprise_configuration.channel_code(),
-                            self.enterprise_configuration.enterprise_customer.uuid,
-                            None,
-                            None,
-                            "429 detected, backing-off before retrying..."
-                        )
+                LOGGER.warning(
+                    generate_formatted_log(
+                        self.enterprise_configuration.channel_code(),
+                        self.enterprise_configuration.enterprise_customer.uuid,
+                        None,
+                        None,
+                        "429 detected, backing-off before retrying..."
                     )
-                    time.sleep((2 ^ (tries - 1)))
+                )
+                time.sleep((2 ^ (tries - 1)))
             else:
                 break
         return response.status_code, response.text

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -290,7 +290,11 @@ def generate_formatted_log(
         f'integrated_channel_course_key={course_or_course_run_key}, {message}'
 
 
-def refresh_session_if_expired(oauth_access_token_function, session=None, expires_at=None):
+def refresh_session_if_expired(
+    oauth_access_token_function,
+    session=None,
+    expires_at=None,
+):
     """
     Instantiate a new session object for use in connecting with integrated channel.
     Or, return an updated session if provided session has expired.

--- a/tests/test_integrated_channels/test_degreed2/test_client.py
+++ b/tests/test_integrated_channels/test_degreed2/test_client.py
@@ -174,15 +174,15 @@ class TestDegreed2ApiClient(unittest.TestCase):
         course_url = degreed_api_client.get_courses_url()
 
         too_fast_response = {
-          "errors": [
-            {
-              "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
-              "code": "quota-exceeded",
-              "status": 429,
-              "title": "API calls quota exceeded.",
-              "detail": "Maximum 70 requests allowed per 1m."
-            }
-          ]
+            "errors": [
+                {
+                  "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
+                  "code": "quota-exceeded",
+                  "status": 429,
+                  "title": "API calls quota exceeded.",
+                  "detail": "Maximum 70 requests allowed per 1m."
+                }
+            ]
         }
 
         responses.add(
@@ -223,15 +223,15 @@ class TestDegreed2ApiClient(unittest.TestCase):
         course_url = degreed_api_client.get_courses_url()
 
         too_fast_response = {
-          "errors": [
-            {
-              "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
-              "code": "quota-exceeded",
-              "status": 429,
-              "title": "API calls quota exceeded.",
-              "detail": "Maximum 70 requests allowed per 1m."
-            }
-          ]
+            "errors": [
+                {
+                  "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
+                  "code": "quota-exceeded",
+                  "status": 429,
+                  "title": "API calls quota exceeded.",
+                  "detail": "Maximum 70 requests allowed per 1m."
+                }
+            ]
         }
 
         responses.add(

--- a/tests/test_integrated_channels/test_degreed2/test_client.py
+++ b/tests/test_integrated_channels/test_degreed2/test_client.py
@@ -176,11 +176,11 @@ class TestDegreed2ApiClient(unittest.TestCase):
         too_fast_response = {
             "errors": [
                 {
-                  "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
-                  "code": "quota-exceeded",
-                  "status": 429,
-                  "title": "API calls quota exceeded.",
-                  "detail": "Maximum 70 requests allowed per 1m."
+                    "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
+                    "code": "quota-exceeded",
+                    "status": 429,
+                    "title": "API calls quota exceeded.",
+                    "detail": "Maximum 70 requests allowed per 1m."
                 }
             ]
         }
@@ -225,11 +225,11 @@ class TestDegreed2ApiClient(unittest.TestCase):
         too_fast_response = {
             "errors": [
                 {
-                  "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
-                  "code": "quota-exceeded",
-                  "status": 429,
-                  "title": "API calls quota exceeded.",
-                  "detail": "Maximum 70 requests allowed per 1m."
+                    "id": "c2e2f849-ed0a-4ed8-833c-f9008113948c",
+                    "code": "quota-exceeded",
+                    "status": 429,
+                    "title": "API calls quota exceeded.",
+                    "detail": "Maximum 70 requests allowed per 1m."
                 }
             ]
         }

--- a/tests/test_integrated_channels/test_degreed2/test_client.py
+++ b/tests/test_integrated_channels/test_degreed2/test_client.py
@@ -5,7 +5,6 @@ Tests for Degreed2 client for integrated_channels.
 
 import datetime
 import json
-import logging
 import unittest
 
 import mock
@@ -26,8 +25,6 @@ NOW = datetime.datetime(2017, 1, 2, 3, 4, 5, tzinfo=timezone.utc)
 NOW_TIMESTAMP_FORMATTED = NOW.strftime('%F')
 
 app_config = apps.get_app_config("degreed2")
-
-LOGGER = logging.getLogger(__name__)
 
 
 def create_course_payload():


### PR DESCRIPTION
## Description

We've been seeing errors in the integrated channel logs for Degreed2 - we're not honoring their 429's and not attempting to back-off nor retry. Seems to be holding up syncs from completing properly.

- back-off/retry all HTTP methods
- test retry
- show modified in admin

## References

- [ENT-5741](https://openedx.atlassian.net/browse/ENT-5741)
