### PR TITLE
fix: drop tpa_hint param in redirects when no SSO

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,12 @@ Change Log
 
 Unreleased
 ----------
+None
+
+[3.44.4]
+--------
 fix: implement back-off and retry for degreed2
+fix: drop tpa_hint param in redirects when no SSO
 
 [3.44.3]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.44.3"
+__version__ = "3.44.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/decorators.py
+++ b/enterprise/decorators.py
@@ -136,8 +136,12 @@ def enterprise_login_required(view):
         if not request.user.is_authenticated:
             parsed_current_url = urlparse(request.get_full_path())
             parsed_query_string = parse_qs(parsed_current_url.query)
+            tpa_hint = enterprise_customer.get_tpa_hint(tpa_hint_param)
+            if tpa_hint:
+                parsed_query_string.update({
+                    'tpa_hint': tpa_hint,
+                })
             parsed_query_string.update({
-                'tpa_hint': enterprise_customer.get_tpa_hint(tpa_hint_param),
                 FRESH_LOGIN_PARAMETER: 'yes'
             })
             next_url = '{current_path}?{query_string}'.format(

--- a/tests/test_decorators.py
+++ b/tests/test_decorators.py
@@ -170,7 +170,10 @@ class TestEnterpriseDecorators(unittest.TestCase):
         # user tries to access enterprise course enrollment page.
         assert response.status_code == 302
         assert 'new_enterprise_login%3Dyes' in response.url
-        assert f'tpa_hint%3D{redirected_tpa_hint}' in response.url
+        if redirected_tpa_hint:
+            assert f'tpa_hint%3D{redirected_tpa_hint}' in response.url
+        else:
+            assert f'tpa_hint%3D{redirected_tpa_hint}' not in response.url
 
     def test_enterprise_login_required_redirects_for_anonymous_users_with_querystring(self):
         """


### PR DESCRIPTION
## Description

- when no SSO is configured for an enterprise customer, do not include a `tpa_hint=None` in the enroll -> auth redirect

## References

- [ENT-5728](https://openedx.atlassian.net/browse/ENT-5728)