### PR TITLE
fix: modify signature of EmbargoApiClient.redirect_if_blocked

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,12 @@ Unreleased
 ----------
 None
 
+[3.46.0]
+--------
+fix: modify signature of EmbargoApiClient.redirect_if_blocked
+Make this signature match and use the same signature that
+``openedx.core.djangoapps.embargo.api.redirect_if_blocked()`` now uses.
+
 [3.44.4]
 --------
 fix: implement back-off and retry for degreed2

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.45.0"
+__version__ = "3.46.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -33,16 +33,15 @@ class EmbargoApiClient:
     """
 
     @staticmethod
-    def redirect_if_blocked(course_run_ids, user=None, ip_address=None, url=None):
+    def redirect_if_blocked(request, course_run_ids, user=None):
         """
         Return redirect to embargo error page if the given user is blocked.
         """
         for course_run_id in course_run_ids:
             redirect_url = embargo_api.redirect_if_blocked(
-                CourseKey.from_string(course_run_id),
+                request=request,
+                course_key=CourseKey.from_string(course_run_id),
                 user=user,
-                ip_address=ip_address,
-                url=url
             )
             if redirect_url:
                 return redirect_url

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -15,7 +15,6 @@ import waffle  # pylint: disable=invalid-django-waffle-import
 from dateutil.parser import parse
 from edx_django_utils import monitoring
 from edx_rest_api_client.exceptions import HttpClientError
-from ipware.ip import get_client_ip
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
 
@@ -1786,7 +1785,10 @@ class CourseEnrollmentView(NonAtomicView):
         """
         # Check to see if access to the course run is restricted for this user.
         embargo_url = EmbargoApiClient.redirect_if_blocked(
-            [course_id], request.user, get_client_ip(request)[0], request.path)
+            request=request,
+            course_run_ids=[course_id],
+            user=request.user,
+        )
         if embargo_url:
             return redirect(embargo_url)
 
@@ -2165,7 +2167,10 @@ class ProgramEnrollmentView(NonAtomicView):
             for course_run in course['course_runs']:
                 course_run_ids.append(course_run['key'])
         embargo_url = EmbargoApiClient.redirect_if_blocked(
-            course_run_ids, request.user, get_client_ip(request)[0], request.path)
+            request=request,
+            course_run_ids=course_run_ids,
+            user=request.user,
+        )
         if embargo_url:
             return redirect(embargo_url)
 


### PR DESCRIPTION
Make this signature match and use the same signature that
``openedx.core.djangoapps.embargo.redirect_if_blocked()`` now uses.

https://openedx.atlassian.net/browse/ENT-5777

A change was introduced in https://github.com/openedx/edx-platform/pull/30295 that modified the signature of `embargo.redirect_if_blocked()`, this change makes enterprise code respect that new signature.

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
