### PR TITLE
fix: Degreed2 estimated time to complete in days

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.46.2]
+--------
+fix: Degreed2 estimated time to complete in days
+
 [3.46.1]
 --------
 feat: admin view improvements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.46.1"
+__version__ = "3.46.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -5,7 +5,7 @@ Content metadata exporter for Degreed.
 
 from logging import getLogger
 
-from enterprise.utils import get_closest_course_run, get_course_run_duration_info, parse_datetime_handle_invalid
+from enterprise.utils import get_closest_course_run, get_course_run_duration_info
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.utils import (
     generate_formatted_log,

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -9,9 +9,9 @@ from enterprise.utils import get_closest_course_run, get_course_run_duration_inf
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.utils import (
     generate_formatted_log,
+    get_courserun_duration_in_days,
     get_image_url,
     strip_html_tags,
-    get_courserun_duration_in_days,
 )
 
 LOGGER = getLogger(__name__)

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -7,7 +7,12 @@ from logging import getLogger
 
 from enterprise.utils import get_closest_course_run, get_course_run_duration_info, parse_datetime_handle_invalid
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
-from integrated_channels.utils import generate_formatted_log, get_image_url, strip_html_tags
+from integrated_channels.utils import (
+    generate_formatted_log,
+    get_image_url,
+    strip_html_tags,
+    get_courserun_duration_in_days,
+)
 
 LOGGER = getLogger(__name__)
 
@@ -40,17 +45,15 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
         Returns: duration in days
         """
         if content_metadata_item.get('content_type') == 'courserun':
-            start = content_metadata_item.get('start')
-            end = content_metadata_item.get('end')
+            return get_courserun_duration_in_days(content_metadata_item)
         elif content_metadata_item.get('content_type') == 'course':
             course_runs = content_metadata_item.get('course_runs')
             if course_runs:
                 course_run = get_closest_course_run(course_runs)
                 if course_run:
-                    start = course_run.get('start')
-                    end = course_run.get('end')
+                    return get_courserun_duration_in_days(course_run)
                 else:
-                    LOGGER.error(
+                    LOGGER.warning(
                         generate_formatted_log(
                             self.enterprise_configuration.channel_code(),
                             self.enterprise_configuration.enterprise_customer.uuid,
@@ -62,7 +65,7 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
                     )
                     return 0
             else:
-                LOGGER.error(
+                LOGGER.warning(
                     generate_formatted_log(
                         self.enterprise_configuration.channel_code(),
                         self.enterprise_configuration.enterprise_customer.uuid,
@@ -75,23 +78,6 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
                 return 0
         else:
             return 0
-
-        start_date = parse_datetime_handle_invalid(start)
-        end_date = parse_datetime_handle_invalid(end)
-        if not start_date or not end_date:
-            LOGGER.error(
-                generate_formatted_log(
-                    self.enterprise_configuration.channel_code(),
-                    self.enterprise_configuration.enterprise_customer.uuid,
-                    None,
-                    None,
-                    'Failed to find valid start/end dates, so duration is going to be set to 0. '
-                    f'Course item was {content_metadata_item} '
-                    f'Parsed Start was: {start_date}, End was: {end_date}'
-                )
-            )
-            return 0
-        return (end_date - start_date).days
 
     def transform_description(self, content_metadata_item):
         """

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -235,6 +235,22 @@ def get_duration_from_estimated_hours(estimated_hours):
     return None
 
 
+def get_courserun_duration_in_days(course_run):
+    """
+    Return the duration in number of days corresponding to a course run.
+    """
+    min_effort = course_run.get('min_effort')
+    max_effort = course_run.get('max_effort')
+    weeks_to_complete = course_run.get('weeks_to_complete')
+    if min_effort and max_effort and weeks_to_complete:
+        hours_per_day = 8.0
+        average_hours_per_week = (min_effort + max_effort) / 2.0
+        total_days = (weeks_to_complete * average_hours_per_week) / hours_per_day
+        return math.ceil(total_days)
+    else:
+        return 0
+
+
 def get_subjects_from_content_metadata(content_metadata_item):
     """
     Returns a list of subject names for the content metadata item.

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
@@ -149,18 +149,24 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
                     "start": "2021-10-01T16:00:00Z",
                     "end": "2022-01-01T17:00:00Z",
                     "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+                    "min_effort": 2,
+                    "max_effort": 4,
+                    "weeks_to_complete": 10,
                 },
                 {
                     "key": "course-v1:edX+0087786+3T2021",
                     "start": "2019-10-01T16:00:00Z",
                     "end": "2022-01-02T17:00:00Z",
                     "uuid": "7d238cc5-88e4-4931-a28e-4193ae4b2618",
+                    "min_effort": 2,
+                    "max_effort": 4,
+                    "weeks_to_complete": 10,
                 }
             ],
             "uuid": "3580463a-6f9c-48ed-ae8d-b5a012860d75",
             "advertised_course_run_uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
         }
-        assert exporter.transform_duration(content_metadata_item) == 92
+        assert exporter.transform_duration(content_metadata_item) == 4
 
     def test_transform_duration_course_run(self):
         exporter = Degreed2ContentMetadataExporter('fake-user', self.config)
@@ -170,12 +176,15 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "start": "2021-10-01T16:00:00Z",
             "end": "2022-01-01T17:00:00Z",
             "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+            "min_effort": 2,
+            "max_effort": 4,
+            "weeks_to_complete": 10,
         }
-        assert exporter.transform_duration(content_metadata_item) == 92
+        assert exporter.transform_duration(content_metadata_item) == 4
 
     def test_transform_duration_with_invalid_dates(self):
         """
-        want to return 0 instead of fail with invalid dates
+        want to return 0 instead of fail with missing information
         """
         exporter = Degreed2ContentMetadataExporter('fake-user', self.config)
         content_metadata_item = {
@@ -184,6 +193,9 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "start": "2021-10-01T16:00:00Z",
             "end": None,
             "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+            "min_effort": 2,
+            "max_effort": 4,
+            "weeks_to_complete": None,
         }
         assert exporter.transform_duration(content_metadata_item) == 0
 
@@ -202,5 +214,8 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "start": None,
             "end": "2021-10-01T16:00:00Z",
             "uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+            "min_effort": None,
+            "max_effort": 4,
+            "weeks_to_complete": 10,
         }
         assert exporter.transform_duration(content_metadata_item) == 0

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -245,7 +245,6 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         assert utils.is_valid_url('badurl.com') is False
         assert utils.is_valid_url('https://') is False
 
-
     @ddt.data(
         (
             {

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -244,3 +244,36 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
 
         assert utils.is_valid_url('badurl.com') is False
         assert utils.is_valid_url('https://') is False
+
+
+    @ddt.data(
+        (
+            {
+                'start': '2018-02-05T05:00:00Z',
+                'min_effort': 2,
+                'max_effort': 4,
+                'weeks_to_complete': 10
+            },
+            4,
+        ),
+        (
+            {
+                'start': '2018-02-05T05:00:00Z',
+                'min_effort': 1,
+                'max_effort': 8,
+                'weeks_to_complete': 3
+            },
+            2,
+        ),
+        (
+            {
+                'start': '2018-02-05T05:00:00Z',
+                'min_effort': 1,
+                'max_effort': 8,
+            },
+            0,
+        ),
+    )
+    @ddt.unpack
+    def test_get_courserun_duration_in_days(self, course_run, expected_duration_days):
+        assert utils.get_courserun_duration_in_days(course_run) == expected_duration_days


### PR DESCRIPTION
## Description

- was erroneously reporting time-to-complete as whole course availability, days between start_date and end_date of the course run
- now averaging effort (which is hours), multiplying by weeks to complete, and dividing by 8-hour days to get a rough duration in days

## References

- [ENT-5788](https://openedx.atlassian.net/browse/ENT-5788)

