### PR TITLE
fix: update logic for parsing course price for SAP

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.46.3]
+--------
+fix: update logic for parsing course price for SAP
+
 [3.46.2]
 --------
 fix: Degreed2 estimated time to complete in days

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.46.2"
+__version__ = "3.46.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1140,6 +1140,38 @@ def parse_datetime_handle_invalid(datetime_value):
         return None
 
 
+def get_advertised_course_run(course):
+    """
+    Find the advertised course run for a given course
+    Arguments:
+        course (dict): course dict
+    Returns:
+        dict: a course_run or None
+    """
+    advertised_course_run_uuid = course.get('advertised_course_run_uuid')
+    if advertised_course_run_uuid:
+        for course_run in course.get('course_runs', []):
+            if advertised_course_run_uuid == course_run.get('uuid'):
+                return course_run
+    return None
+
+
+def is_course_run_active(course_run):
+    """
+    Checks whether a course run is active. That is, whether the course run is published,
+    enrollable, and marketable.
+    Arguments:
+        course_run (dict): The metadata about a course run.
+    Returns:
+        bool: True if course run is "active"
+    """
+    is_published = is_course_run_published(course_run)
+    is_enrollable = course_run.get('is_enrollable', False)
+    is_marketable = course_run.get('is_marketable', False)
+
+    return is_published and is_enrollable and is_marketable
+
+
 def get_course_run_duration_info(course_run):
     """
     Return course run's duration(str) info.

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -9,8 +9,8 @@ from django.utils.translation import gettext_lazy as _
 from enterprise.utils import (
     get_closest_course_run,
     get_duration_of_course_or_courserun,
-    is_course_run_available_for_enrollment, 
-    parse_lms_api_datetime, 
+    is_course_run_available_for_enrollment,
+    parse_lms_api_datetime,
     get_advertised_course_run,
     is_course_run_active,
 )
@@ -167,7 +167,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
                     if 'first_enrollable_paid_seat_price' in course_run and is_course_run_active(course_run):
                         price = course_run.get('first_enrollable_paid_seat_price') or 0.0
                         break
-       
+
         return [
             {
                 "currency": "USD",

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -9,8 +9,10 @@ from django.utils.translation import gettext_lazy as _
 from enterprise.utils import (
     get_closest_course_run,
     get_duration_of_course_or_courserun,
-    is_course_run_available_for_enrollment,
-    parse_lms_api_datetime,
+    is_course_run_available_for_enrollment, 
+    parse_lms_api_datetime, 
+    get_advertised_course_run,
+    is_course_run_active,
 )
 from enterprise.views import CourseEnrollmentView
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
@@ -155,10 +157,17 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         Return the current course run's price.
         """
         price = 0.0
+
         if self.enterprise_configuration.show_course_price:
-            for course_run in content_metadata_item.get('course_runs', []):
-                if course_run['availability'] == 'Current':
-                    price = course_run.get('first_enrollable_paid_seat_price', 0.0) or 0.0
+            advertised_course_run = get_advertised_course_run(content_metadata_item)
+            if advertised_course_run and 'first_enrollable_paid_seat_price' in advertised_course_run:
+                price = advertised_course_run.get('first_enrollable_paid_seat_price') or 0.0
+            else:
+                for course_run in content_metadata_item.get('course_runs', []):
+                    if 'first_enrollable_paid_seat_price' in course_run and is_course_run_active(course_run):
+                        price = course_run.get('first_enrollable_paid_seat_price') or 0.0
+                        break
+       
         return [
             {
                 "currency": "USD",

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -7,12 +7,12 @@ from logging import getLogger
 from django.utils.translation import gettext_lazy as _
 
 from enterprise.utils import (
+    get_advertised_course_run,
     get_closest_course_run,
     get_duration_of_course_or_courserun,
+    is_course_run_active,
     is_course_run_available_for_enrollment,
     parse_lms_api_datetime,
-    get_advertised_course_run,
-    is_course_run_active,
 )
 from enterprise.views import CourseEnrollmentView
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -1299,7 +1299,10 @@ def create_course_run_dict(start="2014-10-14T13:11:03Z", end="3000-10-13T13:11:0
                            upgrade_deadline="3000-10-13T13:11:04Z",
                            availability="Starting Soon",
                            status="published",
-                           weeks_to_complete=1):
+                           weeks_to_complete=1,
+                           uuid='785b11f5-fad5-4ce1-9233-e1a3ed31aadb',
+                           is_enrollable=True,
+                           is_marketable=True):
     """
     Return enrollable and upgradeable course run dict.
     """
@@ -1311,7 +1314,10 @@ def create_course_run_dict(start="2014-10-14T13:11:03Z", end="3000-10-13T13:11:0
         "enrollment_end": enrollment_end,
         "seats": [{"type": "verified", "upgrade_deadline": upgrade_deadline}],
         "availability": availability,
-        "weeks_to_complete": weeks_to_complete
+        "weeks_to_complete": weeks_to_complete,
+        "uuid": uuid,
+        "is_enrollable": is_enrollable,
+        "is_marketable": is_marketable
     }
 
 

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -32,7 +32,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
 
     @ddt.data(
         (
-            #advertised course run has price, use it
+            # advertised course run has price, use it
             {
                 "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
                 "course_runs": [
@@ -58,7 +58,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True,
         ),
         (
-            #advertised course run has no price, fall back to another active course
+            # advertised course run has no price, fall back to another active course
             {
                 "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
                 "course_runs": [
@@ -83,7 +83,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True,
         ),
         (
-            #no advertised course run, use active course run
+            # no advertised course run, use active course run
             {
                 "course_runs": [
                     {
@@ -100,7 +100,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True
         ),
         (
-            #no advertised course run and no active course run, return 0
+            # no advertised course run and no active course run, return 0
             {
                 'course_runs': [
                     {
@@ -117,7 +117,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True
         ),
         (
-            #show_course_price false, return 0
+            # show_course_price false, return 0
             {
                 'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                 'course_runs': [
@@ -135,7 +135,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             False
         ),
         (
-            #no price data, return 0
+            # no price data, return 0
             {
                 'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                 'course_runs': [
@@ -152,7 +152,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True
         ),
         (
-            #no course run data, return 0
+            # no course run data, return 0
             {'course_runs': []},
             0.0,
             True

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -87,7 +87,7 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             {
                 "course_runs": [
                     {
-                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',                        
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                         'title': 'edX Demonstration Course',
                         'status': 'published',
                         'is_enrollable': True,

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -32,29 +32,83 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
 
     @ddt.data(
         (
+            #advertised course run has price, use it
             {
+                "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
                 "course_runs": [
                     {
-                        'availability': 'Current',
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                         'title': 'edX Demonstration Course',
-                        'first_enrollable_paid_seat_price': 100
+                        'first_enrollable_paid_seat_price': 100,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True
                     },
                     {
-                        'availability': 'Archived',
+                        'uuid': '28e2d4c2-a020-4959-b461-6f879bbe1391',
                         'title': 'edX Demonstration Course',
-                        'first_enrollable_paid_seat_price': 50
+                        'first_enrollable_paid_seat_price': 50,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True
                     }
                 ]
             },
-            100.0,
+            100,
             True,
         ),
         (
+            #advertised course run has no price, fall back to another active course
+            {
+                "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
+                "course_runs": [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'title': 'edX Demonstration Course',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True
+                    },
+                    {
+                        'uuid': '28e2d4c2-a020-4959-b461-6f879bbe1391',
+                        'title': 'edX Demonstration Course',
+                        'first_enrollable_paid_seat_price': 50,
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True
+                    }
+                ]
+            },
+            50,
+            True,
+        ),
+        (
+            #no advertised course run, use active course run
             {
                 "course_runs": [
                     {
-                        'availability': 'Archived',
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',                        
                         'title': 'edX Demonstration Course',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
+                        'first_enrollable_paid_seat_price': 100
+                    }
+                ]
+            },
+            100,
+            True
+        ),
+        (
+            #no advertised course run and no active course run, return 0
+            {
+                'course_runs': [
+                    {
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
+                        'title': 'edX Demonstration Course',
+                        'status': 'unpublished',
+                        'is_enrollable': False,
+                        'is_marketable': False,
                         'first_enrollable_paid_seat_price': 100
                     }
                 ]
@@ -63,24 +117,16 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True
         ),
         (
+            #show_course_price false, return 0
             {
+                'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                 'course_runs': [
                     {
-                        'availability': 'Current',
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                         'title': 'edX Demonstration Course',
-                        'first_enrollable_paid_seat_price': 0.0
-                    }
-                ]
-            },
-            0.0,
-            True
-        ),
-        (
-            {
-                'course_runs': [
-                    {
-                        'availability': 'Current',
-                        'title': 'edX Demonstration Course',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True,
                         'first_enrollable_paid_seat_price': 100
                     }
                 ]
@@ -89,11 +135,16 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             False
         ),
         (
+            #no price data, return 0
             {
+                'advertised_course_run_uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                 'course_runs': [
                     {
-                        'availability': 'Current',
+                        'uuid': 'dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f',
                         'title': 'edX Demonstration Course',
+                        'status': 'published',
+                        'is_enrollable': True,
+                        'is_marketable': True
                     }
                 ]
             },
@@ -101,11 +152,11 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             True
         ),
         (
+            #no course run data, return 0
             {'course_runs': []},
             0.0,
-            True,
-        ),
-
+            True
+        )
     )
     @responses.activate
     @ddt.unpack

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1044,6 +1044,68 @@ class TestEnterpriseUtils(unittest.TestCase):
 
     @ddt.data(
         (
+            #advertised course run is set and included, return that one
+            {
+                "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
+                "course_runs": [
+                    fake_catalog_api.create_course_run_dict(uuid='dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f'),
+                    fake_catalog_api.create_course_run_dict(uuid='28e2d4c2-a020-4959-b461-6f879bbe1391')
+                ]
+            },
+            fake_catalog_api.create_course_run_dict(uuid='dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f')
+        ),
+        (
+            #advertised course run is set but not included, return None
+            {
+                "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
+                "course_runs": [
+                    fake_catalog_api.create_course_run_dict(uuid='28e2d4c2-a020-4959-b461-6f879bbe1391')
+                ]
+            },
+            None
+        ),
+        (
+            #advertised course run is not set, return None
+            {
+                "course_runs": [
+                    fake_catalog_api.create_course_run_dict(uuid='28e2d4c2-a020-4959-b461-6f879bbe1391')
+                ]
+            },
+            None
+        ),
+    )
+    @ddt.unpack
+    def test_get_advertised_course_run(self, course, expected_course_run):
+        assert utils.get_advertised_course_run(course) == expected_course_run
+
+    @ddt.data(
+        (
+            #everything true, course is active
+            fake_catalog_api.create_course_run_dict(status='published', is_enrollable=True, is_marketable=True),
+            True
+        ),
+        (
+            #not published
+            fake_catalog_api.create_course_run_dict(status='unpublished', is_enrollable=True, is_marketable=True),
+            False
+        ),
+        (
+            #not enrollable
+            fake_catalog_api.create_course_run_dict(status='published', is_enrollable=False, is_marketable=True),
+            False
+        ),
+        (
+            #not marketable
+            fake_catalog_api.create_course_run_dict(status='published', is_enrollable=True, is_marketable=False),
+            False
+        )
+    )
+    @ddt.unpack
+    def test_is_course_run_active(self, course_run, expected_result):
+        assert utils.is_course_run_active(course_run) == expected_result
+
+    @ddt.data(
+        (
             {
                 "min_effort": 2,
                 "max_effort": 3,

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -1044,7 +1044,7 @@ class TestEnterpriseUtils(unittest.TestCase):
 
     @ddt.data(
         (
-            #advertised course run is set and included, return that one
+            # advertised course run is set and included, return that one
             {
                 "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
                 "course_runs": [
@@ -1055,7 +1055,7 @@ class TestEnterpriseUtils(unittest.TestCase):
             fake_catalog_api.create_course_run_dict(uuid='dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f')
         ),
         (
-            #advertised course run is set but not included, return None
+            # advertised course run is set but not included, return None
             {
                 "advertised_course_run_uuid": "dd7bb3e4-56e9-4639-9296-ea9c2fb99c7f",
                 "course_runs": [
@@ -1065,7 +1065,7 @@ class TestEnterpriseUtils(unittest.TestCase):
             None
         ),
         (
-            #advertised course run is not set, return None
+            # advertised course run is not set, return None
             {
                 "course_runs": [
                     fake_catalog_api.create_course_run_dict(uuid='28e2d4c2-a020-4959-b461-6f879bbe1391')
@@ -1080,22 +1080,22 @@ class TestEnterpriseUtils(unittest.TestCase):
 
     @ddt.data(
         (
-            #everything true, course is active
+            # everything true, course is active
             fake_catalog_api.create_course_run_dict(status='published', is_enrollable=True, is_marketable=True),
             True
         ),
         (
-            #not published
+            # not published
             fake_catalog_api.create_course_run_dict(status='unpublished', is_enrollable=True, is_marketable=True),
             False
         ),
         (
-            #not enrollable
+            # not enrollable
             fake_catalog_api.create_course_run_dict(status='published', is_enrollable=False, is_marketable=True),
             False
         ),
         (
-            #not marketable
+            # not marketable
             fake_catalog_api.create_course_run_dict(status='published', is_enrollable=True, is_marketable=False),
             False
         )


### PR DESCRIPTION
Updating course price parsing for SAP to match the logic in enterprise catalog: https://openedx.atlassian.net/browse/ENT-5687

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
