### PR TITLE
feat: degreed2 course duration in hours

### DIFF
--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -9,7 +9,7 @@ from enterprise.utils import get_closest_course_run, get_course_run_duration_inf
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.utils import (
     generate_formatted_log,
-    get_courserun_duration_in_days,
+    get_courserun_duration_in_hours,
     get_image_url,
     strip_html_tags,
 )
@@ -38,20 +38,20 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
     }
 
     def transform_duration_type(self, content_metadata_item):  # pylint: disable=unused-argument
-        return 'Days'
+        return 'Hours'
 
     def transform_duration(self, content_metadata_item):
         """
         Returns: duration in days
         """
         if content_metadata_item.get('content_type') == 'courserun':
-            return get_courserun_duration_in_days(content_metadata_item)
+            return get_courserun_duration_in_hours(content_metadata_item)
         elif content_metadata_item.get('content_type') == 'course':
             course_runs = content_metadata_item.get('course_runs')
             if course_runs:
                 course_run = get_closest_course_run(course_runs)
                 if course_run:
-                    return get_courserun_duration_in_days(course_run)
+                    return get_courserun_duration_in_hours(course_run)
                 else:
                     LOGGER.warning(
                         generate_formatted_log(

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -235,18 +235,17 @@ def get_duration_from_estimated_hours(estimated_hours):
     return None
 
 
-def get_courserun_duration_in_days(course_run):
+def get_courserun_duration_in_hours(course_run):
     """
-    Return the duration in number of days corresponding to a course run.
+    Return the approximate number of hours required to complete this course run.
     """
     min_effort = course_run.get('min_effort')
     max_effort = course_run.get('max_effort')
     weeks_to_complete = course_run.get('weeks_to_complete')
     if min_effort and max_effort and weeks_to_complete:
-        hours_per_day = 8.0
         average_hours_per_week = (min_effort + max_effort) / 2.0
-        total_days = (weeks_to_complete * average_hours_per_week) / hours_per_day
-        return math.ceil(total_days)
+        total_hours = (weeks_to_complete * average_hours_per_week)
+        return math.ceil(total_hours)
     else:
         return 0
 

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
@@ -166,7 +166,8 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "uuid": "3580463a-6f9c-48ed-ae8d-b5a012860d75",
             "advertised_course_run_uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
         }
-        assert exporter.transform_duration(content_metadata_item) == 4
+        assert exporter.transform_duration_type(content_metadata_item) == 'Hours'
+        assert exporter.transform_duration(content_metadata_item) == 30
 
     def test_transform_duration_course_run(self):
         exporter = Degreed2ContentMetadataExporter('fake-user', self.config)
@@ -180,7 +181,8 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "max_effort": 4,
             "weeks_to_complete": 10,
         }
-        assert exporter.transform_duration(content_metadata_item) == 4
+        assert exporter.transform_duration_type(content_metadata_item) == 'Hours'
+        assert exporter.transform_duration(content_metadata_item) == 30
 
     def test_transform_duration_with_invalid_dates(self):
         """

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -253,7 +253,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
                 'max_effort': 4,
                 'weeks_to_complete': 10
             },
-            4,
+            30,
         ),
         (
             {
@@ -262,7 +262,7 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
                 'max_effort': 8,
                 'weeks_to_complete': 3
             },
-            2,
+            14,
         ),
         (
             {
@@ -274,5 +274,5 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         ),
     )
     @ddt.unpack
-    def test_get_courserun_duration_in_days(self, course_run, expected_duration_days):
-        assert utils.get_courserun_duration_in_days(course_run) == expected_duration_days
+    def test_get_courserun_duration_in_hours(self, course_run, expected_duration_days):
+        assert utils.get_courserun_duration_in_hours(course_run) == expected_duration_days


### PR DESCRIPTION
## Description

- Send course duration information to Degreed in approximate hours.
- total_hours = average_hours_per_week * number_of_weeks

## References

- ENT-5797
- https://github.com/openedx/edx-enterprise/pull/1547

