### PR TITLE
fix: degreed2 improperly tracking completion status

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.46.5]
+--------
+fix: degreed2 improperly tracking completion status
+
 [3.46.4]
 --------
 fix: Degreed2 estimated time to complete in hours

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.46.4"
+__version__ = "3.46.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -24,6 +24,7 @@ class Degreed2LearnerExporter(LearnerExporter):
             self,
             enterprise_enrollment,
             completed_date=None,
+            course_completed=False,
             **kwargs
     ):  # pylint: disable=arguments-differ
         """
@@ -50,6 +51,7 @@ class Degreed2LearnerExporter(LearnerExporter):
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=get_course_id_for_enrollment(enterprise_enrollment),
                     completed_timestamp=completed_timestamp,
+                    course_completed=course_completed,
                     enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id,
                 ),
@@ -58,6 +60,7 @@ class Degreed2LearnerExporter(LearnerExporter):
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=enterprise_enrollment.course_id,
                     completed_timestamp=completed_timestamp,
+                    course_completed=course_completed,
                     enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id,
                 )


### PR DESCRIPTION
## Description

Degreed2 wasn't making use of passed-in completion status from `args` and was defaulting to true which made some learner audit records improperly included for sync. Since the record had no completion timestamp, validation was failing. Solution is to use the `course_completed` passed to the exporter.

## References

- [ENT-5803](https://2u-internal.atlassian.net/browse/ENT-5803)
- similar to https://github.com/edx/edx-enterprise/blob/master/integrated_channels/cornerstone/exporters/learner_data.py#L26
