### PR TITLE
fix: correctly handle multiple oauth configs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.46.6]
+--------
+fix: correctly handle multiple canvas and blackboard oauth configs
+
 [3.46.5]
 --------
 fix: degreed2 improperly tracking completion status

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.46.5"
+__version__ = "3.46.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/views.py
+++ b/integrated_channels/blackboard/views.py
@@ -128,11 +128,11 @@ class BlackboardCompleteOAuthView(generics.ListAPIView):
                 return self.render_page(request, 'error')
 
             try:
-                enterprise_config = BlackboardEnterpriseCustomerConfiguration.objects.get(
+                enterprise_config = BlackboardEnterpriseCustomerConfiguration.objects.filter(
                     enterprise_customer=enterprise_customer
-                )
+                ).first()
             except BlackboardEnterpriseCustomerConfiguration.DoesNotExist:
-                LOGGER.error(f"No Blackboard configuration found for state: {state_uuid}")
+                LOGGER.error(f"No state data found for given uuid: {state_uuid}")
                 return self.render_page(request, 'error')
 
         BlackboardGlobalConfiguration = apps.get_model(

--- a/integrated_channels/canvas/views.py
+++ b/integrated_channels/canvas/views.py
@@ -104,11 +104,11 @@ class CanvasCompleteOAuthView(generics.ListAPIView):
                 return self.render_page(request, 'error')
 
             try:
-                enterprise_config = CanvasEnterpriseCustomerConfiguration.objects.get(
+                enterprise_config = CanvasEnterpriseCustomerConfiguration.objects.filter(
                     enterprise_customer=enterprise_customer
-                )
+                ).first()
             except CanvasEnterpriseCustomerConfiguration.DoesNotExist:
-                LOGGER.error(f"No Canvas configuration found for state: {state_uuid}")
+                LOGGER.error(f"No state data found for given uuid: {state_uuid}")
                 return self.render_page(request, 'error')
 
         access_token_request_params = {

--- a/tests/test_integrated_channels/test_blackboard/test_views.py
+++ b/tests/test_integrated_channels/test_blackboard/test_views.py
@@ -23,11 +23,17 @@ from integrated_channels.blackboard.models import BlackboardEnterpriseCustomerCo
 ENTERPRISE_ID = str(uuid4())
 BAD_ENTERPRISE_ID = str(uuid4())
 SINGLE_CONFIG = {
+    'uuid': '123e4567-e89b-12d3-a456-426655440001',
     'client_id': 'id',
     'client_secret': 'secret',
     'base_url': 'http://betatest.blackboard.com',
 }
-
+SECOND_CONFIG = {
+    'uuid': '123e4567-e89b-12d3-a456-426655440002',
+    'client_id': 'id2',
+    'client_secret': 'secret2',
+    'base_url': 'http://betatest2.blackboard.com',
+}
 
 @pytest.mark.django_db
 class TestBlackboardAPIViews(APITestCase):
@@ -50,6 +56,7 @@ class TestBlackboardAPIViews(APITestCase):
         self.urlbase = reverse('blackboard-oauth-complete')
 
         BlackboardEnterpriseCustomerConfiguration.objects.get_or_create(
+            uuid=SINGLE_CONFIG['uuid'],
             client_id=SINGLE_CONFIG['client_id'],
             client_secret=SINGLE_CONFIG['client_secret'],
             blackboard_base_url=SINGLE_CONFIG['base_url'],
@@ -58,9 +65,51 @@ class TestBlackboardAPIViews(APITestCase):
             enterprise_customer_id=ENTERPRISE_ID,
         )
 
-    def test_successful_refresh_token_request(self):
+        BlackboardEnterpriseCustomerConfiguration.objects.get_or_create(
+            uuid=SECOND_CONFIG['uuid'],
+            client_id=SECOND_CONFIG['client_id'],
+            client_secret=SECOND_CONFIG['client_secret'],
+            blackboard_base_url=SECOND_CONFIG['base_url'],
+            enterprise_customer=self.enterprise_customer,
+            active=True,
+            enterprise_customer_id=ENTERPRISE_ID,
+        )
+
+    def test_successful_refresh_token_by_uuid_request(self):
         """
-        GET blackboard/oauth-complete?state=state?code=code
+        GET blackboard/oauth-complete?state=config_uuid?code=code
+        w/ 200 Response
+        """
+        query_kwargs = {
+            'state': SINGLE_CONFIG['uuid'],
+            'code': 'test-code'
+        }
+        oauth_complete_url = '{}?{}'.format(self.urlbase, urlencode(query_kwargs))
+
+        auth_token_url = urljoin(
+            SINGLE_CONFIG['base_url'],
+            self.app_config.oauth_token_auth_path
+        )
+
+        assert BlackboardEnterpriseCustomerConfiguration.objects.get(
+            uuid=SINGLE_CONFIG['uuid']
+        ).refresh_token == ''
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                auth_token_url,
+                json={'refresh_token': self.refresh_token, 'token_type': 'refresh_token', 'expires_in': '2020-02-01'},
+                status=200
+            )
+            response = self.client.get(oauth_complete_url)
+            assert response.status_code == 200
+            assert BlackboardEnterpriseCustomerConfiguration.objects.get(
+                uuid=SINGLE_CONFIG['uuid']
+            ).refresh_token == self.refresh_token
+
+    def test_successful_refresh_token_by_legacy_customer_uuid_request(self):
+        """
+        GET blackboard/oauth-complete?state=enterprise_customer_uuid?code=code
         w/ 200 Response
         """
         query_kwargs = {
@@ -74,9 +123,9 @@ class TestBlackboardAPIViews(APITestCase):
             self.app_config.oauth_token_auth_path
         )
 
-        assert BlackboardEnterpriseCustomerConfiguration.objects.get(
+        assert BlackboardEnterpriseCustomerConfiguration.objects.filter(
             enterprise_customer=self.enterprise_customer
-        ).refresh_token == ''
+        ).first().refresh_token == ''
         with responses.RequestsMock() as rsps:
             rsps.add(
                 responses.POST,
@@ -86,9 +135,9 @@ class TestBlackboardAPIViews(APITestCase):
             )
             response = self.client.get(oauth_complete_url)
             assert response.status_code == 200
-            assert BlackboardEnterpriseCustomerConfiguration.objects.get(
+            assert BlackboardEnterpriseCustomerConfiguration.objects.filter(
                 enterprise_customer=self.enterprise_customer
-            ).refresh_token == self.refresh_token
+            ).first().refresh_token == self.refresh_token
 
     def test_refresh_token_request_without_required_params(self):
         """
@@ -134,14 +183,11 @@ class TestBlackboardAPIViews(APITestCase):
         """
         GET blackboard/oauth-complete?state=state?code=code
         """
-        BlackboardEnterpriseCustomerConfiguration.objects.get(
-            enterprise_customer=self.enterprise_customer
-        ).delete()
         query_kwargs = {
-            'state': ENTERPRISE_ID,
+            'state': 'BADCODE',
             'code': 'test-code'
         }
         with LogCapture(level=logging.ERROR) as log_capture:
             oauth_complete_url = '{}?{}'.format(self.urlbase, urlencode(query_kwargs))
             self.client.get(oauth_complete_url)
-            assert 'No Blackboard configuration found for state' in log_capture.records[0].getMessage()
+            assert 'No state data found for given uuid' in log_capture.records[0].getMessage()

--- a/tests/test_integrated_channels/test_blackboard/test_views.py
+++ b/tests/test_integrated_channels/test_blackboard/test_views.py
@@ -35,6 +35,7 @@ SECOND_CONFIG = {
     'base_url': 'http://betatest2.blackboard.com',
 }
 
+
 @pytest.mark.django_db
 class TestBlackboardAPIViews(APITestCase):
     """

--- a/tests/test_integrated_channels/test_canvas/test_views.py
+++ b/tests/test_integrated_channels/test_canvas/test_views.py
@@ -35,6 +35,7 @@ SECOND_CANVAS_CONFIG = {
     'canvas_base_url': 'http://betatest2.instructure.com',
 }
 
+
 @pytest.mark.django_db
 class TestCanvasAPIViews(APITestCase):
     """

--- a/tests/test_integrated_channels/test_canvas/test_views.py
+++ b/tests/test_integrated_channels/test_canvas/test_views.py
@@ -21,12 +21,19 @@ from integrated_channels.canvas.models import CanvasEnterpriseCustomerConfigurat
 ENTERPRISE_ID = str(uuid4())
 BAD_ENTERPRISE_ID = str(uuid4())
 SINGLE_CANVAS_CONFIG = {
+    'uuid': '123e4567-e89b-12d3-a456-426655440001',
     'client_id': 'id',
     'client_secret': 'secret',
     'canvas_account_id': '10001',
     'canvas_base_url': 'http://betatest.instructure.com',
 }
-
+SECOND_CANVAS_CONFIG = {
+    'uuid': '123e4567-e89b-12d3-a456-426655440002',
+    'client_id': 'id2',
+    'client_secret': 'secret2',
+    'canvas_account_id': '20002',
+    'canvas_base_url': 'http://betatest2.instructure.com',
+}
 
 @pytest.mark.django_db
 class TestCanvasAPIViews(APITestCase):
@@ -49,6 +56,7 @@ class TestCanvasAPIViews(APITestCase):
         self.urlbase = reverse('canvas-oauth-complete')
 
         CanvasEnterpriseCustomerConfiguration.objects.get_or_create(
+            uuid=SINGLE_CANVAS_CONFIG['uuid'],
             client_id=SINGLE_CANVAS_CONFIG['client_id'],
             client_secret=SINGLE_CANVAS_CONFIG['client_secret'],
             canvas_account_id=SINGLE_CANVAS_CONFIG['canvas_account_id'],
@@ -58,9 +66,52 @@ class TestCanvasAPIViews(APITestCase):
             enterprise_customer_id=ENTERPRISE_ID,
         )
 
-    def test_successful_refresh_token_request(self):
+        CanvasEnterpriseCustomerConfiguration.objects.get_or_create(
+            uuid=SECOND_CANVAS_CONFIG['uuid'],
+            client_id=SECOND_CANVAS_CONFIG['client_id'],
+            client_secret=SECOND_CANVAS_CONFIG['client_secret'],
+            canvas_account_id=SECOND_CANVAS_CONFIG['canvas_account_id'],
+            canvas_base_url=SECOND_CANVAS_CONFIG['canvas_base_url'],
+            enterprise_customer=self.enterprise_customer,
+            active=True,
+            enterprise_customer_id=ENTERPRISE_ID,
+        )
+
+    def test_successful_refresh_token_by_uuid_request(self):
         """
-        GET canvas/oauth-complete?state=state?code=code
+        GET canvas/oauth-complete?state=config_uuid?code=code
+        w/ 200 Response
+        """
+        query_kwargs = {
+            'state': SINGLE_CANVAS_CONFIG['uuid'],
+            'code': 'test-code'
+        }
+        oauth_complete_url = '{}?{}'.format(self.urlbase, urlencode(query_kwargs))
+
+        auth_token_url = urljoin(
+            SINGLE_CANVAS_CONFIG['canvas_base_url'],
+            self.app_config.oauth_token_auth_path
+        )
+
+        assert CanvasEnterpriseCustomerConfiguration.objects.get(
+            uuid=SINGLE_CANVAS_CONFIG['uuid']
+        ).refresh_token == ''
+        with responses.RequestsMock() as rsps:
+            rsps.add(
+                responses.POST,
+                auth_token_url,
+                json={'refresh_token': self.refresh_token},
+                status=200
+            )
+            self.client.get(oauth_complete_url)
+
+        assert CanvasEnterpriseCustomerConfiguration.objects.get(
+            uuid=SINGLE_CANVAS_CONFIG['uuid']
+        ).refresh_token == self.refresh_token
+
+    def test_successful_refresh_token_by_legacy_customer_uuid_request(self):
+        """
+        GET canvas/oauth-complete?state=enterprise_customer_uuid?code=code
         w/ 200 Response
         """
         query_kwargs = {
@@ -74,9 +125,9 @@ class TestCanvasAPIViews(APITestCase):
             self.app_config.oauth_token_auth_path
         )
 
-        assert CanvasEnterpriseCustomerConfiguration.objects.get(
+        assert CanvasEnterpriseCustomerConfiguration.objects.filter(
             enterprise_customer=self.enterprise_customer
-        ).refresh_token == ''
+        ).first().refresh_token == ''
         with responses.RequestsMock() as rsps:
             rsps.add(
                 responses.POST,
@@ -86,9 +137,9 @@ class TestCanvasAPIViews(APITestCase):
             )
             self.client.get(oauth_complete_url)
 
-        assert CanvasEnterpriseCustomerConfiguration.objects.get(
+        assert CanvasEnterpriseCustomerConfiguration.objects.filter(
             enterprise_customer=self.enterprise_customer
-        ).refresh_token == self.refresh_token
+        ).first().refresh_token == self.refresh_token
 
     def test_refresh_token_request_without_required_params(self):
         """
@@ -134,15 +185,12 @@ class TestCanvasAPIViews(APITestCase):
         """
         GET canvas/oauth-complete?state=state?code=code
         """
-        CanvasEnterpriseCustomerConfiguration.objects.get(
-            enterprise_customer=self.enterprise_customer
-        ).delete()
         query_kwargs = {
-            'state': ENTERPRISE_ID,
+            'state': 'BADCODE',
             'code': 'test-code'
         }
         oauth_complete_url = '{}?{}'.format(self.urlbase, urlencode(query_kwargs))
         with LogCapture(level=logging.ERROR) as log_capture:
             oauth_complete_url = '{}?{}'.format(self.urlbase, urlencode(query_kwargs))
             self.client.get(oauth_complete_url)
-            assert 'No Canvas configuration found for state' in log_capture.records[0].getMessage()
+            assert 'No state data found for given uuid' in log_capture.records[0].getMessage()


### PR DESCRIPTION
## Description

- when using legacy enterprise_uuid urls in canvas and blackboard, handle gracefully by selecting the first available config
- expand testing to handle legacy case alongside the new config uuid case

## References

- [ENT-5610](https://2u-internal.atlassian.net/browse/ENT-5610)
