### PR TITLE
build: enable jshint and use Node 12 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,9 @@ jobs:
       with:
         python-version: '3.8'
         architecture: x64
+    - uses: actions/setup-node@v2
+      with:
+        node-version: 12
     - run: pip install -r requirements/ci.txt
     - name: Run tox
       env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,8 +32,7 @@ jobs:
       run: codecov
     - name: Run jshint
       if: matrix.toxenv=='django32-celery50'     # Only run this once as part of tests
-      continue-on-error: true
       run: |
-        npm i
+        npm ci
         make jshint
         

--- a/Makefile
+++ b/Makefile
@@ -132,14 +132,14 @@ upgrade: check_pins  ## update the requirements/*.txt files with the latest pack
 	rm requirements/test.txt.tmp
 
 requirements.js: ## install JS requirements for local development
-	npm install
+	npm ci
 
 requirements: requirements.js ## install development environment requirements
 	pip install -qr requirements/dev.txt --exists-action w
 	pip-sync requirements/test-master.txt requirements/dev.txt requirements/private.* requirements/test.txt
 
 jshint: ## run Javascript linting
-	@[ -x ./node_modules/jshint/bin/jshint ] || npm install jshint --save-dev
+	@[ -x ./node_modules/jshint/bin/jshint ] || npm install jshint --no-save
 	./node_modules/jshint/bin/jshint enterprise
 	./node_modules/jshint/bin/jshint spec
 


### PR DESCRIPTION
# Description

Temporarily run CI workflow using Node 12 to get jshint functional again. Making edx-enterprise compatible with Node 16 with be done as follow-up via https://2u-internal.atlassian.net/browse/ENT-5821

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
