### PR TITLE
feat: add lms_user_id to serialized admin users

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.49.5]
+--------
+feat: add lms_user_id to serialized admin users
+
 [3.49.4]
 --------
 feat: add dry-run mode to integrated channels

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.49.4"
+__version__ = "3.49.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -221,7 +221,8 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
 
         for role_assignment in admin_role_assignments:
             admin_users_by_enterprise_uuid[role_assignment.enterprise_customer_id].append({
-                'email': role_assignment.user.email
+                'email': role_assignment.user.email,
+                'lms_user_id': role_assignment.user.id,
             })
 
         return admin_users_by_enterprise_uuid

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -133,7 +133,8 @@ class TestEnterpriseCustomerSerializer(BaseSerializerTestWithEnterpriseRoleAssig
     def test_serialize_admin_users(self):
         serializer = EnterpriseCustomerSerializer(self.enterprise_customer_1)
         expected_admin_users = [{
-            'email': self.user_1.email
+            'email': self.user_1.email,
+            'lms_user_id': self.user_1.id,
         }]
         serialized_admin_users = serializer.data['admin_users']
         self.assertEqual(serialized_admin_users, expected_admin_users)
@@ -142,13 +143,16 @@ class TestEnterpriseCustomerSerializer(BaseSerializerTestWithEnterpriseRoleAssig
         serializer = EnterpriseCustomerSerializer([self.enterprise_customer_1, self.enterprise_customer_2], many=True)
 
         expected_enterprise_customer_1_admin_users = [{
-            'email': self.user_1.email
+            'email': self.user_1.email,
+            'lms_user_id': self.user_1.id,
         }]
 
         expected_enterprise_customer_2_admin_users = [{
-            'email': self.user_1.email
+            'email': self.user_1.email,
+            'lms_user_id': self.user_1.id,
         }, {
-            'email': self.user_3.email
+            'email': self.user_3.email,
+            'lms_user_id': self.user_3.id,
         }]
 
         enterprise_customer_1_admin_users = serializer.data[0]['admin_users']


### PR DESCRIPTION
- Add lms_user_id so that it can be used to identify admin user profiles in braze (we use admin users to determine admins to email right now). Could be useful for other things too.
- Upgrade pip-tools to 6.6.1 according to https://github.com/jazzband/pip-tools/issues/1617#issuecomment-1126245586

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
