### PR TITLE
fix: don't transmit schedule data to SAP if start or end date is empty

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.49.3]
+--------
+fix: don't transmit schedule data to SAP if start or end date is empty
+
 [3.49.2]
 --------
 feat: improved channel logging

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.49.2"
+__version__ = "3.49.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -145,6 +145,11 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         Return the schedule of the content item.
         """
         duration, start, end = get_duration_of_course_or_courserun(content_metadata_item)
+
+        # SAP will throw errors if we try to send an empty start or end date
+        if (not start or not end):
+            return []
+
         return [{
             'startDate': parse_datetime_to_epoch_millis(start) if start else '',
             'endDate': parse_datetime_to_epoch_millis(end) if end else '',

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -415,7 +415,7 @@ pillow==9.0.1
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-pip-tools==6.5.1
+pip-tools==6.6.1
     # via -r requirements/dev.in
 pkginfo==1.8.2
     # via twine

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -268,8 +268,23 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
             }]
         ),
         (
+            {
+                "content_type": "course",
+                "key": "CatalystX+IL-BSL.S1x",
+                "title": "Cómo Convertirse en un Líder Exitoso (Entrenamiento de Liderazgo Inclusivo)",
+                "course_runs": [
+                    {
+                        "key": "course-v1:CatalystX+IL-BSL.S1x+2T2017",
+                        "start": "2017-05-16T16:00:00Z",
+                        "end": "",
+                    }
+                ],
+            },
+            []
+        ),
+        (
             {},
-            [{'startDate': '', 'endDate': '', 'active': False, 'duration': '0 days'}]
+            []
         )
     )
     @ddt.unpack


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-5836

SAP throws errors if we include an empty start or end date in the schedule field.  This is an issue because having an empty end date is a perfectly valid state for a course run to be in.

The schedule field is optional [per SAP docs](https://help.sap.com/docs/SAP_SUCCESSFACTORS_LEARNING/9d4c9e0d04304afdbe8f1b4480d71403/2be70bfe31e64399be709de794f639ee.html) and we were not sending over anything for schedule prior to [this PR](https://github.com/openedx/edx-enterprise/pull/1480), so hopefully this should be fine.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
