### PR TITLE
fix: incorrect completed-at date

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.49.6]
+--------
+fix: incorrect learner completion completed-at dates
+
 [3.49.5]
 --------
 feat: add lms_user_id to serialized admin users

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.49.5"
+__version__ = "3.49.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -647,15 +647,35 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         if not certificate:
             return completed_date, grade, is_passing, percent_grade, passed_timestamp
 
-        completed_date = certificate.get('created_date')
+        # get_certificate_for_user has an optional formatting argument which defaults to True
+        # edx-platform/blob/6b9eb122dd5b018cfeffc120a70e503b2c159c0b/lms/djangoapps/certificates/api.py#L128
+        # when True, the certifiate's `created_date` is transformed into just `created`
+        completed_date = certificate.get('created', None)
+        # guard against the default formatting argument changing
+        if not completed_date:
+            completed_date = certificate.get('created_date', None)
         if completed_date:
             completed_date = parse_datetime(completed_date)
-        else:
-            completed_date = timezone.now()
 
         # also get passed_timestamp which is used to line up completion logic with analytics
         persistent_grade = get_persistent_grade(course_id, user)
         passed_timestamp = persistent_grade.passed_timestamp if persistent_grade is not None else None
+
+        if (not completed_date) and passed_timestamp:
+            LOGGER.info(generate_formatted_log(
+                channel_name, enterprise_customer_uuid, lms_user_id, course_id,
+                'get_course_certificate misisng created/created_date, '
+                'but there is a passed_timestamp so using that'
+            ))
+            completed_date = passed_timestamp
+        elif not completed_date and not passed_timestamp:
+            LOGGER.info(generate_formatted_log(
+                channel_name, enterprise_customer_uuid, lms_user_id, course_id,
+                'get_course_certificate misisng created/created_date, '
+                'no passed_timestamp so defaulting to timezone.now(), '
+                f'certificate={certificate}'
+            ))
+            completed_date = timezone.now()
 
         # For consistency with _collect_grades_data, we only care about Pass/Fail grades. This could change.
         is_passing = certificate.get('is_passing')

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -6,6 +6,7 @@ grade and completion data for enrollments belonging to a particular
 enterprise customer.
 """
 
+from datetime import datetime, timezone
 from logging import getLogger
 
 from opaque_keys import InvalidKeyError
@@ -667,7 +668,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 'get_course_certificate misisng created/created_date, '
                 'but there is a passed_timestamp so using that'
             ))
-            completed_date = passed_timestamp
+            completed_date = datetime.fromtimestamp((passed_timestamp / 1000), tz=timezone.utc)
         elif not completed_date and not passed_timestamp:
             LOGGER.info(generate_formatted_log(
                 channel_name, enterprise_customer_uuid, lms_user_id, course_id,

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -6,7 +6,7 @@ grade and completion data for enrollments belonging to a particular
 enterprise customer.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime
 from logging import getLogger
 
 from opaque_keys import InvalidKeyError

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -312,7 +312,7 @@ class TestLearnerExporter(unittest.TestCase):
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_completion_summary')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.is_course_completed')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
-    def test_learner_data_instructor_paced_with_certificate(
+    def test_learner_data_instructor_paced_with_certificate_created_date(
             self,
             mock_course_catalog_api,
             mock_is_course_completed,
@@ -334,12 +334,74 @@ class TestLearnerExporter(unittest.TestCase):
 
         mock_get_persistent_grade.return_value = None
 
-        # Return a mock certificate
+        # Return a mock certificate a created_date
         certificate = dict(
             username=self.user,
             course_id=self.course_id,
             certificate_type='professional',
             created_date=self.NOW.isoformat(),
+            status="downloadable",
+            is_passing=True,
+            grade='A-',
+        )
+        mock_get_course_certificate.return_value = certificate
+
+        # Return instructor-paced course details
+        mock_get_course_details.return_value = mock_course_overview(
+            pacing='instructor',
+        )
+
+        # Mock enrollment data
+        mock_enrollment_api.return_value.get_course_enrollment.return_value = dict(
+            mode="verified"
+        )
+
+        learner_data = list(self.exporter.export())
+        assert len(learner_data) == 2
+        assert learner_data[0].course_id == self.course_key
+        assert learner_data[1].course_id == self.course_id
+
+        for report in learner_data:
+            assert report.enterprise_course_enrollment_id == enrollment.id
+            assert report.course_completed
+            assert report.completed_timestamp == self.NOW_TIMESTAMP
+            assert report.grade == LearnerExporter.GRADE_PASSING
+
+    @mock.patch('enterprise.models.EnrollmentApiClient')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_persistent_grade')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_completion_summary')
+    @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.is_course_completed')
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    def test_learner_data_instructor_paced_with_certificate_created(
+            self,
+            mock_course_catalog_api,
+            mock_is_course_completed,
+            mock_get_completion_summary,
+            mock_get_course_certificate,
+            mock_get_persistent_grade,
+            mock_get_course_details,
+            mock_enrollment_api
+    ):
+        mock_course_catalog_api.return_value.get_course_id.return_value = self.course_key
+
+        enrollment = factories.EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            course_id=self.course_id,
+        )
+
+        mock_get_completion_summary.return_value = {'complete_count': 1, 'incomplete_count': 0, 'locked_count': 0}
+        mock_is_course_completed.return_value = True
+
+        mock_get_persistent_grade.return_value = None
+
+        # Return a mock certificate with a created field (formatted)
+        certificate = dict(
+            username=self.user,
+            course_id=self.course_id,
+            certificate_type='professional',
+            created=self.NOW.isoformat(),
             status="downloadable",
             is_passing=True,
             grade='A-',


### PR DESCRIPTION
## Description

- when working on a customer issue we discovered incorrect completed-at dates in learner completion records
- they had all defaulted to `time.now()` despite certificate and passing timestamps being available
- discovered a formatting method which is on by default that changes a field name from `created_date` to `created`
- expanded the logic to check multiple sources for a correct or approximately correct completed date before defaulting to `time.now()`
- better logging

## References

- [ENT-5895](https://2u-internal.atlassian.net/browse/ENT-5895)
