### PR TITLE
fix: str to head off TypeError on date parse

### DIFF
--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -656,7 +656,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         if not completed_date:
             completed_date = certificate.get('created_date', None)
         if completed_date:
-            completed_date = parse_datetime(completed_date)
+            completed_date = parse_datetime(str(completed_date))
 
         # also get passed_timestamp which is used to line up completion logic with analytics
         persistent_grade = get_persistent_grade(course_id, user)


### PR DESCRIPTION
## Description

- follow-on to https://github.com/openedx/edx-enterprise/pull/1575
- saw error in prod:
```
2022-06-01 20:05:30,859 ERROR 1484 [celery.app.trace] [user None] [ip None] trace.py:265 - Task integrated_channels.integrated_channel.tasks.transmit_learner_data[08f4c8e5-60f3-49cd-9d61-6c27ff40e2fd] raised unexpected: TypeError('expected string or bytes-like object')
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 451, in trace_task
    R = retval = fun(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/application_celery.py", line 99, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/celery/app/trace.py", line 734, in __protected_call__
    return self.run(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/edx_django_utils/monitoring/internal/code_owner/utils.py", line 193, in new_function
    return wrapped_function(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/tasks.py", line 109, in transmit_learner_data
    integrated_channel.transmit_learner_data(api_user)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/models.py", line 204, in transmit_learner_data
    transmitter.transmit(exporter)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/sap_success_factors/transmitters/learner_data.py", line 42, in transmit
    super().transmit(payload, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/transmitters/learner_data.py", line 295, in transmit
    for learner_data in payload.export(**kwargs):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/exporters/learner_data.py", line 425, in export
    ) = self.get_grades_summary(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/exporters/learner_data.py", line 314, in get_grades_summary
    self.collect_certificate_data(enterprise_enrollment, channel_name)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/integrated_channels/integrated_channel/exporters/learner_data.py", line 659, in collect_certificate_data
    completed_date = parse_datetime(completed_date)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/dateparse.py", line 107, in parse_datetime
    match = datetime_re.match(value)
TypeError: expected string or bytes-like object
```