### PR TITLE
fix: append backslash to ecommerce url and change get to get_or_creat…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.49.10]
+---------
+fix: append backslash to ecommerce url and change `get` to `get_or_create` in `fulfill_pending_course_enrollments`
+
 [3.49.9]
 --------
 feat: add source query param in data sharing consent url

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.49.9"
+__version__ = "3.49.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api_client/ecommerce.py
+++ b/enterprise/api_client/ecommerce.py
@@ -93,7 +93,7 @@ class EcommerceApiClient:
         Since `student.CourseEnrollment` lives in LMS, we're just passing
         around dicts of the relevant information.
         """
-        api_url = urljoin(f"{self.API_BASE_URL}/", "manual_course_enrollment_order")
+        api_url = urljoin(f"{self.API_BASE_URL}/", "manual_course_enrollment_order/")
         try:
             response = self.client.post(api_url, json={"enrollments": enrollments})
             response.raise_for_status()

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1396,7 +1396,7 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
                     # alongside the enterprise enrollment.
                     if enrollment.license_uuid:
                         source = EnterpriseEnrollmentSource.get_source(EnterpriseEnrollmentSource.ENROLLMENT_URL)
-                        enterprise_course_enrollment = EnterpriseCourseEnrollment.objects.get(
+                        enterprise_course_enrollment, _ = EnterpriseCourseEnrollment.objects.get_or_create(
                             enterprise_customer_user=enterprise_customer_user,
                             course_id=enrollment.course_id,
                             defaults={


### PR DESCRIPTION
…e in fulfill_pending_course_enrollments

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
