### PR TITLE
feat: basic integrated channels task concurrency control

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.51.1]
+--------
+feat: basic integrated channels task concurrency control
+
 [3.51.0]
 --------
 feat: Added command for monthly impact report for enterprise administrators

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.51.0"
+__version__ = "3.51.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/constants.py
+++ b/integrated_channels/integrated_channel/constants.py
@@ -3,3 +3,4 @@ Constants used by the integrated channels
 """
 
 ISO_8601_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+TASK_LOCK_EXPIRY_SECONDS = 43200

--- a/integrated_channels/integrated_channel/constants.py
+++ b/integrated_channels/integrated_channel/constants.py
@@ -3,4 +3,4 @@ Constants used by the integrated channels
 """
 
 ISO_8601_DATE_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
-TASK_LOCK_EXPIRY_SECONDS = 43200
+TASK_LOCK_EXPIRY_SECONDS = 60 * 60 * 12

--- a/integrated_channels/integrated_channel/management/commands/transmit_content_metadata.py
+++ b/integrated_channels/integrated_channel/management/commands/transmit_content_metadata.py
@@ -50,4 +50,5 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         for channel in channels:
             channel_code = channel.channel_code()
             channel_pk = channel.pk
-            transmit_content_metadata.delay(username, channel_code, channel_pk)
+            # NOTE pass arguments as named kwargs for use in lock key
+            transmit_content_metadata.delay(username=username, channel_code=channel_code, channel_pk=channel_pk)

--- a/integrated_channels/integrated_channel/management/commands/transmit_learner_data.py
+++ b/integrated_channels/integrated_channel/management/commands/transmit_learner_data.py
@@ -53,4 +53,6 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
 
         # Transmit the learner data to each integrated channel
         for integrated_channel in self.get_integrated_channels(options):
-            transmit_learner_data.delay(api_username, integrated_channel.channel_code(), integrated_channel.pk)
+            # NOTE pass arguments as named kwargs for use in lock key
+            transmit_learner_data.delay(
+                username=api_username, channel_code=integrated_channel.channel_code(), channel_pk=integrated_channel.pk)

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -31,7 +31,7 @@ def locked(expiry_seconds, lock_name_kwargs):  # lint-amnesty, pylint: disable=m
         def wrapper(*args, **kwargs):  # lint-amnesty, pylint: disable=inconsistent-return-statements
             cache_key = f'{func.__name__}'
             for key in lock_name_kwargs:
-                cache_key = f'{cache_key}-{key}:{kwargs.get(key)}'
+                cache_key += f'-{key}:{kwargs.get(key)}'
             if cache.add(cache_key, "true", expiry_seconds):
                 exception = None
                 try:

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -3,15 +3,18 @@ Celery tasks for integrated channel management commands.
 """
 
 import time
+from functools import wraps
 
 from celery import shared_task
 from celery.utils.log import get_task_logger
 from edx_django_utils.monitoring import set_code_owner_attribute
 
 from django.contrib import auth
+from django.core.cache import cache
 from django.utils import timezone
 
 from enterprise.utils import get_enterprise_uuids_for_user_and_course
+from integrated_channels.integrated_channel.constants import TASK_LOCK_EXPIRY_SECONDS
 from integrated_channels.integrated_channel.management.commands import (
     INTEGRATED_CHANNEL_CHOICES,
     IntegratedChannelCommandUtils,
@@ -20,6 +23,34 @@ from integrated_channels.utils import generate_formatted_log
 
 LOGGER = get_task_logger(__name__)
 User = auth.get_user_model()
+
+
+def locked(expiry_seconds, lock_name_kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring
+    def task_decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):  # lint-amnesty, pylint: disable=inconsistent-return-statements
+            cache_key = f'{func.__name__}'
+            for key in lock_name_kwargs:
+                cache_key = f'{cache_key}-{key}:{kwargs.get(key)}'
+            if cache.add(cache_key, "true", expiry_seconds):
+                exception = None
+                try:
+                    LOGGER.info('Locking task in cache with key: %s for %s seconds', cache_key, expiry_seconds)
+                    return func(*args, **kwargs)
+                except Exception as error:  # lint-amnesty, pylint: disable=broad-except
+                    LOGGER.exception(error)
+                    exception = error
+                finally:
+                    LOGGER.info('Unlocking task in cache with key: %s', cache_key)
+                    cache.delete(cache_key)
+                    if exception:
+                        LOGGER.error(f'Re-raising exception from inside locked task: {type(exception).__name__}')
+                        raise exception
+            else:
+                LOGGER.info('Task with key %s already exists in cache', cache_key)
+                return None
+        return wrapper
+    return task_decorator
 
 
 def _log_batch_task_start(task_name, channel_code, job_user_id, integrated_channel_full_config, extra_message=''):
@@ -57,6 +88,7 @@ def _log_batch_task_finish(task_name, channel_code, job_user_id,
 
 @shared_task
 @set_code_owner_attribute
+@locked(expiry_seconds=TASK_LOCK_EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
 def transmit_content_metadata(username, channel_code, channel_pk):
     """
     Task to send content metadata to each linked integrated channel.
@@ -90,6 +122,7 @@ def transmit_content_metadata(username, channel_code, channel_pk):
 
 @shared_task
 @set_code_owner_attribute
+@locked(expiry_seconds=TASK_LOCK_EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
 def transmit_learner_data(username, channel_code, channel_pk):
     """
     Task to send learner data to a linked integrated channel.
@@ -278,6 +311,7 @@ def transmit_single_subsection_learner_data(username, course_run_id, subsection_
 
 @shared_task
 @set_code_owner_attribute
+@locked(expiry_seconds=TASK_LOCK_EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
 def transmit_subsection_learner_data(job_username, channel_code, channel_pk):
     """
     Task to send assessment level learner data to a linked integrated channel.

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -26,6 +26,9 @@ User = auth.get_user_model()
 
 
 def locked(expiry_seconds, lock_name_kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring
+    """
+    A decorator to wrap a method in a cache-based lock with a cache-key derrived from function name and selected kwargs 
+    """
     def task_decorator(func):
         @wraps(func)
         def wrapper(*args, **kwargs):  # lint-amnesty, pylint: disable=inconsistent-return-statements

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -25,9 +25,9 @@ LOGGER = get_task_logger(__name__)
 User = auth.get_user_model()
 
 
-def locked(expiry_seconds, lock_name_kwargs):  # lint-amnesty, pylint: disable=missing-function-docstring
+def locked(expiry_seconds, lock_name_kwargs):
     """
-    A decorator to wrap a method in a cache-based lock with a cache-key derrived from function name and selected kwargs 
+    A decorator to wrap a method in a cache-based lock with a cache-key derrived from function name and selected kwargs
     """
     def task_decorator(func):
         @wraps(func)

--- a/tests/test_integrated_channels/test_integrated_channel/test_tasks.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_tasks.py
@@ -1,0 +1,68 @@
+"""
+Test the Enterprise Integrated Channel tasks and related functions.
+"""
+
+import unittest
+from unittest.mock import Mock, patch
+
+import ddt
+import pytest
+
+from integrated_channels.integrated_channel.tasks import locked
+
+EXPIRY_SECONDS = 100
+A_MOCK = Mock()
+
+
+@locked(expiry_seconds=EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
+def a_locked_method(username, channel_code, channel_pk):  # lint-amnesty, pylint: disable=unused-argument
+    A_MOCK.subtask()
+
+
+@locked(expiry_seconds=EXPIRY_SECONDS, lock_name_kwargs=['channel_code', 'channel_pk'])
+def a_locked_method_exception(username, channel_code, channel_pk):
+    raise Exception('a_locked_method_exception raised an Exception')
+
+
+@ddt.ddt
+class LockedTest(unittest.TestCase):
+    """Test class to verify locking of mocked resources"""
+
+    def setUp(self):
+        super().setUp()
+        A_MOCK.reset_mock()
+
+    @patch('integrated_channels.integrated_channel.tasks.cache.delete')
+    @patch('integrated_channels.integrated_channel.tasks.cache.add')
+    @ddt.data(True, False)
+    def test_locked_method(self, lock_available, add_mock, delete_mock):
+        """
+        Test that a method gets executed or not based on if a lock can be acquired
+        """
+        add_mock.return_value = lock_available
+        username = 'edx_worker'
+        channel_code = 'DEGREED2'
+        channel_pk = 10
+        a_locked_method(username=username, channel_code=channel_code, channel_pk=channel_pk)
+        cache_key = f'a_locked_method-channel_code:{channel_code}-channel_pk:{channel_pk}'
+        self.assertEqual(lock_available, A_MOCK.subtask.called)
+        if lock_available:
+            add_mock.assert_called_once_with(cache_key, "true", EXPIRY_SECONDS)
+            delete_mock.assert_called_once()
+
+    @patch('integrated_channels.integrated_channel.tasks.cache.delete')
+    @patch('integrated_channels.integrated_channel.tasks.cache.add')
+    def test_locked_method_exception(self, add_mock, delete_mock):
+        """
+        Test that a lock is unlocked when an exception is raised and that the exception is re-raised
+        """
+        lock_available = True
+        add_mock.return_value = lock_available
+        username = 'edx_worker'
+        channel_code = 'DEGREED2'
+        channel_pk = 10
+        with pytest.raises(Exception):
+            a_locked_method_exception(username=username, channel_code=channel_code, channel_pk=channel_pk)
+        cache_key = f'a_locked_method_exception-channel_code:{channel_code}-channel_pk:{channel_pk}'
+        add_mock.assert_called_once_with(cache_key, "true", EXPIRY_SECONDS)
+        delete_mock.assert_called_once()

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -246,8 +246,8 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
         )
 
         expected_calls = [
-            mock.call('C-3PO', 'SAP', 1),
-            mock.call('C-3PO', 'DEGREED', 1)
+            mock.call(username='C-3PO', channel_code='SAP', channel_pk=1),
+            mock.call(username='C-3PO', channel_code='DEGREED', channel_pk=1)
         ]
 
         call_command('transmit_content_metadata', '--catalog_user', 'C-3PO')
@@ -279,8 +279,8 @@ class TestTransmitCourseMetadataManagementCommand(unittest.TestCase, EnterpriseM
         self.mock_enterprise_customer_catalogs(enterprise_catalog_uuid)
 
         expected_calls = [
-            mock.call('C-3PO', 'SAP', 1),
-            mock.call('C-3PO', 'DEGREED', 1),
+            mock.call(username='C-3PO', channel_code='SAP', channel_pk=1),
+            mock.call(username='C-3PO', channel_code='DEGREED', channel_pk=1),
         ]
 
         call_command('transmit_content_metadata', '--catalog_user', 'C-3PO')


### PR DESCRIPTION
## Description

Implement a simple tool to allow celery task concurrency control to help prevent integrated channel jobs from overrunning each other. Based on prior art linked in ticket. More abstract, generic library method perhaps in the future.

**Grooming Notes:** 

- scope of this ticket will be to provide a fix for the current issue in the integrated channels.  We will follow up with a future discovery ticket to see if we can abstract out to a more generic solution.
- “Fast” implementation: create a lock key string representing the unique instance of the job, try to set it in memcache with an expiration of the lock timeout length, subsequent runs can check for the existence of the key in memcache and bail out if it exists

## References

- [ENT-5957](https://2u-internal.atlassian.net/browse/ENT-5957)
- [ENT-5901](https://2u-internal.atlassian.net/browse/ENT-5901)
