### PR TITLE
feat: added nudge email for dormant enrolled enterprise learners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.53.0]
+--------
+feat: Added management command for weekly nudge to dormant enterprise learners
+
 [3.52.0]
 --------
 feat: add `enable_portal_learner_credit_management_screen` to `EnterpriseCustomer`

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.52.0"
+__version__ = "3.53.0"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/management/commands/nudge_dormant_enrolled_enterprise_learners.py
+++ b/enterprise/management/commands/nudge_dormant_enrolled_enterprise_learners.py
@@ -1,0 +1,192 @@
+"""
+Django management command to send nudge email to dormant enrolled enterprise learners.
+"""
+import logging
+
+import snowflake.connector
+
+from django.conf import settings
+from django.core.management import BaseCommand
+
+from enterprise import utils
+
+LOGGER = logging.getLogger(__name__)
+QUERY = '''
+    WITH first_video as (
+        -- fetch first unhidden video in a course.
+        SELECT
+            course_id,                        -- the course run key.
+            ROW_NUMBER() OVER
+            (PARTITION BY course_id
+             ORDER BY order_index) row_,      -- the order of the video in the course.
+            block_type,                       -- the type of block (should be "video" for all).
+            display_name,                     -- the name of the video.
+            lms_web_url                       -- the link to the area in the course where the video is.
+        FROM
+            core_sources.course_structure
+        WHERE
+            block_type = 'video'              -- filter videos only.
+        AND
+            is_visible_to_staff_only = False  -- filter hidden videos out.
+        QUALIFY
+            row_ = 1                          -- only get the first video for each course.
+    ),
+    not_started as (
+        SELECT
+            lms_user_id,
+            lms_courserun_key,
+            split_part(course_key,'+',1) as org_name,
+            course_title,
+            consent_created,
+            lms_enrollment_created,
+            lms_enrollment_mode,
+            block_count
+        FROM
+            enterprise.ent_base_enterprise_enrollment
+        WHERE
+            DATE(lms_enrollment_created) BETWEEN CURRENT_DATE - 13 AND CURRENT_DATE - 7
+        AND
+            COALESCE(block_count,0) = 0
+        AND
+            consent_granted = True
+    ),
+    course_data as (
+        SELECT
+            dcr.courserun_key,
+            dcr.start_datetime,
+            cmcr.min_effort,
+            cmcr.max_effort,
+            cmcr.enrollment_count,
+            CASE WHEN cmcr.pacing_type = 'self_paced' THEN 'Self Paced' ELSE 'Instructor Paced' END as pacing_type,
+            cmcr.weeks_to_complete,
+            'https://prod-discovery.edx-cdn.org/' || cmc.image as course_image
+        FROM
+            core.dim_courseruns as dcr
+        LEFT JOIN
+            discovery.course_metadata_courserun as cmcr
+        ON
+            dcr.courserun_key = cmcr.key
+        LEFT JOIN
+            discovery.course_metadata_course as cmc
+        ON
+            cmcr.course_id = cmc.id
+        WHERE
+            cmcr.draft = False
+        AND
+            cmc.draft = False
+    )
+    SELECT
+        not_started.lms_user_id as external_id,
+        not_started.org_name,
+        not_started.course_title,
+        course_data.enrollment_count,
+        course_data.min_effort,
+        course_data.max_effort,
+        course_data.weeks_to_complete,
+        course_data.pacing_type,
+        CASE WHEN pacing_type = 'Instructor Paced' THEN 'Led on a course schedule' ELSE 'Move at your speed' END as pacing_subtitle,
+        COALESCE(CASE WHEN first_video.display_name = 'Video' THEN 'First Video' ELSE first_video.display_name END,'First Video') as display_name,
+        course_data.course_image,
+        first_video.lms_web_url,
+        'https://courses.edx.org/courses/' || not_started.lms_courserun_key || '/discussion/forum/' as discussion_link,
+        'https://learning.edx.org/course/' || not_started.lms_courserun_key || '/home' as home_link
+    FROM
+        not_started
+    LEFT JOIN
+        first_video
+    ON
+        not_started.lms_courserun_key = first_video.course_id
+    LEFT JOIN
+        course_data
+    ON
+        not_started.lms_courserun_key = course_data.courserun_key
+    WHERE
+        -- start date is in the past.
+        course_data.start_datetime <= CURRENT_DATE
+    AND
+        -- there is a video.
+        lms_web_url IS NOT NULL
+    -- Note: this filters out so the learner only has one sample in the dataset. In a productized feature, this constraint would probably be removed,
+    -- and the learner would get an email when any of the enrollment hit this stage.
+    QUALIFY
+        ROW_NUMBER() OVER (PARTITION BY not_started.lms_user_id ORDER BY lms_enrollment_created DESC) = 1
+'''
+
+
+class Command(BaseCommand):
+    """
+    Django management command to send nudge email to dormant enrolled enterprise learners.
+
+    Example usage:
+    ./manage.py lms nudge_dormant_enrolled_enterprise_learners
+    ./manage.py lms nudge_dormant_enrolled_enterprise_learners --no-commit
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--no-commit',
+            action='store_true',
+            dest='no_commit',
+            default=False,
+            help='Dry Run, print log messages without committing anything.',
+        )
+
+    def get_query_results_from_snowflake(self):
+        """
+        Get query results from Snowflake and yield each row.
+        """
+        ctx = snowflake.connector.connect(
+            user=settings.SNOWFLAKE_SERVICE_USER,
+            password=settings.SNOWFLAKE_SERVICE_USER_PASSWORD,
+            account='edx.us-east-1',
+            database='prod'
+        )
+        cs = ctx.cursor()
+        try:
+            cs.execute(QUERY)
+            rows = cs.fetchall()
+            for row in rows:
+                yield row
+        finally:
+            cs.close()
+        ctx.close()
+
+    def emit_event(self, **kwargs):
+        """
+         Emit the Segment event which will be used by Braze to send the email
+        """
+        utils.track_event(kwargs['EXTERNAL_ID'], 'edx.bi.enterprise.user.dormant.nudge', kwargs)
+        LOGGER.info(
+            '[Dormant Nudge] Segment event fired for nudge email to dormant enrolled enterprise learners. '
+            'LMS User Id: {user_id}, Organization Name: {org_name}, Course Title: {course_title}'.format(
+                user_id=kwargs['EXTERNAL_ID'],
+                org_name=kwargs['ORG_NAME'],
+                course_title=kwargs['COURSE_TITLE']
+            )
+        )
+
+    def handle(self, *args, **options):
+        should_commit = not options['no_commit']
+
+        LOGGER.info('[Dormant Nudge]  Process started.')
+        for next_row in self.get_query_results_from_snowflake():
+            message_data = {
+                'EXTERNAL_ID': next_row[0],
+                'ORG_NAME': next_row[1],
+                'COURSE_TITLE': next_row[2],
+                'ENROLLMENT_COUNT': next_row[3],
+                'MIN_EFFORT': next_row[4],
+                'MAX_EFFORT': next_row[5],
+                'WEEKS_TO_COMPLETE': next_row[6],
+                'PACING_TYPE': next_row[7],
+                'PACING_SUBTITLE': next_row[8],
+                'DISPLAY_NAME': next_row[9],
+                'COURSE_IMAGE': next_row[10],
+                'LMS_WEB_URL': next_row[11],
+                'DISCUSSION_LINK': next_row[12],
+                'HOME_LINK': next_row[13]
+            }
+            if should_commit:
+                self.emit_event(**message_data)
+
+        LOGGER.info('[Dormant Nudge] Execution completed.')

--- a/tests/test_enterprise/management/test_nudge_dormant_enrolled_enterprise_learners.py
+++ b/tests/test_enterprise/management/test_nudge_dormant_enrolled_enterprise_learners.py
@@ -1,0 +1,65 @@
+"""
+Tests for the django management command `nudge_dormant_enrolled_enterprise_learners`.
+"""
+from unittest import mock
+
+from pytest import mark
+from testfixtures import LogCapture
+
+from django.core.management import call_command
+from django.test import TestCase
+
+LOGGER_NAME = 'enterprise.management.commands.nudge_dormant_enrolled_enterprise_learners'
+
+
+@mark.django_db
+class NudgeDormantEnrolledEnterpriseLearnersCommandTests(TestCase):
+    """
+    Test command `nudge_dormant_enrolled_enterprise_learners`.
+    """
+    command = 'nudge_dormant_enrolled_enterprise_learners'
+
+    @mock.patch('enterprise.management.commands.nudge_dormant_enrolled_enterprise_learners.utils.track_event')
+    @mock.patch('enterprise.management.commands.nudge_dormant_enrolled_enterprise_learners.Command.'
+                'get_query_results_from_snowflake')
+    def test_nudge_dormant_enrolled_enterprise_learners(
+            self,
+            mock_get_query_results,
+            mock_event_track,
+    ):
+        """
+        Test that nudge_dormant_enrolled_enterprise_learners event is sent
+        """
+        mock_get_query_results.return_value = [list(range(14)) for i in range(10)]
+        with LogCapture(LOGGER_NAME) as log:
+            call_command(self.command)
+            self.assertEqual(mock_event_track.call_count, 10)
+            self.assertIn(
+                '[Dormant Nudge] Segment event fired for nudge email to dormant enrolled enterprise learners. '
+                'LMS User Id: 0, Organization Name: 1, Course Title: 2',
+                log.records[-2].message
+            )
+        mock_event_track.reset_mock()
+        # test with --no-commit param
+        with LogCapture(LOGGER_NAME) as log:
+            call_command(self.command, '--no-commit')
+            self.assertEqual(mock_event_track.call_count, 0)
+            self.assertIn(
+                '[Dormant Nudge] Execution completed.',
+                log.records[-1].message
+            )
+
+    @mock.patch('enterprise.management.commands.nudge_dormant_enrolled_enterprise_learners.snowflake.connector')
+    @mock.patch('enterprise.management.commands.nudge_dormant_enrolled_enterprise_learners.utils.track_event')
+    def test_get_query_results_from_snowflake(self, mock_event_track, mock_connector):
+        """
+        Test get_query_results_from_snowflake works correctly
+        """
+        mock_connector.connect.return_value.cursor.return_value.fetchall.return_value = [range(14), range(14)]
+        with LogCapture(LOGGER_NAME) as log:
+            call_command(self.command)
+            self.assertEqual(mock_event_track.call_count, 2)
+            self.assertIn(
+                '[Dormant Nudge] Execution completed.',
+                log.records[-1].message
+            )


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
