### PR TITLE
feat: mark Cornerstone session token fields read-only in admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.53.3]
+--------
+feat: mark Cornerstone session token fields read-only in admin
+
 [3.53.2]
 --------
 feat: update data sharing consent request language

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.53.2"
+__version__ = "3.53.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -66,6 +66,8 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
 
     readonly_fields = (
         "enterprise_customer_name",
+        "session_token",
+        "session_token_modified",
     )
 
     raw_id_fields = (


### PR DESCRIPTION
## Description

- mark `session_token` read-only in Django Admin to avoid confusion and errors
- mark `session_token_modified` read-only in Django Admin to avoid confusion and errors

## References

- https://2u-internal.atlassian.net/browse/ENT-6059