### PR TITLE
fix: follow-on to cornerstone learner records foreign keys job

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.54.2]
+--------
+fix: follow-on to cornerstone learner records foreign keys job
+
 [3.54.1]
 --------
 fix: create cornerstone learner audit records with new foreign keys

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.54.1"
+__version__ = "3.54.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/management/commands/backfill_missing_csod_foreign_keys.py
+++ b/integrated_channels/integrated_channel/management/commands/backfill_missing_csod_foreign_keys.py
@@ -38,9 +38,11 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         configs = CornerstoneEnterpriseCustomerConfiguration.objects.filter(
             cornerstone_base_url__icontains=subdomain_formatted_as_url_prefix,
         )
-        if len(configs) != 1:
-            raise Exception(f'{len(configs)} found for {customer_subdomain} when expecting just 1')
-        return configs.first()
+        if len(configs) > 1:
+            LOGGER.error(f'multiple ({len(configs)}) configs found for "{customer_subdomain}" when expecting just 1')
+            return None
+        else:
+            return configs.first()
 
     def batch_by_pk(self, ModelClass, extra_filter=Q(), batch_size=10000):
         """
@@ -69,7 +71,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
                 for audit_record in audit_record_batch:
                     config = self.find_csod_config_by_subdomain(audit_record.subdomain)
                     if config is None:
-                        LOGGER.error(f'cannot find CSOD config for subdomain {audit_record.subdomain}')
+                        LOGGER.error(f'cannot find CSOD config for subdomain "{audit_record.subdomain}"')
                         continue
                     ent_cust_uuid = config.enterprise_customer.uuid
                     LOGGER.info(f'CornerstoneLearnerDataTransmissionAudit <{audit_record.pk}> '

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1736,29 +1736,29 @@ class TestBackfillCSODJoinKeysManagementCommand(unittest.TestCase, EnterpriseMoc
 
     def test_not_found(self):
         """
-        Verify that the management command errors out when evaluating a subdomain with no config having a
+        Verify that the management command does not adjust records when evaluating a subdomain with no config having a
         corresponding base url
         """
         factories.CornerstoneLearnerDataTransmissionAuditFactory(subdomain='should-not-exist')
-        with raises(Exception):
-            call_command(
-                'backfill_missing_csod_foreign_keys',
-            )
+        call_command(
+            'backfill_missing_csod_foreign_keys',
+        )
+        assert 1 == CornerstoneLearnerDataTransmissionAudit.objects.filter(plugin_configuration_id__isnull=True).count()
 
     def test_duplicate_config_found(self):
         """
-        Verify that the management command errors out when evaluating a subdomain with multiple configs having a
-        corresponding base url
+        Verify that the management command does not adjust records when evaluating a subdomain with multiple configs 
+        having a corresponding base url
         """
         # a CSOD config with duplicate domain
         factories.CornerstoneEnterpriseCustomerConfigurationFactory(
             cornerstone_base_url=self.cornerstone_base_url_one
         )
         factories.CornerstoneLearnerDataTransmissionAuditFactory(subdomain='edx')
-        with raises(Exception):
-            call_command(
-                'backfill_missing_csod_foreign_keys',
-            )
+        call_command(
+            'backfill_missing_csod_foreign_keys',
+        )
+        assert 1 == CornerstoneLearnerDataTransmissionAudit.objects.filter(plugin_configuration_id__isnull=True).count()
 
     def test_all_one_config(self):
         """

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1747,7 +1747,7 @@ class TestBackfillCSODJoinKeysManagementCommand(unittest.TestCase, EnterpriseMoc
 
     def test_duplicate_config_found(self):
         """
-        Verify that the management command does not adjust records when evaluating a subdomain with multiple configs 
+        Verify that the management command does not adjust records when evaluating a subdomain with multiple configs
         having a corresponding base url
         """
         # a CSOD config with duplicate domain


### PR DESCRIPTION
## Description

Follow-on to #1603

Noticed old learner data records which have subdomains no longer in use. These we can leave in place orphaned. This PR makes the migration job continue gracefully, skipping those records. Tests have been adjusted to reflect this change.
