### PR TITLE
fix: overlapping content across catalogs constantly causing recreates

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.55.2]
+--------
+fix: integrated channels properly handling customers with multiple catalogs that have overlapping content.
+
 [3.55.1]
 --------
 fix: properly removing update transmission payloads from SAP transmissions before saving completed records.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.55.1"
+__version__ = "3.55.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -12,6 +12,90 @@ from test_utils import FAKE_UUIDS
 
 FAKE_URL = 'https://fake.url'
 
+FAKE_COURSE_RUN_TO_CREATE = {
+    'key': 'some-courserun-key=-that-doesnt-exist',
+    'uuid': '785b11f5-fad5-4ce1-9233-e1a3ed31aadb',
+    'title': 'edX Demonstration Course',
+    'image': {
+        'description': None,
+        'height': None,
+        'src': 'http://edx.devstack.lms:18000/asset-v1:edX+DemoX+Demo_Course+type@asset+block@images_course_image.jpg',
+        'width': None
+    },
+    'short_description': 'This course demonstrates many features of the edX platform.',
+    'marketing_url': 'course/demo-course?utm_=test_enterprise&utm_medium=enterprise',
+    'seats': [
+        {
+            'type': 'audit',
+            'price': '0.00',
+            'currency': 'USD',
+            'upgrade_deadline': None,
+            'credit_provider': None,
+            'credit_hours': None,
+            'sku': '68EFFFF'
+        },
+        {
+            'type': 'verified',
+            'price': '149.00',
+            'currency': 'USD',
+            'upgrade_deadline': '2018-08-03T16:44:26.595896Z',
+            'credit_provider': None,
+            'credit_hours': None,
+            'sku': '8CF08E5'
+        }
+    ],
+    'start': '2013-02-05T05:00:00Z',
+    'end': '3000-12-31T18:00:00Z',
+    'enrollment_start': None,
+    'enrollment_end': None,
+    'enrollment_url': FAKE_URL,
+    'pacing_type': 'instructor_paced',
+    'type': 'verified',
+    'status': 'published',
+    'course': 'edX+DemoX',
+    'full_description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'announcement': None,
+    'video': None,
+    'content_language': 'English',
+    'transcript_languages': [],
+    'instructors': [],
+    'staff': [
+        {
+            'uuid': '51df1077-1b8d-4f86-8305-8adbc82b72e9',
+            'given_name': 'Anant',
+            'family_name': 'Agarwal',
+            'bio': "Lorem ipsum dolor sit amet, consectetur adipiscing elit.",
+            'profile_image_url': 'https://www.edx.org/sites/default/files/executive/photo/anant-agarwal.jpg',
+            'slug': 'anant-agarwal',
+            'position': {
+                'title': 'CEO',
+                'organization_name': 'edX'
+            },
+            'profile_image': {},
+            'works': [],
+            'urls': {
+                'twitter': None,
+                'facebook': None,
+                'blog': None
+            },
+            'email': None
+        }
+    ],
+    'min_effort': 5,
+    'max_effort': 6,
+    'weeks_to_complete': 10,
+    'modified': '2017-08-18T00:32:33.754662Z',
+    'level_type': 'Type 1',
+    'availability': 'Current',
+    'mobile_available': False,
+    'hidden': False,
+    'reporting_type': 'mooc',
+    'eligible_for_financial_aid': True,
+    'content_type': 'courserun',
+    'has_enrollable_seats': True,
+    'content_last_modified': '2020-08-18T00:32:33.754662Z'
+}
+
 FAKE_COURSE_RUN = {
     'key': 'course-v1:edX+DemoX+Demo_Course',
     'uuid': '785b11f5-fad5-4ce1-9233-e1a3ed31aadb',
@@ -100,6 +184,82 @@ FAKE_COURSE_RUN2['key'] = 'course-v1:edX+DemoX+Demo_Course2'
 
 FAKE_INVALID_KEY_COURSE_RUN = copy.deepcopy(FAKE_COURSE_RUN)
 FAKE_INVALID_KEY_COURSE_RUN['key'] = 'course-v1:edX+Thisissuperlong+weneedthistobethelongestitseverbeen<.>'
+
+FAKE_COURSE_TO_CREATE_2 = {
+    'key': 'another-course-key-that-doesnt-exist',
+    'uuid': 'a9e8bb52-0c8d-4579-8496-1a8becb0a79c',
+    'title': 'edX Demonstration Course',
+    'course_runs': [FAKE_COURSE_RUN],
+    'owners': [
+        {
+            'uuid': '2bd367cf-c58e-400c-ac99-fb175405f7fa',
+            'key': 'edX',
+            'name': 'edX',
+            'certificate_logo_image_url': None,
+            'description': '',
+            'homepage_url': None,
+            'tags': [],
+            'logo_image_url': 'https://foo.com/bar.png',
+            'marketing_url': None
+        }
+    ],
+    'image': None,
+    'short_description': 'This course demonstrates many features of the edX platform.',
+    'full_description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'level_type': None,
+    'subjects': [],
+    'prerequisites': [],
+    'expected_learning_items': [
+        'XBlocks',
+        'Peer Assessment'
+    ],
+    'video': None,
+    'sponsors': [],
+    'modified': '2017-08-18T00:23:21.111991Z',
+    'marketing_url': None,
+    'content_type': 'course',
+    'enrollment_url': FAKE_URL,
+    'programs': [],
+    'content_last_modified': '2020-08-18T00:32:33.754662Z'
+}
+
+FAKE_COURSE_TO_CREATE = {
+    'key': 'some-course-key',
+    'uuid': 'a9e8bb52-0c8d-4579-8496-1a8becb0a79c',
+    'title': 'edX Demonstration Course',
+    'course_runs': [FAKE_COURSE_RUN],
+    'owners': [
+        {
+            'uuid': '2bd367cf-c58e-400c-ac99-fb175405f7fa',
+            'key': 'edX',
+            'name': 'edX',
+            'certificate_logo_image_url': None,
+            'description': '',
+            'homepage_url': None,
+            'tags': [],
+            'logo_image_url': 'https://foo.com/bar.png',
+            'marketing_url': None
+        }
+    ],
+    'image': None,
+    'short_description': 'This course demonstrates many features of the edX platform.',
+    'full_description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
+    'level_type': None,
+    'subjects': [],
+    'prerequisites': [],
+    'expected_learning_items': [
+        'XBlocks',
+        'Peer Assessment'
+    ],
+    'video': None,
+    'sponsors': [],
+    'modified': '2017-08-18T00:23:21.111991Z',
+    'marketing_url': None,
+    'content_type': 'course',
+    'enrollment_url': FAKE_URL,
+    'programs': [],
+    'content_last_modified': '2020-08-18T00:32:33.754662Z'
+}
 
 FAKE_COURSE = {
     'key': 'edX+DemoX',
@@ -983,6 +1143,49 @@ FAKE_SEARCH_ALL_SHORT_COURSE_RESULT_LIST = [
     },
 ]
 
+FAKE_SEARCH_ALL_PROGRAM_RESULT_1_TO_CREATE = {
+    "title": "some-program-key-that-doesnt-exist",
+    "marketing_url": "professional-certificate/marketingslug1",
+    "content_type": "program",
+    "card_image_url": "http://wowslider.com/sliders/demo-10/data/images/dock.jpg",
+    "min_hours_effort_per_week": 5,
+    "authoring_organization_uuids": [
+        "12de950c-6fae-49f7-aaa9-778c2fbdae56"
+    ],
+    "hidden": False,
+    "authoring_organizations": [
+        {
+            "marketing_url": None,
+            "homepage_url": None,
+            "tags": [],
+            "certificate_logo_image_url": None,
+            "name": "",
+            "key": "edX",
+            "description": None,
+            "uuid": "12de950c-6fae-49f7-aaa9-778c2fbdae56",
+            "logo_image_url": None
+        }
+    ],
+    "staff_uuids": [],
+    "published": True,
+    "uuid": FAKE_UUIDS[3],
+    "max_hours_effort_per_week": 10,
+    "subject_uuids": [],
+    "weeks_to_complete_min": None,
+    "type": "Professional Certificate",
+    "language": [
+        "English"
+    ],
+    "partner": "edx",
+    "subtitle": "Program Subtitle 1",
+    "status": "active",
+    "weeks_to_complete_max": None,
+    "aggregation_key": "program:" + FAKE_UUIDS[3],
+    'enrollment_url': FAKE_URL,
+    "is_program_eligible_for_one_click_purchase": True,
+    'content_last_modified': '2021-08-18T00:32:33.754662Z'
+}
+
 FAKE_SEARCH_ALL_PROGRAM_RESULT_1 = {
     "title": "Program Title 1",
     "marketing_url": "professional-certificate/marketingslug1",
@@ -1343,10 +1546,35 @@ def get_fake_catalog_diff_create_w_program():
     """
     # items_to_create, items_to_delete, matched_items
     return [
-        {'content_key': FAKE_COURSE_RUN['key']},
-        {'content_key': FAKE_COURSE['key']},
-        {'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}
+        {'content_key': FAKE_COURSE_RUN_TO_CREATE['key']},
+        {'content_key': FAKE_COURSE_TO_CREATE['key']},
+        {'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1_TO_CREATE['uuid']}
     ], [], []
+
+
+def get_fake_content_metadata_for_create_w_program():
+    """
+    Returns a fake response from the EnterpriseCatalogApiClient.get_catalog_diff where two courses and a program are to
+    be created
+    """
+    content_metadata = OrderedDict()
+    content_metadata[FAKE_COURSE_RUN_TO_CREATE['key']] = copy.deepcopy(FAKE_COURSE_RUN_TO_CREATE)
+    content_metadata[FAKE_COURSE_TO_CREATE['key']] = copy.deepcopy(FAKE_COURSE_TO_CREATE)
+    content_metadata[FAKE_SEARCH_ALL_PROGRAM_RESULT_1_TO_CREATE['uuid']] = copy.deepcopy(
+        FAKE_SEARCH_ALL_PROGRAM_RESULT_1_TO_CREATE
+    )
+    return list(content_metadata.values())
+
+
+def get_fake_content_metadata_for_partial_create_w_program():
+    """
+    Returns a fake response from the EnterpriseCatalogApiClient.get_catalog_diff where two courses and a program are to
+    be created
+    """
+    content_metadata = OrderedDict()
+    content_metadata[FAKE_COURSE_TO_CREATE['key']] = copy.deepcopy(FAKE_COURSE_TO_CREATE)
+    content_metadata[FAKE_COURSE_TO_CREATE_2['key']] = copy.deepcopy(FAKE_COURSE_TO_CREATE_2)
+    return list(content_metadata.values())
 
 
 def get_fake_catalog_diff_w_one_each():
@@ -1358,6 +1586,22 @@ def get_fake_catalog_diff_w_one_each():
     items_to_delete = [{'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}]
     matched_items = [{'content_key': FAKE_COURSE['key'], 'date_updated': datetime.datetime.now()}]
     return items_to_create, items_to_delete, matched_items
+
+
+def get_fake_catalog_diff_w_one_each_2():
+    """
+    Returns a fake response from the EnterpriseCatalogApiClient.get_catalog_diff where two courses and a program are
+    returned, one in each change-type bucket. The item to create is different from get_fake_catalog_diff_w_one_each to
+    trigger a create of a different course
+    """
+    return (
+        [{'content_key': FAKE_COURSE_TO_CREATE_2['key']}],
+        [{'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}],
+        [{
+            'content_key': FAKE_COURSE_TO_CREATE['key'],
+            'date_updated': datetime.datetime.now() - datetime.timedelta(seconds=3)
+        }]
+    )
 
 
 def get_fake_catalog_diff_create_with_invalid_key():


### PR DESCRIPTION
[related ticket](https://2u-internal.atlassian.net/browse/ENT-5849)

TLDR- we noticed that certain pieces of content were constantly being "created" (or attempted to be) for customers through the integrated channels. The common factor between all these customers and all this content was that the customers had multiple catalogs that shared the content.

**The problem:** 
The integrated channels (roughly) work as such-
- we iterate over each customer catalog
- we collect all transmission audits under each catalogs, one by one
   - specifically we filter the audit table by customer + catalog uuid
- we take the collected audits and send them to the ent catalog service and ask what work needs to be done
- we take the work that needs to be done and send it to the customer
- after successfully sending a piece of content to the customer, we save the record as a transmission audit
   - IF THERE EXISTS A RECORD OF THAT PIECE OF CONTENT FOR THE CUSTOMER UNDER A DIFFERENT CATALOG, we edit the record instead of creating a new one, swapping the catalog UUID to the new catalog. 

with this logic, on the second transmit content metadata run (and subsequently all future runs), the content will be missing under the list of sent content of one of the overlapping catalogs when we go to fetch all previous transmission audits. Thus when we ask the ent catalog service what works needs to be done, it will report that the content needs to be created. This is what creates the endless stream of "creating content X" for customers.

**The fix**
Unfortunately when collecting all audits, we can't look up content across catalogs. Due to how the catalog diff endpoint functions, we have to report content/ask for work to do catalog by catalog. Therefore the fix is to move down the line- when we get the list of work from the catalog diff endpoint, we have to check any requested creates to see if we have a record of that to-be-created content already existing on the customer's instance.   If it does already exist then we simply remove it from the list of things to do.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
