### PR TITLE
fix: properly selecting fields when searching for already created content items in exporter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.55.3]
+--------
+fix: accurately selecting content key values when filtering for existing content metadata transmission audits.
+
 [3.55.2]
 --------
 fix: integrated channels properly handling customers with multiple catalogs that have overlapping content.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.55.2"
+__version__ = "3.55.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -185,7 +185,7 @@ class ContentMetadataExporter(Exporter):
             integrated_channel_code=self.enterprise_configuration.channel_code(),
             plugin_configuration_id=self.enterprise_configuration.id,
             deleted_at__isnull=True,
-        ).only("content_id")
+        ).values_list("content_id", flat=True)
         unique_new_items_to_create = []
 
         # We need to remove any potential create transmissions if the content already exists on the customer's instance

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -15,6 +15,7 @@ from enterprise.utils import get_content_metadata_item_id
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.integrated_channel.models import ContentMetadataItemTransmission
 from test_utils import FAKE_UUIDS, factories
+from test_utils.factories import ContentMetadataItemTransmissionFactory
 from test_utils.fake_catalog_api import (
     FAKE_COURSE_RUN,
     get_fake_catalog,
@@ -71,6 +72,39 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         for key in create_payload:
             assert key in ['edX+DemoX', 'course-v1:edX+DemoX+Demo_Course', FAKE_UUIDS[3]]
             assert key in content_updated_mapping
+
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
+    def test_content_exporter_with_overlapping_content(self, mock_get_catalog_diff, mock_get_content_metadata):
+        """
+        Test that the content metadata exporter will check the diff request `create` payload for any already existing
+        transmission audits and exclude those from the create payload
+        """
+        content_1 = 'course-v1:edX+DemoX+Demo_Course'
+        content_2 = 'edX+DemoX'
+
+        # Double check that neither of these values exists as transmission audits yet
+        assert not ContentMetadataItemTransmission.objects.filter(content_id__in=[content_1, content_2])
+
+        # Create one
+        ContentMetadataItemTransmissionFactory(
+            content_id=content_1,
+            enterprise_customer=self.enterprise_customer_catalog.enterprise_customer,
+            integrated_channel_code=self.config.channel_code(),
+            plugin_configuration_id=self.config.id,
+        )
+
+        mock_get_content_metadata.return_value = get_fake_content_metadata()
+        # Mock that the catalog service reports we need to create both pieces of content
+        mock_get_catalog_diff.return_value = (
+            [{'content_key': content_1}, {'content_key': content_2}], [], []
+        )
+        exporter = ContentMetadataExporter('fake-user', self.config)
+        create_payload, update_payload, delete_payload, _ = exporter.export()
+        # Assert that the exporter detects the already existing content, and excludes it from the create payload
+        assert len(create_payload) == 1
+        assert len(update_payload) == 0
+        assert len(delete_payload) == 0
 
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-5849

Previous PR: https://github.com/openedx/edx-enterprise/pull/1612

Oops- `only` does not act like I expected it to. If you want to select specific fields in the Django ORM you need to use `values` or `values_list`. The param `flat` will flatten the results to just a list instead of a list of dictionaries that look like `[{'field_name': value}]`

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
