### PR TITLE
fix: properly handling API requests to canvas instances that have no root accounts

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.1]
+--------
+fix: accounting for integrated Canvas instances that have no root account Ids.
+
 [3.56.0]
 --------
 feat: refactor content metadata jobs to save api call status

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.0"
+__version__ = "3.56.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/canvas/utils.py
+++ b/integrated_channels/canvas/utils.py
@@ -156,20 +156,21 @@ class CanvasUtil:
         if not course:
             # now let's try the root account instead (searches under all subaccounts)
             root_canvas_account = CanvasUtil.find_root_canvas_account(enterprise_configuration, session)
-            course = CanvasUtil.find_course_in_account(
-                enterprise_configuration,
-                session,
-                root_canvas_account['id'],
-                edx_course_id,
-            )
-            if course:
-                LOGGER.info(generate_formatted_log(
-                    'canvas',
-                    enterprise_configuration.enterprise_customer.uuid,
-                    None,
+            if root_canvas_account:
+                course = CanvasUtil.find_course_in_account(
+                    enterprise_configuration,
+                    session,
+                    root_canvas_account['id'],
                     edx_course_id,
-                    'Found course under root Canvas account'
-                ))
+                )
+                if course:
+                    LOGGER.info(generate_formatted_log(
+                        'canvas',
+                        enterprise_configuration.enterprise_customer.uuid,
+                        None,
+                        edx_course_id,
+                        'Found course under root Canvas account'
+                    ))
         return course
 
     @staticmethod

--- a/tests/test_integrated_channels/test_canvas/test_utils.py
+++ b/tests/test_integrated_channels/test_canvas/test_utils.py
@@ -5,6 +5,7 @@ import copy
 import datetime
 import random
 import unittest
+from unittest import mock
 
 import pytest
 from requests.models import Response
@@ -105,6 +106,17 @@ class TestCanvasUtils(unittest.TestCase):
         course = CanvasUtil.find_course_in_account(
             self.enterprise_config, mock_session, canvas_account_id, edx_course_id)
         assert course == a_course_2
+
+    @mock.patch('integrated_channels.canvas.utils.CanvasUtil.find_course_in_account')
+    @mock.patch('integrated_channels.canvas.utils.CanvasUtil.find_root_canvas_account')
+    def test_find_no_root_account(self, mock_find_root_canvas_account, mock_find_course_in_account):
+        mock_find_course_in_account.return_value = None
+        mock_find_root_canvas_account.return_value = None
+        mock_session, _ = refresh_session_if_expired(self.get_oauth_access_token)
+        course = CanvasUtil.find_course_by_course_id(
+            self.enterprise_config, mock_session, 666
+        )
+        assert course is None
 
     def test_find_course_in_account_fail(self):
         success_response = unittest.mock.Mock(spec=Response)


### PR DESCRIPTION

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
