### PR TITLE
fix: refactor the way we send cornerstone content metadata deletes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.2]
+--------
+fix: refactor the way we send cornerstone content metadata deletes
+
 [3.56.1]
 --------
 fix: accounting for integrated Canvas instances that have no root account Ids.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.1"
+__version__ = "3.56.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -93,6 +93,9 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
         Return the transformed version of the course is_active status by traversing course runs and setting IsActive to
         True if any of the course runs have availability value set to `Current`, `Starting Soon` or `Upcoming`.
         """
+        # lets not overwrite something we've already tried to set INACTIVE
+        if content_metadata_item.get('IsActive') is not None and content_metadata_item.get('IsActive') == False:
+            return False
         is_active = False
         for course_run in content_metadata_item.get('course_runs', []):
             if course_run.get('availability') in ['Current', 'Starting Soon', 'Upcoming']:

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -93,9 +93,6 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
         Return the transformed version of the course is_active status by traversing course runs and setting IsActive to
         True if any of the course runs have availability value set to `Current`, `Starting Soon` or `Upcoming`.
         """
-        # lets not overwrite something we've already tried to set INACTIVE
-        if content_metadata_item.get('IsActive') is not None and content_metadata_item.get('IsActive') is False:
-            return False
         is_active = False
         for course_run in content_metadata_item.get('course_runs', []):
             if course_run.get('availability') in ['Current', 'Starting Soon', 'Upcoming']:

--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -94,7 +94,7 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
         True if any of the course runs have availability value set to `Current`, `Starting Soon` or `Upcoming`.
         """
         # lets not overwrite something we've already tried to set INACTIVE
-        if content_metadata_item.get('IsActive') is not None and content_metadata_item.get('IsActive') == False:
+        if content_metadata_item.get('IsActive') is not None and content_metadata_item.get('IsActive') is False:
             return False
         is_active = False
         for course_run in content_metadata_item.get('course_runs', []):

--- a/integrated_channels/cornerstone/transmitters/content_metadata.py
+++ b/integrated_channels/cornerstone/transmitters/content_metadata.py
@@ -16,13 +16,12 @@ class CornerstoneContentMetadataTransmitter(ContentMetadataTransmitter):
             client=client
         )
 
-def _transmit_action(self, content_metadata_item_map, client_method, action_name):
-    """
-    Set status to IsActive to False for items that should be deleted.
-    """
-    if action_name == 'delete':
-        for _, item in content_metadata_item_map.items():
-            LOGGER.info(f'_transmit_delete <{item.id}>')
-            item.channel_metadata['IsActive'] = False
-            item.save()
-    return super()._transmit_action(content_metadata_item_map, client_method, action_name)
+    def _transmit_action(self, content_metadata_item_map, client_method, action_name):
+        """
+        Set status to IsActive to False for items that should be deleted.
+        """
+        if action_name == 'delete':
+            for _, item in content_metadata_item_map.items():
+                item.channel_metadata['IsActive'] = False
+                item.save()
+        return super()._transmit_action(content_metadata_item_map, client_method, action_name)

--- a/integrated_channels/cornerstone/transmitters/content_metadata.py
+++ b/integrated_channels/cornerstone/transmitters/content_metadata.py
@@ -15,3 +15,14 @@ class CornerstoneContentMetadataTransmitter(ContentMetadataTransmitter):
             enterprise_configuration=enterprise_configuration,
             client=client
         )
+
+def _transmit_action(self, content_metadata_item_map, client_method, action_name):
+    """
+    Set status to IsActive to False for items that should be deleted.
+    """
+    if action_name == 'delete':
+        for _, item in content_metadata_item_map.items():
+            LOGGER.info(f'_transmit_delete <{item.id}>')
+            item.channel_metadata['IsActive'] = False
+            item.save()
+    return super()._transmit_action(content_metadata_item_map, client_method, action_name)

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -127,11 +127,11 @@ class CornerstoneCoursesListView(BaseViewSet):
 
         get_count = int(request.GET.get('count', exporter.MAX_PAYLOAD_COUNT))
         content_item_count = min(get_count, exporter.MAX_PAYLOAD_COUNT)
-        created, updated, _ = transmitter.transmit(
+        created, updated, deleted = transmitter.transmit(
             *exporter.export_for_web_polling(max_payload_count=content_item_count)
         )
 
-        data = [i.channel_metadata for i in (created + updated)]
+        data = [i.channel_metadata for i in (created + updated + deleted)]
 
         logger.info(f'integrated_channel=CSOD, '
                     f'integrated_channel_enterprise_customer_uuid={enterprise_customer_uuid}, '

--- a/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
+++ b/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
@@ -1,5 +1,5 @@
 """
-Backfill the new remote_created_at and remote_updated_at content audit record values.
+Mark for re-send all CSOD content transmission with a remote_deleted_at but no api_response_status_code
 """
 import logging
 

--- a/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
+++ b/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
@@ -9,7 +9,7 @@ from django.core.management.base import BaseCommand
 from django.db.models import Q
 
 from integrated_channels.integrated_channel.management.commands import IntegratedChannelCommandMixin
-from integrated_channels.utils import generate_formatted_log, batch_by_pk
+from integrated_channels.utils import batch_by_pk, generate_formatted_log
 
 User = auth.get_user_model()
 

--- a/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
+++ b/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
@@ -1,0 +1,63 @@
+"""
+Backfill the new remote_created_at and remote_updated_at content audit record values.
+"""
+import logging
+
+from django.apps import apps
+from django.contrib import auth
+from django.core.management.base import BaseCommand
+from django.db.models import Q
+
+from integrated_channels.integrated_channel.management.commands import IntegratedChannelCommandMixin
+from integrated_channels.utils import generate_formatted_log, batch_by_pk
+
+User = auth.get_user_model()
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(IntegratedChannelCommandMixin, BaseCommand):
+    """
+    Mark for re-send all CSOD content transmission with a remote_deleted_at but no api_response_status_code
+
+    ./manage.py lms reset_csod_remote_deleted_at
+    """
+
+    def handle(self, *args, **options):
+        """
+        Mark for re-send all CSOD content transmission with a remote_deleted_at but no api_response_status_code
+        """
+
+        ContentMetadataItemTransmission = apps.get_model(
+            'integrated_channel',
+            'ContentMetadataItemTransmission'
+        )
+
+        csod_deleted_at_but_null_status = Q(
+            integrated_channel_code='CSOD',
+            remote_deleted_at__isnull=False,
+            api_response_status_code__isnull=True
+        )
+
+        for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_deleted_at_but_null_status):
+            for item in items_batch:
+                try:
+                    item.remote_deleted_at = None
+                    item.save()
+                    LOGGER.info(generate_formatted_log(
+                        item.integrated_channel_code,
+                        item.enterprise_customer.uuid,
+                        None,
+                        item.content_id,
+                        f'integrated_channel_content_transmission_id={item.id}, '
+                        'setting remote_deleted_at to None'
+                    ))
+                except Exception:  # pylint: disable=broad-except
+                    LOGGER.exception(generate_formatted_log(
+                        item.integrated_channel_code,
+                        item.enterprise_customer.uuid,
+                        None,
+                        item.content_id,
+                        f'integrated_channel_content_transmission_id={item.id}, '
+                        'error setting remote_deleted_at to None'
+                    ))

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -56,6 +56,7 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         """
         Return the status of the content item.
         """
+        # lets not overwrite something we've already tried to set INACTIVE
         if content_metadata_item.get('status') == 'INACTIVE':
             return 'INACTIVE'
         else:

--- a/integrated_channels/sap_success_factors/transmitters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/transmitters/content_metadata.py
@@ -1,13 +1,8 @@
 """
 Class for transmitting content metadata to SuccessFactors.
 """
-
-import logging
-
 from integrated_channels.integrated_channel.transmitters.content_metadata import ContentMetadataTransmitter
 from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient
-
-LOGGER = logging.getLogger(__name__)
 
 
 class SapSuccessFactorsContentMetadataTransmitter(ContentMetadataTransmitter):
@@ -30,7 +25,6 @@ class SapSuccessFactorsContentMetadataTransmitter(ContentMetadataTransmitter):
         """
         if action_name == 'delete':
             for _, item in content_metadata_item_map.items():
-                LOGGER.info(f'_transmit_delete <{item.id}>')
                 item.channel_metadata['status'] = 'INACTIVE'
                 item.save()
         return super()._transmit_action(content_metadata_item_map, client_method, action_name)

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -15,6 +15,7 @@ from urllib.parse import urlparse
 import pytz
 import requests
 
+from django.db.models import Q
 from django.utils import timezone
 from django.utils.html import strip_tags
 
@@ -381,3 +382,26 @@ def is_valid_url(url):
         return all([result.scheme, result.netloc])
     except ValueError:
         return False
+
+
+def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000):
+    """
+    yield per batch efficiently
+    using limit/offset does a lot of table scanning to reach higher offsets
+    this scanning can be slow on very large tables
+    if you order by pk, you can use the pk as a pivot rather than offset
+    this utilizes the index, which is faster than scanning to reach offset
+    Example usage:
+    csod_only_filter = Q(integrated_channel_code='CSOD')
+    for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_only_filter):
+        for item in items_batch:
+            ...
+    """
+    qs = ModelClass.objects.filter(extra_filter).order_by('pk')[:batch_size]
+    while qs.exists():
+        yield qs
+        # qs.last() doesn't work here because we've already sliced
+        # loop through so we eventually grab the last one
+        for item in qs:
+            start_pk = item.pk
+        qs = ModelClass.objects.filter(pk__gt=start_pk).filter(extra_filter).order_by('pk')[:batch_size]

--- a/tests/test_integrated_channels/test_cornerstone/test_views.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_views.py
@@ -211,8 +211,8 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
         mock_get_content_metadata.return_value = get_fake_content_metadata_for_partial_create_w_program()
         response = self.client.get(url, HTTP_IF_MODIFIED_SINCE=if_modified_since)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # 1 create, 1 update, 1 delete, no deletes sent, no count restriction, so expect 2
-        self.assertEqual(len(response.data), 2)
+        # 1 create, 1 update, 1 delete, so expect 3
+        self.assertEqual(len(response.data), 3)
         url = '{path}?ciid={customer_uuid}&count={count}'.format(
             path=self.course_list_url,
             customer_uuid=self.enterprise_customer_catalog.enterprise_customer.uuid,
@@ -224,5 +224,5 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
         # Re-request and expect the create to be already created so the only item to be returned is the update item
         response = self.client.get(url, HTTP_IF_MODIFIED_SINCE=if_modified_since)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # 1 create, 1 update, 1 delete, no deletes sent, count set to 1, so expect 1
+        # 1 create, 1 update, 1 delete, count set to 1, so expect 1
         self.assertEqual(len(response.data), 1)


### PR DESCRIPTION
## Description

Previously we were not sending deleted content messages to Cornerstone when they pulled a course update. 

This PR:
- adds delete messages into to CSOD update view
- follows the SAP pattern to set an inactive field on delete transmission actions
- moved a useful snippet into a utility class, clean up old copy/paste usage
- cleans up some debug logging and adds comments

## References

- https://2u-internal.atlassian.net/browse/ENT-6081
- https://2u-internal.atlassian.net/browse/ENT-6121