### PR TITLE
fix: fix devstack seed data script role assignments.

### DIFF
--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -112,7 +112,7 @@ class Command(BaseCommand):
         """ Ensures the `ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP` is created """
         Group.objects.get_or_create(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
 
-    def _create_enterprise_user(self, username, role, enterprise_customer=None):
+    def _create_enterprise_user(self, username, role, enterprise_customer=None, applies_to_all_contexts=False):
         """
         Creates a new user with the specified `username` and `role` (e.g.,
         'enterprise_learner'). The newly created user is added to the
@@ -143,7 +143,9 @@ class Command(BaseCommand):
                 self._create_system_wide_role_assignment(
                     user=user,
                     role=role,
-                    enterprise_customer=enterprise_customer)
+                    enterprise_customer=enterprise_customer,
+                    applies_to_all_contexts=applies_to_all_contexts,
+                )
                 self._create_feature_role_assignments(user=user, role=role)
                 return {
                     "user": user,
@@ -172,7 +174,7 @@ class Command(BaseCommand):
         enrollment_api_group = Group.objects.get(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
         enrollment_api_group.user_set.add(user)
 
-    def _create_system_wide_role_assignment(self, user, role, enterprise_customer):
+    def _create_system_wide_role_assignment(self, user, role, enterprise_customer, applies_to_all_contexts=False):
         """
         Gets or creates a system-wide role assignment for the specified user and role
         """
@@ -180,6 +182,7 @@ class Command(BaseCommand):
         kwargs = {
             'user': user,
             'role': system_role,
+            'applies_to_all_contexts': applies_to_all_contexts,
         }
         if enterprise_customer is not None:
             kwargs['enterprise_customer'] = enterprise_customer
@@ -279,25 +282,29 @@ class Command(BaseCommand):
             # Creates a super admin who has the admin role on all enterprises.
             self._create_enterprise_user(
                 username=ENTERPRISE_ADMIN_ROLE,
-                role=ENTERPRISE_ADMIN_ROLE
+                role=ENTERPRISE_ADMIN_ROLE,
+                applies_to_all_contexts=True,
             ),
             self._create_enterprise_user(
                 username=ENTERPRISE_OPERATOR_ROLE,
-                role=ENTERPRISE_OPERATOR_ROLE
-
+                role=ENTERPRISE_OPERATOR_ROLE,
+                applies_to_all_contexts=True,
             ),
             # Make all of the service workers enterprise_openedx_operators for all enterprises
             self._create_enterprise_user(
                 username='license_manager_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
+                applies_to_all_contexts=True,
             ),
             self._create_enterprise_user(
                 username='enterprise_catalog_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
+                applies_to_all_contexts=True,
             ),
             self._create_enterprise_user(
                 username='enterprise_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
+                applies_to_all_contexts=True,
             ),
         ]
         # Add a couple more learners!


### PR DESCRIPTION
Fixes a role assignment exception we encountered when trying to seed a new devstack with enterprise data.
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
