### PR TITLE
fix: properly pass SAP client status back to content transmission records

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.5]
+--------
+fix: properly pass SAP client status back to content transmission records
+
 [3.56.4]
 --------
 fix: open redirect url whitelisting for data sharing conseent and change enterprise page

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.4"
+__version__ = "3.56.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -157,7 +157,8 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         if status_code >= 400:
             raise ClientError(
                 f'Degreed2: fetch request failed: attempted, external ID={external_id},'
-                f'received status_code={status_code}'
+                f'received status_code={status_code}',
+                status_code=status_code
             )
         response_json = json.loads(response_body)
         if response_json['data']:
@@ -188,9 +189,12 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                     f'Course with integration_id = {a_course.get("external-id")} already exists, '
                 )
             )
+            # content already exists, we'll treat this as a success
+            status_code = 200
         elif status_code >= 400:
             raise ClientError(
-                f'Degreed2APIClient create_content_metadata failed with status {status_code}: {response_body}'
+                f'Degreed2APIClient create_content_metadata failed with status {status_code}: {response_body}',
+                status_code=status_code
             )
         return status_code, response_body
 
@@ -220,12 +224,6 @@ class Degreed2APIClient(IntegratedChannelApiClient):
             patch_url,
             course_id
         )
-        if patch_status_code >= 400:
-            raise ClientError(
-                f'Degreed2: patch request failed: attempted, external ID={external_id},'
-                f'status_code={patch_status_code}'
-                f'response_body={patch_response_body}'
-            )
         return patch_status_code, patch_response_body
 
     def delete_content_metadata(self, serialized_data):
@@ -261,7 +259,8 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                 raise ClientError(
                     f'Degreed2: delete request failed: attempted, external ID={external_id},'
                     f'status_code={del_status_code}'
-                    f'response_body={del_response_body}'
+                    f'response_body={del_response_body}',
+                    status_code=del_status_code
                 )
         except requests.exceptions.RequestException as exc:
             raise ClientError(

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -157,7 +157,7 @@ class ContentMetadataTransmitter(Transmitter):
                     response_status_code = exc.response.status_code
                     response_body = exc.response.text
                 else:
-                    response_status_code = UNKNOWN_ERROR_HTTP_STATUS_CODE
+                    response_status_code = self.UNKNOWN_ERROR_HTTP_STATUS_CODE
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
                     f"[{self.enterprise_configuration.enterprise_customer.name}] "
@@ -166,7 +166,7 @@ class ContentMetadataTransmitter(Transmitter):
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 LOGGER.exception(exc)
-                response_status_code = UNKNOWN_ERROR_HTTP_STATUS_CODE
+                response_status_code = self.UNKNOWN_ERROR_HTTP_STATUS_CODE
                 response_body = exc.message
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -7,6 +7,7 @@ import json
 import logging
 from datetime import datetime
 from itertools import islice
+
 import requests
 
 from django.conf import settings

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -24,6 +24,10 @@ class ContentMetadataTransmitter(Transmitter):
     Used to transmit content metadata to an integrated channel.
     """
 
+    # a 'magic number' to designate an unknown error
+    UNKNOWN_ERROR_HTTP_STATUS_CODE = 555
+
+
     def __init__(self, enterprise_configuration, client=IntegratedChannelApiClient):
         """
         By default, use the abstract integrated channel API client which raises an error when used if not subclassed.
@@ -153,7 +157,7 @@ class ContentMetadataTransmitter(Transmitter):
                     response_status_code = exc.response.status_code
                     response_body = exc.response.text
                 else:
-                    response_status_code = 555
+                    response_status_code = UNKNOWN_ERROR_HTTP_STATUS_CODE
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
                     f"[{self.enterprise_configuration.enterprise_customer.name}] "
@@ -162,7 +166,7 @@ class ContentMetadataTransmitter(Transmitter):
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 LOGGER.exception(exc)
-                response_status_code = 555
+                response_status_code = UNKNOWN_ERROR_HTTP_STATUS_CODE
                 response_body = exc.message
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -27,7 +27,6 @@ class ContentMetadataTransmitter(Transmitter):
     # a 'magic number' to designate an unknown error
     UNKNOWN_ERROR_HTTP_STATUS_CODE = 555
 
-
     def __init__(self, enterprise_configuration, client=IntegratedChannelApiClient):
         """
         By default, use the abstract integrated channel API client which raises an error when used if not subclassed.

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -7,6 +7,7 @@ import json
 import logging
 from datetime import datetime
 from itertools import islice
+import requests
 
 from django.conf import settings
 
@@ -137,15 +138,38 @@ class ContentMetadataTransmitter(Transmitter):
             try:
                 response_status_code, response_body = client_method(serialized_chunk)
             except ClientError as exc:
+                LOGGER.exception(exc)
+                response_status_code = exc.status_code
+                response_body = exc.message
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
                     f"[{self.enterprise_configuration.enterprise_customer.name}] "
                     f"[{self.enterprise_configuration.channel_code()}]. "
-                    f"Task failed with message [{exc.message}] and status code [{exc.status_code}]"
+                    f"Task failed with message [{exc.message}] and status code [{response_status_code}]"
                 )
+            except requests.exceptions.RequestException as exc:
                 LOGGER.exception(exc)
-                response_status_code = exc.status_code
+                if exc.response:
+                    response_status_code = exc.response.status_code
+                    response_body = exc.response.text
+                else:
+                    response_status_code = 555
+                self._log_error(
+                    f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
+                    f"[{self.enterprise_configuration.enterprise_customer.name}] "
+                    f"[{self.enterprise_configuration.channel_code()}]. "
+                    f"Task failed with message [{exc.message}] and status code [{response_status_code}]"
+                )
+            except Exception as exc:  # pylint: disable=broad-except
+                LOGGER.exception(exc)
+                response_status_code = 555
                 response_body = exc.message
+                self._log_error(
+                    f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
+                    f"[{self.enterprise_configuration.enterprise_customer.name}] "
+                    f"[{self.enterprise_configuration.channel_code()}]. "
+                    f"Task failed with message [{exc.message}]"
+                )
             finally:
                 action_happened_at = datetime.utcnow()
                 for content_id, transmission in chunk.items():

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -144,12 +144,12 @@ class ContentMetadataTransmitter(Transmitter):
             except ClientError as exc:
                 LOGGER.exception(exc)
                 response_status_code = exc.status_code
-                response_body = exc.message
+                response_body = str(exc)
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
                     f"[{self.enterprise_configuration.enterprise_customer.name}] "
                     f"[{self.enterprise_configuration.channel_code()}]. "
-                    f"Task failed with message [{exc.message}] and status code [{response_status_code}]"
+                    f"Task failed with message [{response_body}] and status code [{response_status_code}]"
                 )
             except requests.exceptions.RequestException as exc:
                 LOGGER.exception(exc)
@@ -158,21 +158,22 @@ class ContentMetadataTransmitter(Transmitter):
                     response_body = exc.response.text
                 else:
                     response_status_code = self.UNKNOWN_ERROR_HTTP_STATUS_CODE
+                    response_body = str(exc)
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
                     f"[{self.enterprise_configuration.enterprise_customer.name}] "
                     f"[{self.enterprise_configuration.channel_code()}]. "
-                    f"Task failed with message [{exc.message}] and status code [{response_status_code}]"
+                    f"Task failed with message [{str(exc)}] and status code [{response_status_code}]"
                 )
             except Exception as exc:  # pylint: disable=broad-except
                 LOGGER.exception(exc)
                 response_status_code = self.UNKNOWN_ERROR_HTTP_STATUS_CODE
-                response_body = exc.message
+                response_body = str(exc)
                 self._log_error(
                     f"Failed to {action_name} [{len(chunk)}] content metadata items for integrated channel "
                     f"[{self.enterprise_configuration.enterprise_customer.name}] "
                     f"[{self.enterprise_configuration.channel_code()}]. "
-                    f"Task failed with message [{exc.message}]"
+                    f"Task failed with message [{response_body}]"
                 )
             finally:
                 action_happened_at = datetime.utcnow()

--- a/integrated_channels/sap_success_factors/client.py
+++ b/integrated_channels/sap_success_factors/client.py
@@ -179,7 +179,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
         Raises:
             ClientError: If SuccessFactors API call fails.
         """
-        self._sync_content_metadata(serialized_data)
+        return self._sync_content_metadata(serialized_data)
 
     def update_content_metadata(self, serialized_data):
         """
@@ -191,7 +191,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
         Raises:
             ClientError: If SuccessFactors API call fails.
         """
-        self._sync_content_metadata(serialized_data)
+        return self._sync_content_metadata(serialized_data)
 
     def delete_content_metadata(self, serialized_data):
         """
@@ -203,7 +203,7 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
         Raises:
             ClientError: If SuccessFactors API call fails.
         """
-        self._sync_content_metadata(serialized_data)
+        return self._sync_content_metadata(serialized_data)
 
     def _sync_content_metadata(self, serialized_data):
         """
@@ -216,41 +216,20 @@ class SAPSuccessFactorsAPIClient(IntegratedChannelApiClient):  # pylint: disable
             ClientError: If SuccessFactors API call fails.
         """
         url = self.enterprise_configuration.sapsf_base_url + self.global_sap_config.course_api_path
-        try:
-            status_code, response_body = self._call_post_with_session(url, serialized_data)
-        except requests.exceptions.RequestException as exc:
-            LOGGER.error(
-                generate_formatted_log(
-                    self.enterprise_configuration.channel_code(),
-                    self.enterprise_configuration.enterprise_customer.uuid,
-                    None,
-                    None,
-                    f"SAPSuccessFactorsAPIClient request failed: {exc.__class__.__name__} {str(exc)}"
-                )
-            )
-            raise ClientError(
-                'SAPSuccessFactorsAPIClient request failed: {error} {message}'.format(
-                    error=exc.__class__.__name__,
-                    message=str(exc)
-                )
-            ) from exc
 
-        if status_code >= 400:
+        response_status_code, response_body = self._call_post_with_session(url, serialized_data)
+
+        if response_status_code >= 400:
             LOGGER.error(
                 generate_formatted_log(
                     self.enterprise_configuration.channel_code(),
                     self.enterprise_configuration.enterprise_customer.uuid,
                     None,
                     None,
-                    f"SAPSuccessFactorsAPIClient request failed with status {status_code}: {response_body}"
+                    f"SAPSuccessFactorsAPIClient request failed with status {response_status_code}: {response_body}"
                 )
             )
-            raise ClientError(
-                'SAPSuccessFactorsAPIClient request failed with status {status_code}: {message}'.format(
-                    status_code=status_code,
-                    message=response_body
-                )
-            )
+        return response_status_code, response_body
 
     def _call_post_with_user_override(self, sap_user_id, url, payload):
         """

--- a/tests/test_integrated_channels/test_sap_success_factors/test_client.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_client.py
@@ -239,7 +239,7 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
     @responses.activate
     def test_sap_api_connection_error(self):
         """
-        ``create_content_metadata`` should raise ClientError when API request fails with a connection error.
+        ``create_content_metadata`` should NOT raise ClientError when API request fails with a connection error.
         """
         responses.add(
             responses.POST,
@@ -257,7 +257,7 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
             body=requests.exceptions.RequestException()
         )
 
-        with raises(ClientError):
+        with raises(requests.exceptions.RequestException):
             sap_client = SAPSuccessFactorsAPIClient(self.enterprise_config)
             sap_client.create_content_metadata(self.content_payload)
 
@@ -283,9 +283,9 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
             status=400
         )
 
-        with raises(ClientError):
-            sap_client = SAPSuccessFactorsAPIClient(self.enterprise_config)
-            sap_client.create_content_metadata(self.content_payload)
+        sap_client = SAPSuccessFactorsAPIClient(self.enterprise_config)
+        status, body = sap_client.create_content_metadata(self.content_payload)
+        assert status >= 400
 
     @responses.activate
     def test_expired_access_token(self):

--- a/tests/test_integrated_channels/test_sap_success_factors/test_client.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_client.py
@@ -284,7 +284,7 @@ class TestSAPSuccessFactorsAPIClient(unittest.TestCase):
         )
 
         sap_client = SAPSuccessFactorsAPIClient(self.enterprise_config)
-        status, body = sap_client.create_content_metadata(self.content_payload)
+        status, _ = sap_client.create_content_metadata(self.content_payload)
         assert status >= 400
 
     @responses.activate


### PR DESCRIPTION
## Description

- Pass SAP Client status back to the main content transmission orchestration to record properly
- Have main content transmission orchestration catch/record more error states from the clients
- Degreed2 needs some tweaks too

## References
- https://2u-internal.atlassian.net/browse/ENT-6195