### PR TITLE
feat: expand utility of CSOD deleted_at reset job

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.6]
+--------
+feat: expand utility of CSOD deleted_at reset job
+
 [3.56.5]
 --------
 fix: properly pass SAP client status back to content transmission records

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.5"
+__version__ = "3.56.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
+++ b/integrated_channels/integrated_channel/management/commands/reset_csod_remote_deleted_at.py
@@ -25,7 +25,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
 
     def handle(self, *args, **options):
         """
-        Mark for re-send all CSOD content transmission with a remote_deleted_at but no api_response_status_code
+        Mark for re-send all CSOD content transmission with a remote_deleted_at
         """
 
         ContentMetadataItemTransmission = apps.get_model(
@@ -33,13 +33,12 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
             'ContentMetadataItemTransmission'
         )
 
-        csod_deleted_at_but_null_status = Q(
+        csod_deleted_at = Q(
             integrated_channel_code='CSOD',
-            remote_deleted_at__isnull=False,
-            api_response_status_code__isnull=True
+            remote_deleted_at__isnull=False
         )
 
-        for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_deleted_at_but_null_status):
+        for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_deleted_at):
             for item in items_batch:
                 try:
                     item.remote_deleted_at = None

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1851,7 +1851,7 @@ class TestResetCsodRemoteDeletedAtManagementCommand(unittest.TestCase, Enterpris
             remote_deleted_at=NOW,
             api_response_status_code=None,
         )
-        # a CSOD item we DO NOT want touched
+        # a CSOD item we DO want touched
         csod1 = factories.ContentMetadataItemTransmissionFactory(
             content_id='DemoX-CSOD-1',
             enterprise_customer=factories.EnterpriseCustomerFactory(),
@@ -1881,5 +1881,5 @@ class TestResetCsodRemoteDeletedAtManagementCommand(unittest.TestCase, Enterpris
         csod2.refresh_from_db()
 
         assert generic1.remote_deleted_at is not None
-        assert csod1.remote_deleted_at is not None
+        assert csod1.remote_deleted_at is None
         assert csod2.remote_deleted_at is None


### PR DESCRIPTION
## Description

Originally this job was meant to only reset the `remote_deleted_at` of content which hadn't yet been sent with the newly refactored content metadata code (hence the null remote api status code). Now, we'd like to be able to reset the `remote_deleted_at` for _all_ deleted CSOD content to force a re-transmission of the delete with the new, lower payload size.

## References

- https://2u-internal.atlassian.net/browse/ENT-6081