### PR TITLE
fix: properly truncate payload to resolve missing CSOD deletes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.9]
+--------
+fix: properly truncate payload to resolve missing CSOD deletes
+
 [3.56.8]
 --------
 feat: add debug logging to investigate missing CSOD deletes

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.8"
+__version__ = "3.56.9"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -15,7 +15,7 @@ from django.db.models import Q
 from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise.utils import get_content_metadata_item_id
 from integrated_channels.integrated_channel.exporters import Exporter
-from integrated_channels.utils import generate_formatted_log, truncate_item_collections
+from integrated_channels.utils import generate_formatted_log, truncate_item_dicts
 
 LOGGER = getLogger(__name__)
 
@@ -314,7 +314,7 @@ class ContentMetadataExporter(Exporter):
             items_to_delete
         )
 
-        truncated_create, truncated_update, truncated_delete = truncate_item_collections(
+        truncated_create, truncated_update, truncated_delete = truncate_item_dicts(
             content_to_create,
             content_to_update,
             content_to_delete,

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -300,31 +300,31 @@ class ContentMetadataExporter(Exporter):
                     course_or_course_run_key=item.get('content_key')
                 )
 
-        truncated_create, truncated_update, truncated_delete = truncate_item_collections(
-            unique_new_items_to_create,
-            matched_items,
-            items_to_delete,
-            max_item_count
-        )
-
         content_to_create = self._check_matched_content_to_create(
             enterprise_catalog,
-            truncated_create
+            unique_new_items_to_create
         )
         content_to_update = self._check_matched_content_updated_at(
             enterprise_catalog,
-            truncated_update,
+            matched_items,
             force_retrieve_all_catalogs
         )
         content_to_delete = self._check_matched_content_to_delete(
             enterprise_catalog,
-            truncated_delete
+            items_to_delete
+        )
+
+        truncated_create, truncated_update, truncated_delete = truncate_item_collections(
+            content_to_create,
+            content_to_update,
+            content_to_delete,
+            max_item_count
         )
 
         stuff_to_log = {
-            'content_to_create': content_to_create,
-            'content_to_update': content_to_update,
-            'content_to_delete': content_to_delete,
+            'truncated_create': truncated_create,
+            'truncated_update': truncated_update,
+            'truncated_delete': truncated_delete,
         }
 
         for log_key, items in stuff_to_log.items():
@@ -335,7 +335,7 @@ class ContentMetadataExporter(Exporter):
                     course_or_course_run_key=key_content_id
                 )
 
-        return content_to_create, content_to_update, content_to_delete
+        return truncated_create, truncated_update, truncated_delete
 
     def _check_matched_content_to_delete(self, enterprise_customer_catalog, items):
         """

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -416,9 +416,9 @@ def truncate_item_dicts(items_to_create, items_to_update, items_to_delete, combi
     # if we have more to work with than the allowed space, slice it up
     if len(items_to_create) + len(items_to_delete) + len(items_to_update) > combined_maximum_size:
         # prioritize creates, then updates, then deletes
-        items_to_create = dict(itertools.islice(items_to_create.items(),combined_maximum_size))
+        items_to_create = dict(itertools.islice(items_to_create.items(), combined_maximum_size))
         count_left = combined_maximum_size - len(items_to_create)
-        items_to_update = dict(itertools.islice(items_to_update.items(),count_left))
+        items_to_update = dict(itertools.islice(items_to_update.items(), count_left))
         count_left = count_left - len(items_to_update)
-        items_to_delete = dict(itertools.islice(items_to_delete.items(),count_left))
+        items_to_delete = dict(itertools.islice(items_to_delete.items(), count_left))
     return items_to_create, items_to_update, items_to_delete

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -3,6 +3,7 @@ Utilities common to different integrated channels.
 """
 
 import base64
+import itertools
 import json
 import math
 import re
@@ -407,7 +408,7 @@ def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000):
         qs = ModelClass.objects.filter(pk__gt=start_pk).filter(extra_filter).order_by('pk')[:batch_size]
 
 
-def truncate_item_collections(items_to_create, items_to_update, items_to_delete, combined_maximum_size):
+def truncate_item_dicts(items_to_create, items_to_update, items_to_delete, combined_maximum_size):
     """
     given the item collections to create, update, and delete on the remote LMS side, truncate the
     collections to keep under a maximum batch size, prioritizing creates, updates, then deletes
@@ -415,9 +416,9 @@ def truncate_item_collections(items_to_create, items_to_update, items_to_delete,
     # if we have more to work with than the allowed space, slice it up
     if len(items_to_create) + len(items_to_delete) + len(items_to_update) > combined_maximum_size:
         # prioritize creates, then updates, then deletes
-        items_to_create = items_to_create[0:combined_maximum_size]
+        items_to_create = dict(itertools.islice(items_to_create.items(),combined_maximum_size))
         count_left = combined_maximum_size - len(items_to_create)
-        items_to_update = items_to_update[0:count_left]
+        items_to_update = dict(itertools.islice(items_to_update.items(),count_left))
         count_left = count_left - len(items_to_update)
-        items_to_delete = items_to_delete[0:count_left]
+        items_to_delete = dict(itertools.islice(items_to_delete.items(),count_left))
     return items_to_create, items_to_update, items_to_delete

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -193,7 +193,6 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         )
         past_transmission_to_update.save()
 
-
         mock_content_metadata_response = OrderedDict()
         mock_content_metadata_response[FAKE_COURSE_RUN['key']] = FAKE_COURSE_RUN
         mock_content_metadata_response[FAKE_COURSE_RUN2['key']] = FAKE_COURSE_RUN2

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -18,6 +18,7 @@ from test_utils import FAKE_UUIDS, factories
 from test_utils.factories import ContentMetadataItemTransmissionFactory
 from test_utils.fake_catalog_api import (
     FAKE_COURSE_RUN,
+    FAKE_COURSE_RUN2,
     get_fake_catalog,
     get_fake_catalog_diff_create,
     get_fake_content_metadata,
@@ -166,6 +167,80 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         assert create_payload.get(FAKE_COURSE_RUN['key']) == past_transmission
         assert not update_payload
         assert not delete_payload
+
+    @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
+    def test_content_exporter_truncation_bug_export(self, mock_api_client):
+        """
+        ``ContentMetadataExporter``'s ``export`` produces a JSON dump of the course data.
+        """
+        ContentMetadataExporter.DATA_TRANSFORM_MAPPING = {
+            'contentId': 'key',
+            'title': 'title',
+            'description': 'description',
+            'imageUrl': 'image',
+            'url': 'enrollment_url',
+            'language': 'content_language'
+        }
+        past_transmission_to_update = ContentMetadataItemTransmission(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_id=FAKE_COURSE_RUN['key'],
+            channel_metadata={},
+            content_last_changed=datetime.datetime.now() - datetime.timedelta(hours=1),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_to_update.save()
+
+
+        mock_content_metadata_response = OrderedDict()
+        mock_content_metadata_response[FAKE_COURSE_RUN['key']] = FAKE_COURSE_RUN
+        mock_content_metadata_response[FAKE_COURSE_RUN2['key']] = FAKE_COURSE_RUN2
+        mock_api_client.return_value.get_content_metadata.return_value = list(mock_content_metadata_response.values())
+        mock_create_items = []
+        mock_delete_items = []
+        mock_matched_items = [{'content_key': FAKE_COURSE_RUN['key'], 'date_updated': datetime.datetime.now()}]
+        mock_api_client.return_value.get_catalog_diff.return_value = mock_create_items, mock_delete_items, \
+            mock_matched_items
+        exporter = ContentMetadataExporter('fake-user', self.config)
+        create_payload, update_payload, delete_payload = exporter.export(max_payload_count=1)
+
+        assert update_payload.get(FAKE_COURSE_RUN['key']).channel_metadata.get('contentId') == FAKE_COURSE_RUN['key']
+        assert not create_payload
+        assert not delete_payload
+
+        mock_api_client.return_value.get_catalog_diff.assert_called_with(
+            self.config.enterprise_customer.enterprise_customer_catalogs.first(),
+            [FAKE_COURSE_RUN['key']]
+        )
+
+        past_transmission_to_update.content_last_changed = datetime.datetime.now()
+        past_transmission_to_update.save()
+
+        past_transmission_to_delete = ContentMetadataItemTransmission(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_id=FAKE_COURSE_RUN2['key'],
+            channel_metadata={},
+            content_last_changed=datetime.datetime.now() - datetime.timedelta(hours=1),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_to_delete.save()
+
+        mock_delete_items = [{'content_key': FAKE_COURSE_RUN2['key']}]
+        mock_api_client.return_value.get_catalog_diff.return_value = mock_create_items, mock_delete_items, \
+            mock_matched_items
+
+        create_payload, update_payload, delete_payload = exporter.export(max_payload_count=1)
+
+        assert not update_payload
+        assert not create_payload
+        assert delete_payload.get(FAKE_COURSE_RUN2['key']) == past_transmission_to_delete
+        assert mock_api_client.return_value.get_catalog_diff.call_count == 2
+        assert mock_api_client.return_value.get_content_metadata.call_count == 1
 
     @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
     def test_content_exporter_update_not_needed_export(self, mock_api_client):

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -277,56 +277,56 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
     def test_get_courserun_duration_in_hours(self, course_run, expected_duration_days):
         assert utils.get_courserun_duration_in_hours(course_run) == expected_duration_days
 
-    def test_truncate_item_collections(self):
-        in_a = [1, 2, 3]
-        in_b = [1, 2, 3, 4, 5]
-        in_c = [1, 2, 3, 4, 5, 6, 7]
+    def test_truncate_item_dicts(self):
+        in_a = {'one': 1, 'two': 2, 'three': 3}
+        in_b = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5}
+        in_c = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6, 'seven': 7}
 
         # pick a max > combined input size
-        out_a, out_b, out_c = utils.truncate_item_collections(in_a, in_b, in_c, 100)
+        out_a, out_b, out_c = utils.truncate_item_dicts(in_a, in_b, in_c, 100)
 
         assert len(out_a) == 3
         assert len(out_b) == 5
         assert len(out_c) == 7
 
         # only room for part of input A
-        out_a, out_b, out_c = utils.truncate_item_collections(in_a, in_b, in_c, 1)
+        out_a, out_b, out_c = utils.truncate_item_dicts(in_a, in_b, in_c, 1)
 
         assert len(out_a) == 1
         assert len(out_b) == 0
         assert len(out_c) == 0
 
         # all of input A, part of input B
-        out_a, out_b, out_c = utils.truncate_item_collections(in_a, in_b, in_c, 4)
+        out_a, out_b, out_c = utils.truncate_item_dicts(in_a, in_b, in_c, 4)
 
         assert len(out_a) == 3
         assert len(out_b) == 1
         assert len(out_c) == 0
 
         # all of input A and B, part of input C
-        out_a, out_b, out_c = utils.truncate_item_collections(in_a, in_b, in_c, 10)
+        out_a, out_b, out_c = utils.truncate_item_dicts(in_a, in_b, in_c, 10)
 
         assert len(out_a) == 3
         assert len(out_b) == 5
         assert len(out_c) == 2
 
-        in_a = []
-        in_b = []
-        in_c = [1, 2, 3, 4, 5, 6, 7]
+        in_a = {}
+        in_b = {}
+        in_c = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6, 'seven': 7}
 
         # all of input A and B (empty), all of input C
-        out_a, out_b, out_c = utils.truncate_item_collections(in_a, in_b, in_c, 10)
+        out_a, out_b, out_c = utils.truncate_item_dicts(in_a, in_b, in_c, 10)
 
         assert len(out_a) == 0
         assert len(out_b) == 0
         assert len(out_c) == 7
 
-        in_a = [1]
-        in_b = []
-        in_c = [1, 2, 3, 4, 5, 6, 7]
+        in_a = {'one': 1}
+        in_b = {}
+        in_c = {'one': 1, 'two': 2, 'three': 3, 'four': 4, 'five': 5, 'six': 6, 'seven': 7}
 
         # all of input A and B (empty), all of input C
-        out_a, out_b, out_c = utils.truncate_item_collections(in_a, in_b, in_c, 10)
+        out_a, out_b, out_c = utils.truncate_item_dicts(in_a, in_b, in_c, 10)
 
         assert len(out_a) == 1
         assert len(out_b) == 0


### PR DESCRIPTION
## Description

We were truncating our content payloads before we were filtering out items we were not going to update - this was resulting in missed updates and deletes to content in the remote LMS when using `max_payload_count` less than catalog size (typical with CSOD specifically). This PR re-orders the truncate to happen later in the diff process. It also adds a test which replicates the bug behavior.

In the steady synced state, the entire customer catalog is returned as a matched item from the diff endpoint and then we filter that down (to nothing) after we compare last modified dates to determine if an update needs to be send. Because we truncate to `max_payload_count` _before_ we compare dates to filter, we were only ever filtering on an update collection of the first `max_payload_count` and a truncated (empty) delete collection instead of truncating _after_ we collect all the updates and deletes we'd like to send.

## References

- https://2u-internal.atlassian.net/browse/ENT-6081
- https://github.com/openedx/edx-enterprise/pull/1629
- https://github.com/openedx/edx-enterprise/pull/1627
- https://github.com/openedx/edx-enterprise/pull/1625