### PR TITLE
feat: Added POST support for catalog query preview

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.57.2]
+--------
+feat: Added POST support for catalog query preview
+
 [3.57.1]
 --------
 fix: impoving transmission records by moving response body to new table

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.57.1"
+__version__ = "3.57.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -36,6 +36,7 @@ from enterprise.admin.forms import (
 )
 from enterprise.admin.utils import UrlNames
 from enterprise.admin.views import (
+    CatalogQueryPreviewView,
     EnterpriseCustomerManageLearnerDataSharingConsentView,
     EnterpriseCustomerManageLearnersView,
     EnterpriseCustomerTransmitCoursesView,
@@ -715,6 +716,19 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
     class Meta:
         model = EnterpriseCatalogQuery
 
+    def get_urls(self):
+        """
+        Returns the additional urls used by the custom object tools.
+        """
+        preview_urls = [
+            re_path(
+                r"^([^/]+)/preview/$",
+                self.admin_site.admin_view(CatalogQueryPreviewView.as_view()),
+                name=UrlNames.PREVIEW_QUERY_RESULT
+            )
+        ]
+        return preview_urls + super().get_urls()
+
     list_display = (
         'title',
         'discovery_query_url',
@@ -725,7 +739,11 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
         """
         Return discovery url for preview.
         """
-        return discovery_query_url(obj.content_filter)
+        url = reverse("admin:" + UrlNames.PREVIEW_QUERY_RESULT, args=(obj.pk,))
+        return format_html(
+            '<a href="{url}" target="_blank">Preview</a>',
+            url=url
+        )
 
     def has_delete_permission(self, request, obj=None):
         return False

--- a/enterprise/admin/utils.py
+++ b/enterprise/admin/utils.py
@@ -26,6 +26,7 @@ class UrlNames:
     MANAGE_LEARNERS_DSC = URL_PREFIX + "manage_learners_data_sharing_consent"
     TRANSMIT_COURSES_METADATA = URL_PREFIX + "transmit_courses_metadata"
     PREVIEW_EMAIL_TEMPLATE = URL_PREFIX + "preview_email_template"
+    PREVIEW_QUERY_RESULT = URL_PREFIX + "preview_query_result"
 
 
 def validate_csv(file_stream, expected_columns=None):


### PR DESCRIPTION
**Description** This PR updates the catalog query preview link to use POST instead of GET to enable large size of arguments

**JIRA** [ENT-6179](https://2u-internal.atlassian.net/browse/ENT-6179)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
