### PR TITLE
chore: add plugin_configuration_id to standard integration logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.10]
+---------
+chore: add plugin_configuration_id to standard integration logging
+
 [3.56.9]
 --------
 fix: properly truncate payload to resolve missing CSOD deletes

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.9"
+__version__ = "3.56.10"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -272,11 +272,12 @@ def get_subjects_from_content_metadata(content_metadata_item):
 
 
 def generate_formatted_log(
-    channel_name,
-    enterprise_customer_uuid,
-    lms_user_id,
-    course_or_course_run_key,
-    message
+    channel_name=None,
+    enterprise_customer_uuid=None,
+    lms_user_id=None,
+    course_or_course_run_key=None,
+    plugin_configuration_id=None,
+    message=None
 ):
     """
     Formats and returns a standardized message for the integrated channels.
@@ -288,13 +289,15 @@ def generate_formatted_log(
     - enterprise_customer_uuid (str): UUID of the relevant EnterpriseCustomer
     - lms_user_id (str): The LMS User id (if applicable) related to the message
     - course_or_course_run_key (str): The course key (if applicable) for the message
+    - plugin_configuration_id (str): The configuration id related to the message
     - message (str): The string to be formatted and logged
 
     """
     return f'integrated_channel={channel_name}, '\
         f'integrated_channel_enterprise_customer_uuid={enterprise_customer_uuid}, '\
         f'integrated_channel_lms_user={lms_user_id}, '\
-        f'integrated_channel_course_key={course_or_course_run_key}, {message}'
+        f'integrated_channel_course_key={course_or_course_run_key}, '\
+        f'enterprise_plugin_configuration_id={plugin_configuration_id}, {message}'
 
 
 def refresh_session_if_expired(

--- a/tests/test_integrated_channels/test_utils.py
+++ b/tests/test_integrated_channels/test_utils.py
@@ -235,7 +235,8 @@ class TestIntegratedChannelsUtils(unittest.TestCase):
         assert log_str == 'integrated_channel=1, '\
             'integrated_channel_enterprise_customer_uuid=2, '\
             'integrated_channel_lms_user=3, '\
-            'integrated_channel_course_key=4, 5'
+            'integrated_channel_course_key=4, '\
+            'integrated_channel_enterprise_plugin_configuration_id=5, 6'
 
     def test_is_url_valid(self):
         assert utils.is_valid_url('https://test.com/a-really-really-really-really-long-url/')


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
