### PR TITLE
chore: cleaning up canvas url construction

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.11]
+---------
+chore: cleaning up Canvas client url construction
+
 [3.56.10]
 ---------
 fix: adhering to urljoin patterns in integrated channels API views

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.10"
+__version__ = "3.56.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/canvas/utils.py
+++ b/integrated_channels/canvas/utils.py
@@ -1,6 +1,7 @@
 '''Collection of static util methods for various Canvas operations'''
 import logging
 from http import HTTPStatus
+from urllib.parse import urljoin
 
 from requests.utils import quote
 
@@ -40,7 +41,7 @@ class CanvasUtil:
 
         If root account cannot be found, returns None
         """
-        url = "{}/api/v1/accounts".format(enterprise_configuration.canvas_base_url)
+        url = urljoin(enterprise_configuration.canvas_base_url, "/api/v1/accounts")
         resp = session.get(url)
         all_accounts = resp.json()
         root_account = None
@@ -71,11 +72,8 @@ class CanvasUtil:
 
         The `&state[]=all` is added so we can also fetch priorly 'delete'd courses as well
         """
-        url = "{}/api/v1/accounts/{}/courses/?search_term={}&state[]=all".format(
-            enterprise_configuration.canvas_base_url,
-            canvas_account_id,
-            quote(edx_course_id),
-        )
+        path = f"/api/v1/accounts/{canvas_account_id}/courses/?search_term={quote(edx_course_id)}&state[]=all"
+        url = urljoin(enterprise_configuration.canvas_base_url, path)
         resp = session.get(url)
         all_courses_response = resp.json()
 
@@ -204,9 +202,9 @@ class CanvasUtil:
         """
         Returns endpoint to POST to for course creation
         """
-        return '{}/api/v1/accounts/{}/courses'.format(
+        return urljoin(
             enterprise_configuration.canvas_base_url,
-            enterprise_configuration.canvas_account_id,
+            f'/api/v1/accounts/{enterprise_configuration.canvas_account_id}/courses',
         )
 
     @staticmethod
@@ -214,9 +212,9 @@ class CanvasUtil:
         """
         Returns endpoint to PUT to for course update
         """
-        return '{}/api/v1/courses/{}'.format(
+        return urljoin(
             enterprise_configuration.canvas_base_url,
-            course_id,
+            f'/api/v1/courses/{course_id}',
         )
 
     @staticmethod
@@ -224,7 +222,7 @@ class CanvasUtil:
         """
         Returns endpoint to GET to for course assignments
         """
-        return '{}/api/v1/courses/{}/assignments'.format(
+        return urljoin(
             enterprise_configuration.canvas_base_url,
-            course_id,
+            f'/api/v1/courses/{course_id}/assignments',
         )


### PR DESCRIPTION
Noticed that Canvas (probably many other) integrated channels doesn't properly construct urls (naively joins strings). Strangely this doesn't seem to be interrupting customer experiences but I figured it's worth cleaning up.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
