### PR TITLE
chore: smarter canvas client update course behavior

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 None
 
+[3.56.13]
+---------
+chore: smarter canvas client update course behavior
+
 [3.56.12]
 ---------
 chore: adding http status response code to content record django admin table

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.56.12"
+__version__ = "3.56.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/canvas/client.py
+++ b/integrated_channels/canvas/client.py
@@ -77,7 +77,6 @@ class CanvasAPIClient(IntegratedChannelApiClient):
 
         desired_payload = json.loads(serialized_data.decode('utf-8'))
         course_details = desired_payload['course']
-
         edx_course_id = course_details['integration_id']
         located_course = CanvasUtil.find_course_by_course_id(
             self.enterprise_configuration,
@@ -85,10 +84,12 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             edx_course_id
         )
 
+        # Do one of 3 things with the fetched canvas course info
+        # If no course was found, create it
         if not located_course:
             LOGGER.info(
                 generate_formatted_log(
-                    'canvas',
+                    self.enterprise_configuration.channel_code(),
                     self.enterprise_configuration.enterprise_customer.uuid,
                     None,
                     edx_course_id,
@@ -104,12 +105,14 @@ class CanvasAPIClient(IntegratedChannelApiClient):
 
             # step 2: upload image_url and any other details
             self._update_course_details(created_course_id, course_details)
+            return status_code, response_text
+        # If the course was deleted, Canvas cannot support recreating
         else:
             workflow_state = located_course['workflow_state']
             if workflow_state.lower() == 'deleted':
                 LOGGER.error(
                     generate_formatted_log(
-                        'canvas',
+                        self.enterprise_configuration.channel_code(),
                         self.enterprise_configuration.enterprise_customer.uuid,
                         None,
                         edx_course_id,
@@ -119,13 +122,13 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                         ),
                     )
                 )
-                status_code = 200
-                response_text = MESSAGE_WHEN_COURSE_WAS_DELETED
+                return 200, MESSAGE_WHEN_COURSE_WAS_DELETED
+            # If the course is found, update it instead of creating one
             else:
                 # 'unpublished', 'completed' or 'available' cases
                 LOGGER.warning(
                     generate_formatted_log(
-                        'canvas',
+                        self.enterprise_configuration.channel_code(),
                         self.enterprise_configuration.enterprise_customer.uuid,
                         None,
                         edx_course_id,
@@ -138,28 +141,40 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                         ),
                     )
                 )
-                status_code, response_text = self._update_course_details(
+                return self._update_course_details(
                     located_course['id'],
                     course_details,
                 )
-
-        return status_code, response_text
 
     def update_content_metadata(self, serialized_data):
         self._create_session()
 
         integration_id = self._extract_integration_id(serialized_data)
-        course_id = CanvasUtil.get_course_id_from_edx_course_id(
+        canvas_course = CanvasUtil.find_course_by_course_id(
             self.enterprise_configuration,
             self.session,
             integration_id,
         )
 
+        # If no course was found, we should create the content.
+        if not canvas_course:
+            LOGGER.info(
+                generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    self.enterprise_configuration.enterprise_customer.uuid,
+                    None,
+                    integration_id,
+                    f'Requested course:{integration_id} for update was not found in customers instance. Requesting a '
+                    f'create instead',
+                )
+            )
+            return self.create_content_metadata(serialized_data)
+
+        canvas_course_id = canvas_course.get('id')
         url = CanvasUtil.course_update_endpoint(
             self.enterprise_configuration,
-            course_id,
+            canvas_course_id,
         )
-
         return self._put(url, serialized_data)
 
     def delete_content_metadata(self, serialized_data):
@@ -287,7 +302,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
                 if resp.status_code >= 400:
                     LOGGER.error(
                         generate_formatted_log(
-                            'canvas',
+                            self.enterprise_configuration.channel_code(),
                             self.enterprise_configuration.enterprise_customer.uuid,
                             None,
                             edx_course,
@@ -372,7 +387,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             except ClientError:
                 LOGGER.info(
                     generate_formatted_log(
-                        'canvas',
+                        self.enterprise_configuration.channel_code(),
                         self.enterprise_configuration.enterprise_customer.uuid,
                         None,
                         integration_id,
@@ -480,7 +495,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             exc_string = str(course_exc)
             LOGGER.error(
                 generate_formatted_log(
-                    'canvas',
+                    self.enterprise_configuration.channel_code(),
                     self.enterprise_configuration.enterprise_customer.uuid,
                     None,
                     edx_course_id,
@@ -560,7 +575,7 @@ class CanvasAPIClient(IntegratedChannelApiClient):
             integration_id = decoded_json['course']['integration_id']
         except KeyError as error:
             LOGGER.exception(generate_formatted_log(
-                'canvas',
+                self.enterprise_configuration.channel_code(),
                 self.enterprise_configuration.enterprise_customer.uuid,
                 None,
                 None,


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6306 While investigating a customer's canvas integration, I noticed splunk errors reporting 404's when updating courses. I've updated the `update content metadata` function to now catch 404's and create the content instead.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
