### PR TITLE
feat: a thought experiment for cached exporting

### DIFF
--- a/integrated_channels/cornerstone/exporters/content_metadata.py
+++ b/integrated_channels/cornerstone/exporters/content_metadata.py
@@ -49,11 +49,11 @@ class CornerstoneContentMetadataExporter(ContentMetadataExporter):
     SKIP_KEY_IF_NONE = True
     MAX_PAYLOAD_COUNT = getattr(settings, "ENTERPRISE_CORNERSTONE_MAX_CONTENT_PAYLOAD_COUNT", 1000)
 
-    def export_for_web_polling(self, max_payload_count=MAX_PAYLOAD_COUNT):
+    def export_for_web_polling(self, max_payload_count=MAX_PAYLOAD_COUNT, use_export_cache=True):
         """
         Return the exported and transformed content metadata as a dictionary for CSDO web pull.
         """
-        return self.export(max_payload_count=max_payload_count)
+        return self.export(max_payload_count=max_payload_count, use_export_cache=use_export_cache)
 
     def export_force_all_catalogs(self):
         """

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -191,6 +191,7 @@ class ContentMetadataTransmitter(Transmitter):
                         transmission.remote_updated_at = action_happened_at
                     elif action_name == 'delete':
                         transmission.remote_deleted_at = action_happened_at
+                    transmission.marked_for = None
                     transmission.save()
                     results.append(transmission)
         return results


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
