### PR TITLE
feat: remove debug logging used to investigate missing CSOD deletes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.57.3]
+--------
+feat: remove debug logging used to investigate missing CSOD deletes
+
 [3.57.2]
 --------
 feat: Added POST support for catalog query preview

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.57.2"
+__version__ = "3.57.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -266,20 +266,6 @@ class ContentMetadataExporter(Exporter):
             content_keys
         )
 
-        stuff_to_log = {
-            'items_to_create': items_to_create,
-            'items_to_delete': items_to_delete,
-            'matched_items': matched_items,
-        }
-
-        for key, content_list in stuff_to_log.items():
-            for content in content_list:
-                content_id = content.get('content_key')
-                self._log_info(
-                    f'get_catalog_diff api results {key} includes {content_id}',
-                    course_or_course_run_key=content_id
-                )
-
         ContentMetadataItemTransmission = apps.get_model(
             'integrated_channel',
             'ContentMetadataItemTransmission'
@@ -326,20 +312,6 @@ class ContentMetadataExporter(Exporter):
             content_to_delete,
             max_item_count
         )
-
-        stuff_to_log = {
-            'truncated_create': truncated_create,
-            'truncated_update': truncated_update,
-            'truncated_delete': truncated_delete,
-        }
-
-        for log_key, items in stuff_to_log.items():
-            for key_content_id, item in items.items():
-                item_content_id = item.content_id
-                self._log_info(
-                    f'_get_catalog_diff return {log_key} includes {key_content_id} : {item_content_id}',
-                    course_or_course_run_key=key_content_id
-                )
 
         return truncated_create, truncated_update, truncated_delete
 
@@ -425,13 +397,6 @@ class ContentMetadataExporter(Exporter):
                 f'Retrieved {len(content_keys)} content keys for past transmissions to customer: '
                 f'{self.enterprise_customer.uuid} under catalog: {enterprise_customer_catalog.uuid}.'
             )
-
-            for content_key in content_keys:
-                self._log_info(
-                    f'Retrieved content key: {content_key} for past transmissions to customer: '
-                    f'{self.enterprise_customer.uuid} under catalog: {enterprise_customer_catalog.uuid}.',
-                    course_or_course_run_key=content_key
-                )
 
             # From the saved content records, use the enterprise catalog API to determine what needs sending
             items_to_create, items_to_update, items_to_delete = self._get_catalog_diff(


### PR DESCRIPTION
partial revert of https://github.com/openedx/edx-enterprise/pull/1629 motivated by the logs turning out to be too noisy

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
