### PR TITLE
fix: integrated channels not picking up courses to update

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.58.1]
+--------
+fix: integrated channels not picking up courses to update
+
 [3.58.0]
 --------
 feat: Add a new endpoint to generate a signed token for plotly analytics.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.58.0"
+__version__ = "3.58.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -436,14 +436,15 @@ class ContentMetadataExporter(Exporter):
                         create_payload[key] = existing_record
                     elif key in items_update_keys:
                         existing_record = items_to_update.get(key)
-                        existing_record.channel_metadata = transformed_item
                         existing_record.content_title = item.get('title')
                         # Sanity check
                         existing_record.enterprise_customer_catalog_uuid = enterprise_customer_catalog.uuid
                         existing_record.save()
-                        # Intentionally setting the content_last_changed field post-save so that
-                        # untransmitted courses will get picked up again in subsequent runs
+                        # Intentionally setting the channel_metadata and content_last_changed
+                        # fields post-save to clarify what data has been transmitted
+                        # and so that untransmitted courses will get picked up again in subsequent runs
                         existing_record.content_last_changed = item.get('content_last_modified')
+                        existing_record.channel_metadata = transformed_item
                         update_payload[key] = existing_record
 
             for key, item in items_to_delete.items():

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -438,10 +438,12 @@ class ContentMetadataExporter(Exporter):
                         existing_record = items_to_update.get(key)
                         existing_record.channel_metadata = transformed_item
                         existing_record.content_title = item.get('title')
-                        existing_record.content_last_changed = item.get('content_last_modified')
                         # Sanity check
                         existing_record.enterprise_customer_catalog_uuid = enterprise_customer_catalog.uuid
                         existing_record.save()
+                        # Intentionally setting the content_last_changed field post-save so that
+                        # untransmitted courses will get picked up again in subsequent runs
+                        existing_record.content_last_changed = item.get('content_last_modified')
                         update_payload[key] = existing_record
 
             for key, item in items_to_delete.items():


### PR DESCRIPTION
ENT-6451 - ensure that the content_last_changed field is only updated post-transmit, to ensure that untransmitted courses get picked up on subsequent runs

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
