### PR TITLE
feat: adding admin views for all integrated channel learner data audit tables

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.58.3]
+--------
+feat: transmission audit admin view and api improvements
+
 [3.58.2]
 --------
 fix: integrated channels not picking up courses to update

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.58.2"
+__version__ = "3.58.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/api/v1/logs/serializers.py
+++ b/integrated_channels/api/v1/logs/serializers.py
@@ -64,7 +64,36 @@ class LearnerSyncStatusSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = LearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = (
+            'user_email',
+            'content_title',
+            'progress_status',
+            'sync_status',
+            'sync_last_attempted_at',
+            'friendly_status_message',
+        )
+
+    sync_status = serializers.SerializerMethodField()
+    sync_last_attempted_at = serializers.SerializerMethodField()
+
+    def get_sync_status(self, obj):
+        """
+        Return a string representation of the sync status.
+        """
+        if obj.status is None:
+            sync_status = 'pending'
+        elif not obj.status.isdigit() or int(obj.status) >= 400:
+            sync_status = 'error'
+        elif int(obj.status) < 400:
+            sync_status = 'okay'
+
+        return sync_status
+
+    def get_sync_last_attempted_at(self, obj):
+        """
+        Return the most recent/youngest sync attempt date.
+        """
+        return obj.modified or obj.created
 
     @classmethod
     def get_class_by_channel_code(this_cls, channel_code):
@@ -85,7 +114,7 @@ class GenericLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = GenericLearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"
 
 
 class BlackboardLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -95,7 +124,7 @@ class BlackboardLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = BlackboardLearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"
 
 
 class CanvasLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -105,7 +134,7 @@ class CanvasLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = CanvasLearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"
 
 
 class CornerstoneLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -115,7 +144,7 @@ class CornerstoneLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = CornerstoneLearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"
 
 
 class DegreedLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -125,7 +154,6 @@ class DegreedLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = DegreedLearnerDataTransmissionAudit
-        fields = '__all__'
 
 
 class Degreed2LearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -135,7 +163,7 @@ class Degreed2LearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = Degreed2LearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"
 
 
 class MoodleLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -145,7 +173,7 @@ class MoodleLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = MoodleLearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"
 
 
 class SapLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -155,4 +183,4 @@ class SapLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = SapSuccessFactorsLearnerDataTransmissionAudit
-        fields = '__all__'
+        fields = "__all__"

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -9,7 +9,9 @@ from django.utils.html import format_html
 from integrated_channels.blackboard.models import (
     BlackboardEnterpriseCustomerConfiguration,
     BlackboardGlobalConfiguration,
+    BlackboardLearnerDataTransmissionAudit,
 )
+from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
 
 
 @admin.register(BlackboardGlobalConfiguration)
@@ -75,3 +77,28 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
             return format_html((f'<a href="{obj.oauth_authorization_url}">Authorize Link</a>'))
         else:
             return None
+
+
+@admin.register(BlackboardLearnerDataTransmissionAudit)
+class BlackboardLearnerDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
+    """
+    Django admin model for BlackboardLearnerDataTransmissionAudit.
+    """
+    list_display = (
+        "enterprise_course_enrollment_id",
+        "course_id",
+        "status",
+        "modified",
+    )
+
+    readonly_fields = (
+        "blackboard_user_email",
+        "progress_status",
+        "content_title",
+        "enterprise_customer_name",
+    )
+
+    list_per_page = 1000
+
+    class Meta:
+        model = BlackboardLearnerDataTransmissionAudit

--- a/integrated_channels/blackboard/exporters/learner_data.py
+++ b/integrated_channels/blackboard/exporters/learner_data.py
@@ -55,6 +55,7 @@ class BlackboardLearnerExporter(LearnerExporter):
             BlackboardLearnerDataTransmissionAudit(
                 enterprise_course_enrollment_id=enterprise_enrollment.id,
                 blackboard_user_email=enterprise_customer_user.user_email,
+                user_email=enterprise_customer_user.user_email,
                 course_id=get_course_id_for_enrollment(enterprise_enrollment),
                 course_completed=course_completed,
                 grade=percent_grade,

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -5,7 +5,11 @@ Admin integration for configuring Canvas app to communicate with Canvas systems.
 from django.contrib import admin
 from django.utils.html import format_html
 
-from integrated_channels.canvas.models import CanvasEnterpriseCustomerConfiguration
+from integrated_channels.canvas.models import (
+    CanvasEnterpriseCustomerConfiguration,
+    CanvasLearnerAssessmentDataTransmissionAudit,
+)
+from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
 
 
 @admin.register(CanvasEnterpriseCustomerConfiguration)
@@ -60,3 +64,28 @@ class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
             return format_html((f'<a href="{obj.oauth_authorization_url}">Authorize Link</a>'))
         else:
             return None
+
+
+@admin.register(CanvasLearnerAssessmentDataTransmissionAudit)
+class CanvasLearnerAssessmentDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
+    """
+    Django admin model for CanvasLearnerAssessmentDataTransmissionAudit.
+    """
+    list_display = (
+        "enterprise_course_enrollment_id",
+        "course_id",
+        "status",
+        "modified",
+    )
+
+    readonly_fields = (
+        "canvas_user_email",
+        "progress_status",
+        "content_title",
+        "enterprise_customer_name",
+    )
+
+    list_per_page = 1000
+
+    class Meta:
+        model = CanvasLearnerAssessmentDataTransmissionAudit

--- a/integrated_channels/canvas/exporters/learner_data.py
+++ b/integrated_channels/canvas/exporters/learner_data.py
@@ -56,6 +56,7 @@ class CanvasLearnerExporter(LearnerExporter):
             CanvasLearnerDataTransmissionAudit(
                 enterprise_course_enrollment_id=enterprise_enrollment.id,
                 canvas_user_email=enterprise_customer_user.user_email,
+                user_email=enterprise_customer_user.user_email,
                 course_id=get_course_id_for_enrollment(enterprise_enrollment),
                 course_completed=course_completed,
                 grade=percent_grade,

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -54,6 +54,9 @@ class CornerstoneLearnerExporter(LearnerExporter):
             csod_learner_data_transmission.course_completed = course_completed
             csod_learner_data_transmission.completed_timestamp = completed_date
 
+            # Used for api error reporting
+            csod_learner_data_transmission.user_email = enterprise_enrollment.enterprise_customer_user.user_email
+
             enterprise_customer = enterprise_enrollment.enterprise_customer_user.enterprise_customer
             csod_learner_data_transmission.enterprise_customer_uuid = enterprise_customer.uuid
             csod_learner_data_transmission.plugin_configuration_id = self.enterprise_configuration.id

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -6,7 +6,12 @@ from config_models.admin import ConfigurationModelAdmin
 
 from django.contrib import admin
 
-from integrated_channels.degreed.models import DegreedEnterpriseCustomerConfiguration, DegreedGlobalConfiguration
+from integrated_channels.degreed.models import (
+    DegreedEnterpriseCustomerConfiguration,
+    DegreedGlobalConfiguration,
+    DegreedLearnerDataTransmissionAudit,
+)
+from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
 
 
 @admin.register(DegreedGlobalConfiguration)
@@ -66,3 +71,28 @@ class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+
+@admin.register(DegreedLearnerDataTransmissionAudit)
+class DegreedLearnerDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
+    """
+    Django admin model for DegreedLearnerDataTransmissionAudit.
+    """
+    list_display = (
+        "enterprise_course_enrollment_id",
+        "course_id",
+        "status",
+        "modified",
+    )
+
+    readonly_fields = (
+        "degreed_user_email",
+        "progress_status",
+        "content_title",
+        "enterprise_customer_name",
+    )
+
+    list_per_page = 1000
+
+    class Meta:
+        model = DegreedLearnerDataTransmissionAudit

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -46,6 +46,7 @@ class DegreedLearnerExporter(LearnerExporter):
                 DegreedLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=get_course_id_for_enrollment(enterprise_enrollment),
                     course_completed=course_completed,
                     completed_timestamp=completed_timestamp,
@@ -55,6 +56,7 @@ class DegreedLearnerExporter(LearnerExporter):
                 DegreedLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=enterprise_enrollment.course_id,
                     course_completed=course_completed,
                     completed_timestamp=completed_timestamp,

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -3,35 +3,13 @@
 Django admin integration for configuring degreed app to communicate with Degreed systems.
 """
 
-from django.apps import apps
 from django.contrib import admin
-from django.core.exceptions import ObjectDoesNotExist
 
 from integrated_channels.degreed2.models import (
     Degreed2EnterpriseCustomerConfiguration,
     Degreed2LearnerDataTransmissionAudit,
 )
-
-
-def enterprise_course_enrollment_model():
-    """
-    Returns the ``EnterpriseCourseEnrollment`` class.
-    """
-    return apps.get_model('enterprise', 'EnterpriseCourseEnrollment')
-
-
-def enterprise_customer_user_model():
-    """
-    Returns the ``EnterpriseCustomerUser`` class.
-    """
-    return apps.get_model('enterprise', 'EnterpriseCustomerUser')
-
-
-def enterprise_customer_model():
-    """
-    Returns the ``EnterpriseCustomer`` class.
-    """
-    return apps.get_model('enterprise', 'EnterpriseCustomer')
+from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
 
 
 @admin.register(Degreed2EnterpriseCustomerConfiguration)
@@ -75,12 +53,11 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
 
 
 @admin.register(Degreed2LearnerDataTransmissionAudit)
-class Degreed2LearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
+class Degreed2LearnerDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
     """
     Django admin model for Degreed2LearnerDataTransmissionAudit.
     """
     list_display = (
-        "degreed_user_email",
         "enterprise_course_enrollment_id",
         "course_id",
         "status",
@@ -88,6 +65,9 @@ class Degreed2LearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
     )
 
     readonly_fields = (
+        "degreed_user_email",
+        "progress_status",
+        "content_title",
         "enterprise_customer_name",
     )
 
@@ -95,24 +75,3 @@ class Degreed2LearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
 
     class Meta:
         model = Degreed2LearnerDataTransmissionAudit
-
-    def enterprise_customer_name(self, obj):
-        """
-        Returns: the name for the attached EnterpriseCustomer.
-        Args:
-            obj: The instance of Degreed2LearnerDataTransmissionAudit
-                being rendered with this admin form.
-        """
-
-        # a direct foreign key relationship is missing
-        # multiple queries here so, avoid adding it to list_display fields
-        EnterpriseCourseEnrollment = enterprise_course_enrollment_model()
-        EnterpriseCustomerUser = enterprise_customer_user_model()
-        EnterpriseCustomer = enterprise_customer_model()
-        try:
-            ece = EnterpriseCourseEnrollment.objects.get(pk=obj.enterprise_course_enrollment_id)
-            ecu = EnterpriseCustomerUser.objects.get(pk=ece.enterprise_customer_user_id)
-            ec = EnterpriseCustomer.objects.get(pk=ecu.enterprise_customer_id)
-            return ec.name
-        except ObjectDoesNotExist:
-            return None

--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -49,6 +49,7 @@ class Degreed2LearnerExporter(LearnerExporter):
                 Degreed2LearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=get_course_id_for_enrollment(enterprise_enrollment),
                     completed_timestamp=completed_timestamp,
                     course_completed=course_completed,
@@ -58,6 +59,7 @@ class Degreed2LearnerExporter(LearnerExporter):
                 Degreed2LearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=enterprise_enrollment.course_id,
                     completed_timestamp=completed_timestamp,
                     course_completed=course_completed,

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -5,6 +5,21 @@ Admin site configurations for integrated channel's Content Metadata Transmission
 from django.contrib import admin
 
 from integrated_channels.integrated_channel.models import ContentMetadataItemTransmission
+from integrated_channels.utils import get_enterprise_customer_from_enterprise_enrollment
+
+
+class BaseLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
+    """
+    Base admin class to hold commonly used methods across integrated channel admin views
+    """
+    def enterprise_customer_name(self, obj):
+        """
+        Returns: the name for the attached EnterpriseCustomer or None if customer object does not exist.
+        Args:
+            obj: The instance of Django model being rendered with this admin form.
+        """
+        ent_customer = get_enterprise_customer_from_enterprise_enrollment(obj.enterprise_course_enrollment_id)
+        return ent_customer.name if ent_customer else None
 
 
 @admin.register(ContentMetadataItemTransmission)
@@ -31,5 +46,9 @@ class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
     raw_id_fields = (
         'enterprise_customer',
     )
+
+    readonly_fields = [
+        'api_record_id'
+    ]
 
     list_per_page = 1000

--- a/integrated_channels/moodle/admin/__init__.py
+++ b/integrated_channels/moodle/admin/__init__.py
@@ -7,7 +7,8 @@ from django.contrib import admin
 from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
-from integrated_channels.moodle.models import MoodleEnterpriseCustomerConfiguration
+from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
+from integrated_channels.moodle.models import MoodleEnterpriseCustomerConfiguration, MoodleLearnerDataTransmissionAudit
 
 
 class MoodleEnterpriseCustomerConfigurationForm(forms.ModelForm):
@@ -40,3 +41,28 @@ class MoodleEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     )
 
     form = MoodleEnterpriseCustomerConfigurationForm
+
+
+@admin.register(MoodleLearnerDataTransmissionAudit)
+class MoodleLearnerDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
+    """
+    Django admin model for MoodleLearnerDataTransmissionAudit.
+    """
+    list_display = (
+        "enterprise_course_enrollment_id",
+        "course_id",
+        "status",
+        "modified",
+    )
+
+    readonly_fields = (
+        "moodle_user_email",
+        "progress_status",
+        "content_title",
+        "enterprise_customer_name",
+    )
+
+    list_per_page = 1000
+
+    class Meta:
+        model = MoodleLearnerDataTransmissionAudit

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -52,11 +52,14 @@ class MoodleLearnerExporter(LearnerExporter):
         )
 
         percent_grade = kwargs.get('grade_percent', None)
-
+        # We return two records here, one with the course key and one with the course run id, to account for
+        # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
+        # TODO: this shouldn't be necessary anymore and eventually phased out as part of tech debt
         return [
             MoodleLearnerDataTransmissionAudit(
                 enterprise_course_enrollment_id=enterprise_enrollment.id,
                 moodle_user_email=enterprise_customer_user.user_email,
+                user_email=enterprise_customer_user.user_email,
                 course_id=get_course_id_for_enrollment(enterprise_enrollment),
                 course_completed=course_completed,
                 grade=percent_grade,
@@ -67,6 +70,7 @@ class MoodleLearnerExporter(LearnerExporter):
             MoodleLearnerDataTransmissionAudit(
                 enterprise_course_enrollment_id=enterprise_enrollment.id,
                 moodle_user_email=enterprise_customer_user.user_email,
+                user_email=enterprise_customer_user.user_email,
                 course_id=enterprise_enrollment.course_id,
                 course_completed=course_completed,
                 grade=percent_grade,

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -8,10 +8,12 @@ from requests import RequestException
 from django.contrib import admin
 
 from integrated_channels.exceptions import ClientError
+from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
 from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient
 from integrated_channels.sap_success_factors.models import (
     SAPSuccessFactorsEnterpriseCustomerConfiguration,
     SAPSuccessFactorsGlobalConfiguration,
+    SapSuccessFactorsLearnerDataTransmissionAudit,
 )
 
 
@@ -116,3 +118,28 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
 
     has_access_token.boolean = True
     has_access_token.short_description = 'Has Access Token?'
+
+
+@admin.register(SapSuccessFactorsLearnerDataTransmissionAudit)
+class SapSuccessFactorsLearnerDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
+    """
+    Django admin model for SapSuccessFactorsLearnerDataTransmissionAudit.
+    """
+    list_display = (
+        "enterprise_course_enrollment_id",
+        "course_id",
+        "status",
+        "modified",
+    )
+
+    readonly_fields = (
+        "sapsf_user_id",
+        "progress_status",
+        "content_title",
+        "enterprise_customer_name",
+    )
+
+    list_per_page = 1000
+
+    class Meta:
+        model = SapSuccessFactorsLearnerDataTransmissionAudit

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -62,6 +62,7 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
                 SapSuccessFactorsLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     sapsf_user_id=sapsf_user_id,
+                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=get_course_id_for_enrollment(enterprise_enrollment),
                     course_completed=course_completed,
                     completed_timestamp=completed_timestamp,
@@ -74,6 +75,7 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
                 SapSuccessFactorsLearnerDataTransmissionAudit(
                     enterprise_course_enrollment_id=enterprise_enrollment.id,
                     sapsf_user_id=sapsf_user_id,
+                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
                     course_id=enterprise_enrollment.course_id,
                     course_completed=course_completed,
                     completed_timestamp=completed_timestamp,

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -16,6 +16,8 @@ from urllib.parse import urlparse
 import pytz
 import requests
 
+from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
 from django.db.models import Q
 from django.utils import timezone
 from django.utils.html import strip_tags
@@ -437,3 +439,24 @@ def channel_code_to_app_label(channel_code):
     elif app_label == 'sap':
         app_label = 'sap_success_factors'
     return app_label
+
+
+def get_enterprise_customer_model():
+    """
+    Returns the ``EnterpriseCustomer`` class.
+    """
+    return apps.get_model('enterprise', 'EnterpriseCustomer')
+
+
+def get_enterprise_customer_from_enterprise_enrollment(enrollment_id):
+    """
+    Returns the Django ORM enterprise customer object that is associated with an enterprise enrollment ID
+    """
+    EnterpriseCustomer = get_enterprise_customer_model()
+    try:
+        ec = EnterpriseCustomer.objects.filter(
+            enterprise_customer_users__enterprise_enrollments=enrollment_id
+        ).first()
+        return ec
+    except ObjectDoesNotExist:
+        return None

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -484,6 +484,8 @@ class LearnerDataTransmissionAuditFactory(factory.django.DjangoModelFactory):
         model = LearnerDataTransmissionAudit
 
     enterprise_customer_uuid = factory.LazyAttribute(lambda x: FAKER.uuid4())
+    content_title = factory.LazyAttribute(lambda x: FAKER.word())
+    status = factory.LazyAttribute(lambda x: str(FAKER.random_int(min=1)))
     plugin_configuration_id = factory.LazyAttribute(lambda x: FAKER.pyint())
     enterprise_course_enrollment_id = factory.LazyAttribute(lambda x: FAKER.pyint())
     course_id = factory.LazyAttribute(lambda x: FAKER.slug())
@@ -603,6 +605,7 @@ class SapSuccessFactorsLearnerDataTransmissionAuditFactory(LearnerDataTransmissi
     sapsf_user_id = factory.LazyAttribute(lambda x: FAKER.pyint())
     enterprise_course_enrollment_id = factory.LazyAttribute(lambda x: FAKER.random_int(min=1))
     course_id = factory.LazyAttribute(lambda x: FAKER.slug())
+    user_email = factory.LazyAttribute(lambda x: FAKER.email())
     instructor_name = factory.LazyAttribute(lambda x: FAKER.name())
     grade = factory.LazyAttribute(lambda x: FAKER.bothify('?', letters='ABCDF') + FAKER.bothify('?', letters='+-'))
     status = factory.LazyAttribute(lambda x: FAKER.word())


### PR DESCRIPTION
Jira ticket: https://2u-internal.atlassian.net/browse/ENT-6459

work included:
- django admin views for all channels' learner data transmission audits
- read only field updates (including api_record fields on content metadata transmission audits)
- populating user_email for each individual channel's transmission audit during the learner data export
- made fields returned by learner data transmission audit API a need to need basis

![image](https://user-images.githubusercontent.com/67655836/198355519-a9d67dc6-34c7-4e79-b9f3-8f6cf93c72f7.png)


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
