### PR TITLE
chore: fixing api view that included unneeded values

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.58.4]
+--------
+chore: fixing api view that included unneeded values
+
 [3.58.3]
 --------
 feat: transmission audit admin view and api improvements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.58.3"
+__version__ = "3.58.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/api/v1/logs/serializers.py
+++ b/integrated_channels/api/v1/logs/serializers.py
@@ -96,9 +96,9 @@ class LearnerSyncStatusSerializer(serializers.ModelSerializer):
         return obj.modified or obj.created
 
     @classmethod
-    def get_class_by_channel_code(this_cls, channel_code):
+    def get_completion_class_by_channel_code(this_cls, channel_code):
         """
-        return the `LearnerDataTransmissionAudit` sync-status serializer for a particular channel_code
+        return the `LearnerDataTransmissionAudit` completion related sync-status serializer for a particular channel_code
         """
         app_label = channel_code_to_app_label(channel_code)
         for a_cls in this_cls.__subclasses__():
@@ -114,7 +114,7 @@ class GenericLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = GenericLearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class BlackboardLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -124,7 +124,7 @@ class BlackboardLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = BlackboardLearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class CanvasLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -134,7 +134,7 @@ class CanvasLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = CanvasLearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class CornerstoneLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -144,7 +144,7 @@ class CornerstoneLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = CornerstoneLearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class DegreedLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -154,6 +154,7 @@ class DegreedLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = DegreedLearnerDataTransmissionAudit
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class Degreed2LearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -163,7 +164,7 @@ class Degreed2LearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = Degreed2LearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class MoodleLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -173,7 +174,7 @@ class MoodleLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = MoodleLearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields
 
 
 class SapLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
@@ -183,4 +184,4 @@ class SapLearnerSyncStatusSerializer(LearnerSyncStatusSerializer):
 
     class Meta:
         model = SapSuccessFactorsLearnerDataTransmissionAudit
-        fields = "__all__"
+        fields = LearnerSyncStatusSerializer.Meta.fields

--- a/integrated_channels/api/v1/logs/views.py
+++ b/integrated_channels/api/v1/logs/views.py
@@ -62,7 +62,7 @@ class LearnerSyncStatusViewSet(PermissionRequiredForIntegratedChannelMixin, view
 
     def get_serializer_class(self):
         integrated_channel_code = self.kwargs.get('integrated_channel_code', None)
-        serializer = LearnerSyncStatusSerializer.get_class_by_channel_code(integrated_channel_code)
+        serializer = LearnerSyncStatusSerializer.get_completion_class_by_channel_code(integrated_channel_code)
         if serializer is None:
             raise exceptions.ParseError("Invalid channel code.")
         return serializer
@@ -71,7 +71,7 @@ class LearnerSyncStatusViewSet(PermissionRequiredForIntegratedChannelMixin, view
         enterprise_customer_uuid = self.kwargs.get('enterprise_customer_uuid', None)
         integrated_channel_code = self.kwargs.get('integrated_channel_code', None)
         plugin_configuration_id = self.kwargs.get('plugin_configuration_id', None)
-        ThisLearnerClass = LearnerDataTransmissionAudit.get_class_by_channel_code(integrated_channel_code)
+        ThisLearnerClass = LearnerDataTransmissionAudit.get_completion_class_by_channel_code(integrated_channel_code)
         if ThisLearnerClass is None:
             raise exceptions.ParseError("Invalid channel code.")
 

--- a/integrated_channels/blackboard/models.py
+++ b/integrated_channels/blackboard/models.py
@@ -301,6 +301,13 @@ class BlackboardLearnerAssessmentDataTransmissionAudit(LearnerDataTransmissionAu
             subsection_name=self.subsection_name,
         )
 
+    @classmethod
+    def audit_type(cls):
+        """
+        Assessment level audit type labeling
+        """
+        return "assessment"
+
 
 class BlackboardLearnerDataTransmissionAudit(LearnerDataTransmissionAudit):
     """

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -5,10 +5,7 @@ Admin integration for configuring Canvas app to communicate with Canvas systems.
 from django.contrib import admin
 from django.utils.html import format_html
 
-from integrated_channels.canvas.models import (
-    CanvasEnterpriseCustomerConfiguration,
-    CanvasLearnerAssessmentDataTransmissionAudit,
-)
+from integrated_channels.canvas.models import CanvasEnterpriseCustomerConfiguration, CanvasLearnerDataTransmissionAudit
 from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
 
 
@@ -66,10 +63,10 @@ class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
             return None
 
 
-@admin.register(CanvasLearnerAssessmentDataTransmissionAudit)
-class CanvasLearnerAssessmentDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
+@admin.register(CanvasLearnerDataTransmissionAudit)
+class CanvasLearnerDataTransmissionAuditAdmin(BaseLearnerDataTransmissionAuditAdmin):
     """
-    Django admin model for CanvasLearnerAssessmentDataTransmissionAudit.
+    Django admin model for CanvasLearnerDataTransmissionAudit.
     """
     list_display = (
         "enterprise_course_enrollment_id",
@@ -88,4 +85,4 @@ class CanvasLearnerAssessmentDataTransmissionAuditAdmin(BaseLearnerDataTransmiss
     list_per_page = 1000
 
     class Meta:
-        model = CanvasLearnerAssessmentDataTransmissionAudit
+        model = CanvasLearnerDataTransmissionAudit

--- a/integrated_channels/canvas/models.py
+++ b/integrated_channels/canvas/models.py
@@ -251,6 +251,13 @@ class CanvasLearnerAssessmentDataTransmissionAudit(LearnerDataTransmissionAudit)
             subsection_name=self.subsection_name,
         )
 
+    @classmethod
+    def audit_type(cls):
+        """
+        Assessment level audit type labeling
+        """
+        return "assessment"
+
 
 class CanvasLearnerDataTransmissionAudit(LearnerDataTransmissionAudit):
     """

--- a/integrated_channels/integrated_channel/models.py
+++ b/integrated_channels/integrated_channel/models.py
@@ -373,13 +373,21 @@ class LearnerDataTransmissionAudit(TimeStampedModel):
         return None
 
     @classmethod
-    def get_class_by_channel_code(cls, channel_code):
+    def audit_type(cls):
         """
-        Return the `LearnerDataTransmissionAudit` implementation for the particular channel_code, or None
+        The base learner data transmission audit type - defaults to `completion`
+        """
+        return "completion"
+
+    @classmethod
+    def get_completion_class_by_channel_code(cls, channel_code):
+        """
+        Return the `LearnerDataTransmissionAudit` implementation related to completion reporting for
+        the particular channel_code, or None
         """
         app_label = channel_code_to_app_label(channel_code)
         for a_cls in cls.__subclasses__():
-            if a_cls._meta.app_label == app_label:
+            if a_cls._meta.app_label == app_label and a_cls.audit_type() == "completion":
                 return a_cls
         return None
 

--- a/tests/test_integrated_channels/test_api/test_logs/test_views.py
+++ b/tests/test_integrated_channels/test_api/test_logs/test_views.py
@@ -126,6 +126,28 @@ class LearnerSyncStatusViewSetTests(APITest):
         self.create_user(username=client_username, password=TEST_PASSWORD, is_staff=is_staff)
         self.client.login(username=client_username, password=TEST_PASSWORD)
 
+    def test_get_excludes_unneeded_fields(self):
+        """
+        tests a a get request will not return unneeded fields
+        """
+        self.setup_admin_user(True)
+        url = reverse(
+            'api:v1:logs:learner_sync_status_logs',
+            kwargs={
+                'enterprise_customer_uuid': self.generic_audit_1.enterprise_customer_uuid,
+                'integrated_channel_code': 'GENERIC',
+                'plugin_configuration_id': self.generic_audit_1.plugin_configuration_id
+            }
+        )
+        response = self.client.get(url)
+        LOGGER.info(response.content)
+        response_json = self.load_json(response.content)
+
+        # check that it excludes expected data
+        assert "course_completed" not in response_json['results'][0].keys()
+        assert "instructor_name" not in response_json['results'][0].keys()
+        assert "course_id" not in response_json['results'][0].keys()
+
     def test_get(self):
         """
         tests a regular get with expected data


### PR DESCRIPTION
Accidentally left in unneeded values from the api view

screenshot to verify that I got it right this time 🙃 
![image](https://user-images.githubusercontent.com/67655836/198734036-e226881f-6908-4190-926b-eed6754ab5db.png)
 

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
