### PR TITLE
fix: Enterprise Coupons require comm worker to be a universal ent operator

### DIFF
--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -306,6 +306,11 @@ class Command(BaseCommand):
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
+            self._create_enterprise_user(
+                username='ecommerce_worker',
+                role=ENTERPRISE_OPERATOR_ROLE,
+                applies_to_all_contexts=True,
+            ),
         ]
         # Add a couple more learners!
         for i in range(2):


### PR DESCRIPTION
* fix: Updating `seed_enterprise_devstack_data` Django Admin command to include `ecommerce_worker` in its list of service workers.
