### PR TITLE
fix: catch update transmissions that failed and need to be resent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.58.15]
+---------
+fix: catch update transmissions that failed and need to be resent
+
 [3.58.14]
 ---------
 feat: Add health check for canvas integrated channels

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.58.14"
+__version__ = "3.58.15"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -121,7 +121,7 @@ class ContentMetadataExporter(Exporter):
         force_retrieve_all_catalogs
     ):
         """
-        Take a list of content keys and their respective last updated time and build an mapping between content keys and
+        Take a list of content keys and their respective last updated time and build a mapping between content keys and
         past content metadata transmission record when the last updated time comes after the last updated time of the
         record.
 
@@ -168,11 +168,12 @@ class ContentMetadataExporter(Exporter):
                 )
                 # If not force_retrieve_all_catalogs, filter content records where `content last changed` is less than
                 # the matched item's `date_updated`, otherwise select the row regardless of what the updated at time is.
-                last_changed_query = Q(content_last_changed__lt=content_last_changed)
-                last_changed_query.add(Q(content_last_changed__isnull=True), Q.OR)
                 if not force_retrieve_all_catalogs:
-                    content_query.add(last_changed_query, Q.AND)
-
+                    last_changed_query = Q(content_last_changed__lt=content_last_changed)
+                    last_changed_query.add(Q(content_last_changed__isnull=True), Q.OR)
+                    get_marked_for = Q(marked_for='update')
+                    get_marked_for.add(last_changed_query, Q.OR)
+                    content_query.add(get_marked_for, Q.AND)
                 items_to_update_query = ContentMetadataItemTransmission.objects.filter(content_query)
                 item = items_to_update_query.first()
                 if item:

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -205,6 +205,7 @@ class ContentMetadataTransmitter(Transmitter):
                     elif action_name == 'delete':
                         transmission.remote_deleted_at = action_happened_at
                     transmission.save()
-                    transmission.remove_marked_for()
+                    if transmission.api_response_status_code < 300:
+                        transmission.remove_marked_for()
                     results.append(transmission)
         return results


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
