### PR TITLE
fix: fixed a bug that didn't allow admins to create an account or update password

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.58.17]
+---------
+fix: fixed a bug that didn't allow admins to create an account or update password
+
 [3.58.16]
 ---------
 fix: fix bug that didn't allow admins to customize branding
@@ -31,7 +35,7 @@ feat: Add health check for canvas integrated channels
 
 [3.58.13]
 ---------
-feat: Add in learner and content sync time records to integrated channel configs 
+feat: Add in learner and content sync time records to integrated channel configs
 
 [3.58.12]
 ---------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.58.16"
+__version__ = "3.58.17"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/__init__.py
+++ b/enterprise/api/__init__.py
@@ -3,7 +3,6 @@ Python API for various enterprise functionality.
 """
 from enterprise import roles_api
 from enterprise.models import PendingEnterpriseCustomerAdminUser
-from enterprise.utils import create_tableau_user, delete_tableau_user
 
 
 def activate_admin_permissions(enterprise_customer_user):
@@ -28,25 +27,18 @@ def activate_admin_permissions(enterprise_customer_user):
         return  # this is ok, nothing to do
 
     if not enterprise_customer_user.linked:
-        # EnterpriseCustomerUser is no longer linked, so delete the "enterprise_admin" role and
-        # their Tableau user.
+        # EnterpriseCustomerUser is no longer linked, so delete the "enterprise_admin" role.
         # TODO: ENT-3914 | Add `enterprise_customer=enterprise_customer_user.enterprise_customer`
         # kwarg so that we delete at most a single assignment instance.
         roles_api.delete_admin_role_assignment(
             enterprise_customer_user.user,
         )
-        delete_tableau_user(enterprise_customer_user)
         return  # nothing left to do
 
     roles_api.assign_admin_role(
         enterprise_customer_user.user,
         enterprise_customer=enterprise_customer_user.enterprise_customer
     )
-
-    # Also create the Enterprise admin user in third-party analytics application with the enterprise
-    # customer uuid as username.
-    tableau_username = str(enterprise_customer_user.enterprise_customer.uuid).replace('-', '')
-    create_tableau_user(tableau_username, enterprise_customer_user)
 
     # delete the PendingEnterpriseCustomerAdminUser record
     pending_admin_user.delete()

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -178,8 +178,7 @@ class TestUserPostSaveSignalHandler(EmptyCacheMixin, unittest.TestCase):
         )
         mock_track_enrollment.assert_called_once_with('pending-admin-enrollment', user.id, course_id)
 
-    @mock.patch('enterprise.api.create_tableau_user')
-    def test_handle_user_post_save_with_pending_enterprise_admin(self, mock_create_tableau_user):
+    def test_handle_user_post_save_with_pending_enterprise_admin(self):
         email = "jackie.chan@hollywood.com"
         user = UserFactory(id=1, email=email)
         enterprise_customer = EnterpriseCustomerFactory()
@@ -194,19 +193,12 @@ class TestUserPostSaveSignalHandler(EmptyCacheMixin, unittest.TestCase):
         assert EnterpriseCustomerUser.objects.filter(user_id=user.id).count() == 1, \
             "Precondition check: enterprise customer user exists"
 
-        enterprise_customer_user = EnterpriseCustomerUser.objects.get(user_id=user.id)
-
         enterprise_admin_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=ENTERPRISE_ADMIN_ROLE)
         admin_role_assignment = SystemWideEnterpriseUserRoleAssignment.objects.filter(
             user=user,
             role=enterprise_admin_role,
         )
         assert admin_role_assignment.exists()
-
-        mock_create_tableau_user.assert_called_once_with(
-            str(enterprise_customer.uuid).replace('-', ''),
-            enterprise_customer_user,
-        )
 
         assert PendingEnterpriseCustomerAdminUser.objects.filter(user_email=email).count() == 0, \
             "Final check: pending admin user no longer exists"
@@ -399,11 +391,7 @@ class TestEnterpriseAdminRoleSignals(unittest.TestCase):
         self.enterprise_customer = EnterpriseCustomerFactory()
         super().setUp()
 
-    @mock.patch('enterprise.api.create_tableau_user')
-    def test_delete_enterprise_admin_role_assignment_success(
-            self,
-            mock_create_tableau_user,  # pylint: disable=unused-argument
-    ):
+    def test_delete_enterprise_admin_role_assignment_success(self):
         """
         Test that when `EnterpriseCustomerUser` record is deleted, the associated
         enterprise admin user role assignment is also deleted.


### PR DESCRIPTION
__Jira Ticket:__ [ENT-6518](https://2u-internal.atlassian.net/browse/ENT-6518)

__Description:__
This PR removed tableau related code to fix a bug that was causing issues in the registration process of enterprise admins.


**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
