### PR TITLE
fix: failed content deletes and creates are never retried

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Nothing
 
 
+[3.60.8]
+--------
+fix: failed content deletes and creates are never retried
+
 [3.60.7]
 --------
 fix: cleaning up serializer field inheritance

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.60.7"
+__version__ = "3.60.8"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -111,6 +111,7 @@ class ContentMetadataExporter(Exporter):
             remote_deleted_at__isnull=True,
             remote_created_at__isnull=False,
         )
+        # enterprise_customer_catalog filter is optional
         if enterprise_customer_catalog is not None:
             base_content_query.add(Q(enterprise_customer_catalog_uuid=enterprise_customer_catalog.uuid), Q.AND)
         # api_response_status_code can be null, treat that as successful, otherwise look for less than http 400
@@ -124,9 +125,11 @@ class ContentMetadataExporter(Exporter):
             remote_deleted_at__isnull=False,
             api_response_status_code__gte=400
         )
+        # enterprise_customer_catalog filter is optional
         if enterprise_customer_catalog is not None:
             failed_deletes_content_query.add(Q(enterprise_customer_catalog_uuid=enterprise_customer_catalog.uuid), Q.AND)
 
+        # base query OR failed delete query
         final_content_query = Q(base_content_query | failed_deletes_content_query);
 
         past_transmissions = ContentMetadataItemTransmission.objects.filter(

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -10,7 +10,7 @@ import sys
 from logging import getLogger
 
 from django.apps import apps
-from django.db.models import IntegerField, F, Q, Case, Value, When
+from django.db.models import Case, F, IntegerField, Q, Value, When
 
 from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise.constants import EXEC_ED_CONTENT_DESCRIPTION_TAG, EXEC_ED_COURSE_TYPE, TRANSMISSION_MARK_CREATE

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -10,7 +10,7 @@ import sys
 from logging import getLogger
 
 from django.apps import apps
-from django.db.models import Q
+from django.db.models import IntegerField, F, Q, Case, Value, When
 
 from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise.constants import EXEC_ED_CONTENT_DESCRIPTION_TAG, EXEC_ED_COURSE_TYPE, TRANSMISSION_MARK_CREATE
@@ -94,7 +94,7 @@ class ContentMetadataExporter(Exporter):
             )
         )
 
-    def _get_catalog_content_keys(self, enterprise_customer_catalog):
+    def _get_catalog_content_keys(self, enterprise_customer_catalog=None):
         """
         Retrieve all non-deleted content transmissions under a given customer's catalog
         """
@@ -102,13 +102,35 @@ class ContentMetadataExporter(Exporter):
             'integrated_channel',
             'ContentMetadataItemTransmission'
         )
-        past_transmissions = ContentMetadataItemTransmission.objects.filter(
+
+        # created, not deleted, no error code
+        base_content_query = Q(
             enterprise_customer=self.enterprise_configuration.enterprise_customer,
             integrated_channel_code=self.enterprise_configuration.channel_code(),
-            enterprise_customer_catalog_uuid=enterprise_customer_catalog.uuid,
             plugin_configuration_id=self.enterprise_configuration.id,
             remote_deleted_at__isnull=True,
             remote_created_at__isnull=False,
+        )
+        if enterprise_customer_catalog is not None:
+            base_content_query.add(Q(enterprise_customer_catalog_uuid=enterprise_customer_catalog.uuid), Q.AND)
+        # api_response_status_code can be null, treat that as successful, otherwise look for less than http 400
+        base_content_query.add(Q(api_response_status_code__isnull=True) | Q(api_response_status_code__lt=400), Q.AND)
+
+        # deleted regardless of create, with a failed status
+        failed_deletes_content_query = Q(
+            enterprise_customer=self.enterprise_configuration.enterprise_customer,
+            integrated_channel_code=self.enterprise_configuration.channel_code(),
+            plugin_configuration_id=self.enterprise_configuration.id,
+            remote_deleted_at__isnull=False,
+            api_response_status_code__gte=400
+        )
+        if enterprise_customer_catalog is not None:
+            failed_deletes_content_query.add(Q(enterprise_customer_catalog_uuid=enterprise_customer_catalog.uuid), Q.AND)
+
+        final_content_query = Q(base_content_query | failed_deletes_content_query);
+
+        past_transmissions = ContentMetadataItemTransmission.objects.filter(
+            final_content_query
         ).values('content_id')
         if not past_transmissions:
             return []
@@ -272,13 +294,7 @@ class ContentMetadataExporter(Exporter):
             'ContentMetadataItemTransmission'
         )
         # Fetch all existing, non-deleted transmission audit content keys for the customer/configuration
-        existing_content_keys = ContentMetadataItemTransmission.objects.filter(
-            enterprise_customer=self.enterprise_configuration.enterprise_customer,
-            integrated_channel_code=self.enterprise_configuration.channel_code(),
-            plugin_configuration_id=self.enterprise_configuration.id,
-            remote_deleted_at__isnull=True,
-            remote_created_at__isnull=False,
-        ).values_list("content_id", flat=True)
+        existing_content_keys = set(self._get_catalog_content_keys())
         unique_new_items_to_create = []
 
         # We need to remove any potential create transmissions if the content already exists on the customer's instance

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -431,7 +431,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         Test the _get_catalog_content_keys function when the transmission has successful deletes.
         """
-        past_transmission_one = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -440,7 +440,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             remote_created_at=datetime.datetime.utcnow(),
             remote_updated_at=datetime.datetime.utcnow(),
         )
-        past_transmission_two = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -449,7 +449,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             remote_created_at=datetime.datetime.utcnow(),
             remote_updated_at=datetime.datetime.utcnow(),
         )
-        past_transmission_successful_delete = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -471,7 +471,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         Test the _get_catalog_content_keys function when the transmission has failed deletes.
         """
-        past_transmission_one = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -480,7 +480,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             remote_created_at=datetime.datetime.utcnow(),
             remote_updated_at=datetime.datetime.utcnow(),
         )
-        past_transmission_two = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -489,7 +489,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             remote_created_at=datetime.datetime.utcnow(),
             remote_updated_at=datetime.datetime.utcnow(),
         )
-        past_transmission_failed_delete = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -511,7 +511,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         Test the _get_catalog_content_keys function when the transmission has failed deletes.
         """
-        past_transmission_one = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -520,7 +520,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             remote_created_at=datetime.datetime.utcnow(),
             remote_updated_at=datetime.datetime.utcnow(),
         )
-        past_transmission_two = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),
@@ -529,7 +529,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             remote_created_at=datetime.datetime.utcnow(),
             remote_updated_at=datetime.datetime.utcnow(),
         )
-        past_transmission_failed_create = factories.ContentMetadataItemTransmissionFactory(
+        factories.ContentMetadataItemTransmissionFactory(
             enterprise_customer=self.config.enterprise_customer,
             plugin_configuration_id=self.config.id,
             integrated_channel_code=self.config.channel_code(),

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -426,3 +426,121 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             False
         )
         assert len(matched_records) == 2
+
+    def test__get_catalog_content_keys_with_deletes(self):
+        """
+        Test the _get_catalog_content_keys function when the transmission has successful deletes.
+        """
+        past_transmission_one = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed=datetime.datetime.now(),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_two = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed='2020-07-16T15:11:10.521611Z',
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_successful_delete = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed=datetime.datetime.now(),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+            remote_deleted_at=datetime.datetime.utcnow(),
+            api_response_status_code=200,
+        )
+        exporter = ContentMetadataExporter('fake-user', self.config)
+        # pylint: disable=protected-access
+        matched_records = exporter._get_catalog_content_keys(
+            self.config.enterprise_customer.enterprise_customer_catalogs.first(),
+        )
+        assert len(matched_records) == 2
+
+    def test__get_catalog_content_keys_failed_deletes(self):
+        """
+        Test the _get_catalog_content_keys function when the transmission has failed deletes.
+        """
+        past_transmission_one = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed=datetime.datetime.now(),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_two = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed='2020-07-16T15:11:10.521611Z',
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_failed_delete = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed=datetime.datetime.now(),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+            remote_deleted_at=datetime.datetime.utcnow(),
+            api_response_status_code=500,
+        )
+        exporter = ContentMetadataExporter('fake-user', self.config)
+        # pylint: disable=protected-access
+        matched_records = exporter._get_catalog_content_keys(
+            self.config.enterprise_customer.enterprise_customer_catalogs.first(),
+        )
+        assert len(matched_records) == 3
+
+    def test__get_catalog_content_keys_failed_creates(self):
+        """
+        Test the _get_catalog_content_keys function when the transmission has failed deletes.
+        """
+        past_transmission_one = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed=datetime.datetime.now(),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_two = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed='2020-07-16T15:11:10.521611Z',
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            remote_updated_at=datetime.datetime.utcnow(),
+        )
+        past_transmission_failed_create = factories.ContentMetadataItemTransmissionFactory(
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=self.config.id,
+            integrated_channel_code=self.config.channel_code(),
+            content_last_changed=datetime.datetime.now(),
+            enterprise_customer_catalog_uuid=self.config.enterprise_customer.enterprise_customer_catalogs.first().uuid,
+            remote_created_at=datetime.datetime.utcnow(),
+            api_response_status_code=500,
+        )
+        exporter = ContentMetadataExporter('fake-user', self.config)
+        # pylint: disable=protected-access
+        matched_records = exporter._get_catalog_content_keys(
+            self.config.enterprise_customer.enterprise_customer_catalogs.first(),
+        )
+        assert len(matched_records) == 2


### PR DESCRIPTION
## Description

- fix for https://2u-internal.atlassian.net/browse/ENT-6448
- we were not properly accounting for failed creates or failed deletes
- added tests to cover ticket cases
- DRY'ed up a query by making function more flexible via optional args