### PR TITLE
fix: handle file compression check and test

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.60.13]
+---------
+fix: handle file compression check and test
+
 [3.60.12]
 ---------
 feat: adding last modified timestamp to single LMS config endpoints

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.60.12"
+__version__ = "3.60.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -27,6 +27,7 @@ from enterprise.models import (
     AdminNotification,
     AdminNotificationRead,
     EnterpriseCustomerIdentityProvider,
+    EnterpriseCustomerReportingConfiguration,
     EnterpriseCustomerUser,
     SystemWideEnterpriseUserRoleAssignment,
 )
@@ -831,6 +832,14 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
         return value
 
     def validate(self, data):  # pylint: disable=arguments-renamed
+        error = EnterpriseCustomerReportingConfiguration.validate_compression(
+            data.get('enable_compression'),
+            data.get('data_type'),
+            data.get('delivery_method')
+        )
+        if error:
+            raise serializers.ValidationError(error)
+
         delivery_method = data.get('delivery_method')
         if not delivery_method and self.instance:
             delivery_method = self.instance.delivery_method

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -305,6 +305,7 @@ class TestEnterpriseCustomerReportingConfigurationSerializer(APITest):
         self.data = {
             "enterprise_customer_id": self.enterprise_customer.uuid,
             "active": True,
+            "enable_compression": True,
             "delivery_method": "email",
             "email": ['test@example.com'],
             "frequency": 'daily',
@@ -337,3 +338,14 @@ class TestEnterpriseCustomerReportingConfigurationSerializer(APITest):
         self.data['pgp_encryption_key'] = 'invalid-key'
         serializer = EnterpriseCustomerReportingConfigurationSerializer(data=self.data)
         assert not serializer.is_valid()
+
+        # Valid Compression check should be flagged.
+        self.data['enable_compression'] = False
+        self.data['pgp_encryption_key'] = TEST_PGP_KEY
+        serializer = EnterpriseCustomerReportingConfigurationSerializer(data=self.data)
+        assert not serializer.is_valid()
+        error_message = serializer.errors.get('enable_compression')
+        self.assertEqual(
+            str(error_message[0]),
+            'Compression can only be disabled for the following data types: catalog and delivery method: sftp'
+        )

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4203,6 +4203,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         post_data = {
             'active': 'true',
+            'enable_compression': True,
             'delivery_method': 'email',
             'email': ['test@test.com', 'foo@test.com'],
             'encrypted_password': 'testPassword',
@@ -4259,6 +4260,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         post_data = {
             'active': 'true',
+            'enable_compression': True,
             'delivery_method': 'email',
             'email': ['test@test.com', 'foo@test.com'],
             'encrypted_password': 'testPassword',
@@ -4321,6 +4323,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         user, enterprise_customer = self._create_user_and_enterprise_customer('test_user', 'test_password')
         model_item = {
             'active': True,
+            'enable_compression': True,
             'delivery_method': 'email',
             'day_of_month': 1,
             'day_of_week': None,
@@ -4336,6 +4339,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         put_data = {
             'enterprise_customer_id': str(enterprise_customer.uuid),
             'active': 'true',
+            'enable_compression': True,
             'delivery_method': 'email',
             'email': ['test@test.com', 'foo@test.com'],
             'encrypted_password': 'passwordUpdate',
@@ -4402,6 +4406,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         user, enterprise_customer = self._create_user_and_enterprise_customer('test_user', 'test_password')
         model_item = {
             'active': True,
+            'enable_compression': True,
             'delivery_method': 'email',
             'day_of_month': 1,
             'day_of_week': None,
@@ -4419,6 +4424,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
             'day_of_month': 4,
             'day_of_week': 1,
             'hour_of_day': 12,
+            'enable_compression': True,
         }
         expected_data = patch_data.copy()
         expected_data.pop('enterprise_customer_id')
@@ -4480,6 +4486,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         post_data = {
             'active': 'true',
+            'enable_compression': 'true',
             'delivery_method': 'email',
             'encrypted_password': 'testPassword',
             'frequency': 'monthly',
@@ -4527,6 +4534,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         post_data = {
             'active': 'true',
+            'enable_compression': 'true',
             'delivery_method': 'sftp',
             'encrypted_password': 'testPassword',
             'frequency': 'monthly',
@@ -4569,6 +4577,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         user, enterprise_customer = self._create_user_and_enterprise_customer('test_user', 'test_password')
         model_item = {
             'active': True,
+            'enable_compression': True,
             'delivery_method': 'email',
             'day_of_month': 1,
             'day_of_week': None,
@@ -4620,6 +4629,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         post_data = {
             'active': 'true',
+            'enable_compression': 'true',
             'delivery_method': 'email',
             'encrypted_password': 'testPassword',
             'frequency': 'monthly',
@@ -4672,6 +4682,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
 
         post_data = {
             'active': 'true',
+            'enable_compression': 'true',
             'delivery_method': 'email',
             'encrypted_password': 'testPassword',
             'frequency': 'monthly',
@@ -4721,6 +4732,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         user, enterprise_customer = self._create_user_and_enterprise_customer('test_user', 'test_password')
         model_item = {
             'active': True,
+            'enable_compression': True,
             'delivery_method': 'email',
             'day_of_month': 1,
             'day_of_week': None,
@@ -4749,6 +4761,7 @@ class TestEnterpriseReportingConfigAPIViews(APITest):
         patch_data = {
             'enterprise_customer_id': str(enterprise_customer.uuid),
             'day_of_month': 4,
+            'enable_compression': True,
             'day_of_week': 1,
             'hour_of_day': 12,
             'enterprise_customer_catalog_uuids': [enterprise_catalog_2.uuid]


### PR DESCRIPTION
**Description**
Add file compression option on Reporting Form of frontend-admin-panel. Initially, that option was only enabled by the Django admin, not from the user request that came from the admin panel. But now users will be able to Enable compression from UI.

I apply validations on enable_compression by making a static function of compression_validation in models and using it in the serializer to make it secure.

Here is the picture of adding a button on the UI.

![image](https://user-images.githubusercontent.com/86868918/211327505-f53faed7-d5bb-4102-96c4-8d5a8108b17d.png)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
