### PR TITLE
fix: integrations log TypeErrors

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.60.11]
+---------
+fix: integrations log TypeErrors
+
 [3.60.10]
 ---------
 fix: making moodle client return value match other channels

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.60.10"
+__version__ = "3.60.11"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -5,7 +5,6 @@ Generic content metadata transmitter for integrated channels.
 import functools
 import json
 import logging
-from datetime import datetime
 from itertools import islice
 
 import requests

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -13,6 +13,7 @@ import requests
 from django.apps import apps
 from django.conf import settings
 
+from enterprise.utils import localized_utcnow
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.client import IntegratedChannelApiClient
 from integrated_channels.integrated_channel.transmitters import Transmitter
@@ -177,7 +178,7 @@ class ContentMetadataTransmitter(Transmitter):
                     f"Task failed with message [{response_body}]"
                 )
             finally:
-                action_happened_at = datetime.utcnow()
+                action_happened_at = localized_utcnow()
                 for content_id, transmission in chunk.items():
                     self._log_info(
                         f'integrated_channel_content_transmission_id={transmission.id}, '

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -8,6 +8,7 @@ from http import HTTPStatus
 
 from django.apps import apps
 
+from enterprise.utils import localized_utcnow
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.channel_settings import ChannelSettingsMixin
 from integrated_channels.integrated_channel.client import IntegratedChannelApiClient
@@ -390,7 +391,7 @@ class LearnerTransmitter(Transmitter, ChannelSettingsMixin):
                 )
                 raise
 
-            action_happened_at = datetime.utcnow()
+            action_happened_at = localized_utcnow()
             was_successful = code < 300
             learner_data.status = str(code)
             learner_data.error_message = body if not was_successful else ''

--- a/integrated_channels/integrated_channel/transmitters/learner_data.py
+++ b/integrated_channels/integrated_channel/transmitters/learner_data.py
@@ -3,7 +3,6 @@ Generic learner data transmitter for integrated channels.
 """
 
 import logging
-from datetime import datetime
 from http import HTTPStatus
 
 from django.apps import apps


### PR DESCRIPTION
## Description

- seeing errors in the integration logs `TypeError: can't compare offset-naive and offset-aware datetimes`
- `datetime.utcnow()` does not produce a timezone-aware datetime and needed to be swapped for a datetime aware one
- https://2u-internal.atlassian.net/browse/ENT-6661