### PR TITLE
fix: applied validatoins on report delivery_method

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.60.19]
+---------
+fix: applied validatoins on report delivery_method
+
 [3.60.18]
 ---------
 fix: checking for response attr in http exception handling

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.60.18"
+__version__ = "3.60.19"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -627,6 +627,16 @@ class EnterpriseCustomerReportingConfigAdminForm(forms.ModelForm):
             )
             self.add_error('enterprise_customer_catalogs', message)
 
+        # Check delivery_method validity while updating report
+        create_report = self.instance.pk is not None
+        if create_report:
+            error = (self.instance.validate_delivery_method(
+                self.instance.uuid,
+                cleaned_data.get('delivery_method')
+            ))
+            if error:
+                self.add_error('delivery_method', error.get('delivery_method'))
+
 
 class TransmitEnterpriseCoursesForm(forms.Form):
     """

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -841,6 +841,15 @@ class EnterpriseCustomerReportingConfigurationSerializer(serializers.ModelSerial
             raise serializers.ValidationError(error)
 
         delivery_method = data.get('delivery_method')
+        create_report = data.get('uuid') is not None
+        if create_report:
+            delivery_method_error = self.instance.validate_delivery_method(
+                data.get('uuid'),
+                delivery_method
+            )
+            if delivery_method_error:
+                raise serializers.ValidationError(delivery_method_error)
+
         if not delivery_method and self.instance:
             delivery_method = self.instance.delivery_method
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -2757,6 +2757,23 @@ class EnterpriseCustomerReportingConfiguration(TimeStampedModel):
             return {'enable_compression': error_message}
         return {}
 
+    def validate_delivery_method(self, create_report, delivery_method):
+        """
+        Check delivery_method is changed or not while updating report
+
+        Arguments:
+            create_report (str): report uuid
+            delivery_method (str): selected delivery method
+
+        Returns:
+            (dict): Validation Error
+        """
+        if create_report:
+            if self.delivery_method != delivery_method:
+                error_message = _('Delivery method cannot be updated')
+                return {'delivery_method': error_message}
+        return {}
+
     def clean(self):
         """
         Override of clean method to perform additional validation on frequency, day_of_month/day_of week

--- a/tests/test_admin/test_forms.py
+++ b/tests/test_admin/test_forms.py
@@ -26,7 +26,7 @@ from enterprise.admin.forms import (
 from enterprise.admin.utils import ValidationMessages
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE
 from enterprise.models import EnterpriseCustomer, EnterpriseCustomerReportingConfiguration, SystemWideEnterpriseRole
-from test_utils import TEST_PGP_KEY, fake_enrollment_api
+from test_utils import TEST_PGP_KEY, factories, fake_enrollment_api
 from test_utils.factories import (
     AdminNotificationFactory,
     EnterpriseCatalogQueryFactory,
@@ -711,6 +711,37 @@ class TestEnterpriseCustomerReportingConfigAdminForm(unittest.TestCase):
             'decrypted_password': 'password',
             'enable_compression': True,
         }
+
+    def test_form_valid_delivery_method(self):
+        """
+        Test clean method on form that check delivery method validity
+        """
+        enterprise_customer = factories.EnterpriseCustomerFactory(name="GriffCo")
+        config = EnterpriseCustomerReportingConfiguration.objects.create(
+            enterprise_customer=enterprise_customer,
+            active=True,
+            delivery_method='email',
+            email='test@edx.org',
+            decrypted_password='test_password',
+            day_of_month=1,
+            hour_of_day=1,
+        )
+        form_data = self.form_data.copy()
+        form_data['delivery_method'] = 'email'
+        form = EnterpriseCustomerReportingConfigAdminForm(
+            instance=config,
+            data=form_data,
+        )
+        assert form.is_valid()
+
+        form_data = self.form_data.copy()
+        form_data['delivery_method'] = 'sftp'
+        form = EnterpriseCustomerReportingConfigAdminForm(
+            instance=config,
+            data=form_data,
+        )
+
+        assert not form.is_valid()
 
     def test_form_no_catalogs(self):
         """

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -2173,6 +2173,56 @@ class TestEnterpriseCustomerReportingConfiguration(unittest.TestCase):
         except ValidationError as validation_error:
             assert sorted(validation_error.messages) == sorted(expected_errors)
 
+    def test_clean_validate_delivery_method(self):
+        """
+        Test ``EnterpriseCustomerReportingConfiguration`` custom clean function validating delivery method field.
+        """
+        enterprise_customer = factories.EnterpriseCustomerFactory(name="GriffCo")
+        config = EnterpriseCustomerReportingConfiguration.objects.create(
+            enterprise_customer=enterprise_customer,
+            active=True,
+            delivery_method=EnterpriseCustomerReportingConfiguration.DELIVERY_METHOD_EMAIL,
+            email='test@edx.org',
+            decrypted_password='test_password',
+            day_of_month=1,
+            hour_of_day=1,
+        )
+
+        config.delivery_method = EnterpriseCustomerReportingConfiguration.DELIVERY_METHOD_SFTP
+        config.sftp_hostname = 'sftp_hostname'
+        config.sftp_username = 'sftp_username'
+        config.sftp_file_path = 'sftp_file_path'
+        config.decrypted_sftp_password = 'decrypted_sftp_password'
+
+        expected_errors = [
+            'Delivery method cannot be updated',
+        ]
+        try:
+            config.clean()
+        except ValidationError as validation_error:
+            assert sorted(validation_error.messages) == sorted(expected_errors)
+
+    def test_clean_validate_delivery_method_creating(self):
+        """
+        Test ``EnterpriseCustomerReportingConfiguration`` custom clean function for valid delivery method.
+        """
+        enterprise_customer = factories.EnterpriseCustomerFactory(name="GriffCo")
+        config = EnterpriseCustomerReportingConfiguration.objects.create(
+            enterprise_customer=enterprise_customer,
+            active=True,
+            delivery_method=EnterpriseCustomerReportingConfiguration.DELIVERY_METHOD_EMAIL,
+            email='test@edx.org',
+            decrypted_password='test_password',
+            day_of_month=1,
+            hour_of_day=1,
+        )
+        config.email = 'test2@edx.org'
+        expected_errors = []
+        try:
+            config.clean()
+        except ValidationError as validation_error:
+            assert sorted(validation_error.messages) == sorted(expected_errors)
+
     def test_default_data_type(self):
         """
         Test ``EnterpriseCustomerReportingConfiguration`` default data type is 'progress_v3'.


### PR DESCRIPTION
***Description***
when someone creates an EnterpriseCustomerReportingConfiguration (ECRC) using the delivery_method email and tries to update the delivery_method to sftp then sftp password field is not shown on the Django admin form. Due to which 500 error occurred. 
***Solution***
I apply validation on delivery_method is that when someone tries to update this field either from the Django admin or through the front end then a proper message will be thrown to the user that you can not update the delivery_method.

Here is the ticket [ENT-1689](https://2u-internal.atlassian.net/browse/ENT-1689)
…ort in forms

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
