### PR TITLE
fix: grades api backoff and retry logic

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.60.16]
+---------
+fix: adding backoff and retry logic to the grades api client
+
 [3.60.15]
 ---------
 feat: allowing manage learners form enroll learners using exec ed modes

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.60.15"
+__version__ = "3.60.16"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -318,7 +318,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
 
     def _calculate_backoff(self, attempt_count):
         """
-        Calcualte the seconds to sleep based on attempt_count
+        Calculate the seconds to sleep based on attempt_count
         """
         return (self.BACKOFF_FACTOR * (2 ** (attempt_count - 1)))
 

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -767,7 +767,7 @@ def test_get_course_assessment_grades():
     response_body = {'results': [{'username': 'DarthVadar', 'section_breakdown': expected_result}]}
     responses.add(
         responses.GET,
-        _url("course_grades", f"gradebook/{course_id}/?user_contains={username}"),
+        _url("course_grades", f"gradebook/{course_id}/?username={username}"),
         match_querystring=True,
         json=response_body,
     )
@@ -783,7 +783,7 @@ def test_get_course_assessment_grades_not_found():
     course_id = "course-v1:edX+DemoX+Demo_Course"
     responses.add(
         responses.GET,
-        _url("course_grades", f"gradebook/{course_id}/?user_contains={username}"),
+        _url("course_grades", f"gradebook/{course_id}/?username={username}"),
         match_querystring=True,
         json={'results': [{'username': 'another_username'}]}
     )


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-6733

|https://one.newrelic.com/nr1-core/apm-features/transactions/ODgxNzh8QVBNfEFQUExJQ0FUSU9OfDY5MTM3NDQ5Mg?duration=1800000&state=bbea8bd0-d1aa-070f-243c-5787dac8cf64

https://splunk.edx.org/en-US/app/search/search?q=search%20integrated_channels%20learner_data%20NOT%20%22refresh_token%20not%20found%22%20NOT%20%22(edX%20integration)%20Final%20Grade%22%20grades_api&earliest=-7d%40h&latest=now&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1674955713.4242295

Seems like the single learner data transmission task is failing to reach the grades api, receiving a 504. I've added backoff and retry logic that will hopefully lighten the burden on the LMS with multiple simultaneous transmission jobs.
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/edx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/edx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/edx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/edx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/edx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
