### PR TITLE
feat: adding a bulk action to resend cmti deletes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.60.21]
+---------
+feat: django admin bulk action to clear remote_deleted_at on ContentMetadataItemTransmission records
+
 [3.60.20]
 ---------
 fix: changing api client to parse grades api response body

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.60.20"
+__version__ = "3.60.21"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -22,6 +22,10 @@ class BaseLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
         return ent_customer.name if ent_customer else None
 
 
+@admin.action(description='Clear remote_deleted_at on ContentMetadataItemTransmission item(s)')
+def clear_remote_deleted_at(modeladmin, request, queryset):
+    queryset.update(remote_deleted_at=None)
+
 @admin.register(ContentMetadataItemTransmission)
 class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
     """
@@ -50,6 +54,10 @@ class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
         'api_record',
         'api_response_status_code',
         'friendly_status_message',
+    ]
+
+    actions = [
+        clear_remote_deleted_at,
     ]
 
     list_per_page = 1000

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -23,7 +23,7 @@ class BaseLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
 
 
 @admin.action(description='Clear remote_deleted_at on ContentMetadataItemTransmission item(s)')
-def clear_remote_deleted_at(modeladmin, request, queryset):
+def clear_remote_deleted_at(modeladmin, request, queryset):  # pylint: disable=unused-argument
     queryset.update(remote_deleted_at=None)
 
 @admin.register(ContentMetadataItemTransmission)

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -26,6 +26,7 @@ class BaseLearnerDataTransmissionAuditAdmin(admin.ModelAdmin):
 def clear_remote_deleted_at(modeladmin, request, queryset):  # pylint: disable=unused-argument
     queryset.update(remote_deleted_at=None)
 
+
 @admin.register(ContentMetadataItemTransmission)
 class ContentMetadataItemTransmissionAdmin(admin.ModelAdmin):
     """


### PR DESCRIPTION
## Description

Adding a Django Admin action which will let us (in bulk) clear the `remote_deleted_at` timestamp of `ContentMetadataTransmissionItem` records - which should mark them to be re-deleted on the next Integrated Channels transmission job run.


## Tested locally

![Screenshot 2023-02-07 at 2 33 57 PM](https://user-images.githubusercontent.com/31442/217346979-e5bb19d4-1ac4-43d9-9ed0-7ffb64435721.png)


## References

- https://2u-internal.atlassian.net/browse/ENT-6708
- https://2u-internal.atlassian.net/browse/ENT-6719
- https://docs.djangoproject.com/en/4.1/ref/contrib/admin/actions/