### PR TITLE
fix: check against an updated settings.DEFAULT_FILE_STORAGE to determine if in stage/prod environment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.61.5]
+--------
+fix: Ensure `EnterpriseCustomerBrandingConfigurationSerializer` returns correct logo URL on stage/production after `settings.DEFAULT_FILE_STORAGE` changed to use `storages.backends.s3boto3.S3Boto3Storage` instead of `storages.backends.s3boto.S3BotoStorage`.
+
 [3.61.4]
 --------
 fix: impoved admin screen for system wide enterprise role assignments

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.61.4"
+__version__ = "3.61.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1592,6 +1592,17 @@ class EnterpriseCustomerBrandingConfiguration(TimeStampedModel):
         """
         return self.__str__()
 
+    def _check_file_storage_environment(self):
+        """
+        Returns whether `settings.DEFAULT_FILE_STORAGE` is set for
+        stage/prod or dev environment.
+        """
+        allowed_default_file_storages = [
+            'storages.backends.s3boto.S3BotoStorage',
+            'storages.backends.s3boto3.S3Boto3Storage',
+        ]
+        return settings.DEFAULT_FILE_STORAGE in allowed_default_file_storages
+
     @property
     def safe_logo_url(self):
         """
@@ -1602,7 +1613,7 @@ class EnterpriseCustomerBrandingConfiguration(TimeStampedModel):
 
         # AWS S3 storage is used in stage/production environments but file system
         # storage is used in devstack environment
-        if settings.DEFAULT_FILE_STORAGE == 'storages.backends.s3boto.S3BotoStorage':
+        if self._check_file_storage_environment():
             media_base_url = 'https://' + settings.AWS_S3_CUSTOM_DOMAIN
         else:
             media_base_url = settings.LMS_ROOT_URL + settings.MEDIA_URL


### PR DESCRIPTION
# Description 

Bug ticket: https://2u-internal.atlassian.net/browse/ENT-6873

The enterprise product supports customers who use their custom logo for the application header. This is determined by `safe_logo_url` on the `EnterpriseCustomerBrandingConfiguration` model. This method determines whether to use an S3 URL for stage/prod or the concatenated `settings.LMS_ROOT_URL + settings.MEDIA_URL`.

It makes this choice based on the `settings.DEFAULT_FILE_STORAGE` setting, which recently updated last week from `storages.backends.s3boto.S3BotoStorage` to `storages.backends.s3boto3.S3Boto3Storage`, thus breaking the conditional to use the S3 URL in stage/prod.

This PR makes `safe_logo_url` support both the old and new values for `settings.DEFAULT_FILE_STORAGE`.

Long term, we should find another way to flag on whether we are in a local vs. stage/prod environment than relying on `settings.DEFAULT_FILE_STORAGE` directly.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
