### PR TITLE
feat: get all catalog queries api endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * Nothing
 
+[3.61.7]
+--------
+feat: Serialize and create a viewset for enterpriseCatalogQuery as readonly
+
 [3.61.6]
 --------
 feat: Add user_id support to enroll_learners_in_courses endpoint

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.61.6"
+__version__ = "3.61.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1406,3 +1406,16 @@ class EnterpriseCustomerUnlinkUsersSerializer(serializers.Serializer):
         required=False,
         default=False,
     )
+
+
+class EnterpriseCatalogQuerySerializer(serializers.ModelSerializer):
+    """
+    Serializer for the ``EnterpriseCatalogQuery`` model.
+    """
+
+    class Meta:
+        model = models.EnterpriseCatalogQuery
+        fields = '__all__'
+
+    # Parses from a dictionary to JSON
+    content_filter = serializers.JSONField(required=False)

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -34,6 +34,11 @@ router.register(
     views.EnterpriseCustomerInviteKeyViewSet,
     "enterprise-customer-invite-key"
 )
+router.register(
+    "enterprise_catalog_query",
+    views.EnterpriseCatalogQueryViewSet,
+    "enterprise_catalog_query"
+)
 
 urlpatterns = [
     re_path(r'^read_notification$', views.NotificationReadView.as_view(),
@@ -43,11 +48,6 @@ urlpatterns = [
         r'link_pending_enterprise_users/(?P<enterprise_uuid>[A-Za-z0-9-]+)/?$',
         views.PendingEnterpriseCustomerUserEnterpriseAdminViewSet.as_view({'post': 'link_learners'}),
         name='link-pending-enterprise-learner'
-    ),
-    re_path(
-        r'^enterprise_catalog_query/(?P<catalog_query_id>[\d]+)/$',
-        views.CatalogQueryView.as_view(),
-        name='enterprise-catalog-query'
     ),
     re_path(r'^request_codes$', views.CouponCodesView.as_view(),
             name='request-codes'

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -1268,25 +1268,18 @@ class EnterpriseCustomerReportingConfigurationViewSet(EnterpriseReadWriteModelVi
         return super().destroy(request, *args, **kwargs)
 
 
-class CatalogQueryView(APIView):
+class EnterpriseCatalogQueryViewSet(EnterpriseReadOnlyModelViewSet):
     """
-    View for enterprise catalog query.
-    This will be called from django admin tool to populate `content_filter` field of `EnterpriseCustomerCatalog` model.
+    API views for the ``enterprise_catalog_query`` API endpoint.
     """
-    authentication_classes = [SessionAuthentication]
-    permission_classes = [permissions.IsAuthenticated, permissions.IsAdminUser]
-    http_method_names = ['get']
+    queryset = models.EnterpriseCatalogQuery.objects.all()
+    serializer_class = serializers.EnterpriseCatalogQuerySerializer
+    permission_classes = (permissions.IsAuthenticated,)
+    authentication_classes = (JwtAuthentication, SessionAuthentication,)
 
-    def get(self, request, catalog_query_id):
-        """
-        API endpoint for fetching an enterprise catalog query.
-        """
-        try:
-            catalog_query = models.EnterpriseCatalogQuery.objects.get(pk=catalog_query_id)
-        except models.EnterpriseCatalogQuery.DoesNotExist:
-            return Response({"detail": "Could not find enterprise catalog query."}, status=HTTP_404_NOT_FOUND)
-        return Response(catalog_query.content_filter, status=HTTP_200_OK)
-
+    # isEn
+    # permission_classes = [permissions.IsAdminUser] --> licsense manager Lookup
+    # JWT with enterprise Role, if staff user --> this endpoint
 
 class CouponCodesView(APIView):
     """


### PR DESCRIPTION
Serializes EnterpriseCatalogQuery Model
Distinctly classifies model field, `content_filter` as JSON to parse data
Creates nondescript ViewSet with default Django readonly endpoints
Denotes permissions based on a Jwt Authenticated user with session
Creates general viewset route

Writes a basic test

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
