### PR TITLE
chore: add enterprise_subsidy_worker to ENTERPRISE_ALL_SERVICE_USERNAMES

### DIFF
--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -183,6 +183,7 @@ ENTERPRISE_ALL_SERVICE_USERNAMES = [
     'enterprise_worker',
     'license_manager_worker',
     'enterprise_catalog_worker',
+    'enterprise_subsidy_worker',
 ]
 
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'


### PR DESCRIPTION
This affects only test settings, and is mostly for consistency with production environments.

[ENT-6913](https://2u-internal.atlassian.net/browse/ENT-6913)