### PR TITLE
build: remove unnecessary codecov dependency and use GHA instead

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,8 +35,11 @@ jobs:
         TOXENV: ${{ matrix.toxenv }}
       run: tox
     - name: Run code coverage
-      if: matrix.toxenv=='django32-celery50'     # Only run this once as part of tests
-      run: codecov
+      if: matrix.toxenv=='django32-celery50'
+      uses: codecov/codecov-action@v3
+      with:
+        flags: unittests
+        fail_ci_if_error: true
     - name: Run jshint
       if: matrix.toxenv=='django32-celery50'     # Only run this once as part of tests
       run: |

--- a/requirements/ci.in
+++ b/requirements/ci.in
@@ -2,6 +2,5 @@
 
 -c constraints.txt
 
-codecov                   # Code coverage reporting
 tox                       # Virtualenv management for tests
 tox-battery==0.6.1        # Makes tox aware of requirements file changes

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -8,8 +8,6 @@ certifi==2022.9.24
     # via requests
 charset-normalizer==2.1.1
     # via requests
-codecov==2.1.12
-    # via -r requirements/ci.in
 coverage==6.5.0
     # via codecov
 distlib==0.3.6


### PR DESCRIPTION
**Merge checklist:**
- ❌ (won't do) Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements