### PR TITLE
feat: new management command to remove duplicate transmission audits

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.62.1]
+--------
+feat: new management command to remove duplicate transmission audits
+
 [3.62.0]
 --------
 feat: Add 'auth_org_id' field to EnterpriseCustomer for Auth0 integration

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.62.0"
+__version__ = "3.62.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/management/commands/remove_duplicate_transmission_audits.py
+++ b/integrated_channels/integrated_channel/management/commands/remove_duplicate_transmission_audits.py
@@ -1,0 +1,28 @@
+"""
+Remove duplicate transmission audits, keeping the most recently modified one.
+"""
+import logging
+
+from django.core.management.base import BaseCommand
+
+from integrated_channels.integrated_channel.management.commands import IntegratedChannelCommandMixin
+from integrated_channels.integrated_channel.tasks import remove_duplicate_transmission_audits
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(IntegratedChannelCommandMixin, BaseCommand):
+    """
+    Iterate through all transmission audits and remove duplicates, keeping the most recently modified one.
+
+    ./manage.py lms remove_duplicate_transmission_audits
+    """
+
+    def handle(self, *args, **options):
+        """
+        Iterate through all transmission audits and remove duplicates, keeping the most recently modified one.
+        """
+        try:
+            remove_duplicate_transmission_audits.delay()
+        except Exception as exc:  # pylint: disable=broad-except
+            LOGGER.exception(f'Failed to mark orphaned content metadata audits. Task failed with exception: {exc}')

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1930,3 +1930,59 @@ class TestMarkOrphanedContentMetadataAuditsManagementCommand(unittest.TestCase, 
         call_command('mark_orphaned_content_metadata_audits')
         orphaned_content = OrphanedContentTransmissions.objects.first()
         assert orphaned_content.content_id == self.orphaned_content.content_id
+
+
+@mark.django_db
+@ddt.ddt
+class TestRemoveDuplicateContentMetadataAuditsManageCommand(unittest.TestCase, EnterpriseMockMixin):
+    """
+    Test the ``remove_duplicate_content_metadata_audits`` management command.
+    """
+
+    def setUp(self):
+        self.test_duplicate_number = 50
+        self.enterprise_customer = factories.EnterpriseCustomerFactory(
+            name='Veridian Dynamics',
+        )
+        self.customer_config = factories.DegreedEnterpriseCustomerConfigurationFactory(
+            enterprise_customer=self.enterprise_customer,
+        )
+        for _ in range(50):
+            factories.ContentMetadataItemTransmissionFactory(
+                content_id='DemoX',
+                enterprise_customer=self.enterprise_customer,
+                plugin_configuration_id=self.customer_config.id,
+                integrated_channel_code=self.customer_config.channel_code(),
+                modified=datetime.now() - timedelta(days=1)
+            )
+
+        self.true_transmission_item = factories.ContentMetadataItemTransmissionFactory(
+            content_id='DemoX',
+            enterprise_customer=self.enterprise_customer,
+            plugin_configuration_id=self.customer_config.id,
+            integrated_channel_code=self.customer_config.channel_code(),
+            modified=datetime.now()
+        )
+        super().setUp()
+
+    def test_successful_dry_run(self):
+        assert ContentMetadataItemTransmission.objects.filter(
+            content_id='DemoX'
+        ).count() == self.test_duplicate_number + 1
+        call_command('remove_duplicate_transmission_audits')
+        assert ContentMetadataItemTransmission.objects.filter(
+            content_id='DemoX'
+        ).count() == self.test_duplicate_number + 1
+
+    @override_settings(DISABLE_REMOVE_DUP_TRANSMISSION_AUDIT_DRY_RUN=True)
+    def test_successful_run(self):
+        assert ContentMetadataItemTransmission.objects.filter(
+            content_id='DemoX'
+        ).count() == self.test_duplicate_number + 1
+        call_command('remove_duplicate_transmission_audits')
+        assert ContentMetadataItemTransmission.objects.filter(
+            content_id='DemoX'
+        ).count() == 1
+        assert ContentMetadataItemTransmission.objects.filter(
+            id=self.true_transmission_item.id
+        ).exists()


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7052

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
