### PR TITLE
fix: reading queryset length in a mysql supported way

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.62.2]
+--------
+fix: management command fix- reading queryset length in a mysql supported way 
+
 [3.62.1]
 --------
 feat: new management command to remove duplicate transmission audits

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.62.1"
+__version__ = "3.62.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/management/commands/remove_duplicate_transmission_audits.py
+++ b/integrated_channels/integrated_channel/management/commands/remove_duplicate_transmission_audits.py
@@ -25,4 +25,4 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         try:
             remove_duplicate_transmission_audits.delay()
         except Exception as exc:  # pylint: disable=broad-except
-            LOGGER.exception(f'Failed to mark orphaned content metadata audits. Task failed with exception: {exc}')
+            LOGGER.exception(f'Failed to remove duplicate content metadata audits. Task failed with exception: {exc}')

--- a/integrated_channels/integrated_channel/tasks.py
+++ b/integrated_channels/integrated_channel/tasks.py
@@ -113,7 +113,7 @@ def remove_duplicate_transmission_audits():
                 integrated_channel_code=unique_transmission[2]
             ).order_by('-modified').values_list('id', flat=True)[1:]
         )
-        duplicates_found += len(duplicates)
+        duplicates_found += len(list(duplicates))
         if getattr(settings, "DISABLE_REMOVE_DUP_TRANSMISSION_AUDIT_DRY_RUN", False):
             duplicates.delete()
         else:


### PR DESCRIPTION
https://splunk.edx.org/en-US/app/search/search?q=search%20duplicates%20found&earliest=-24h%40h&latest=now&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1683301288.3509271

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
