### PR TITLE
feat: handle enrollments for "Invite Only" courses

### DIFF
--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -68,6 +68,11 @@ class ManageLearnersForm(forms.Form):
         label=_("Enroll these learners in this course"), required=False,
         help_text=_("To enroll learners in a course, enter a course ID."),
     )
+    force_enrollment = forms.BooleanField(
+        label=_("Force Enrollment"),
+        help_text=_("The selected course is 'Invite Only'. Only staff can enroll learners to this course."),
+        required=False,
+    )
     course_mode = forms.ChoiceField(
         label=_("Course enrollment track"), required=False,
         choices=BLANK_CHOICE_DASH + [
@@ -130,6 +135,7 @@ class ManageLearnersForm(forms.Form):
         REASON = "reason"
         SALES_FORCE_ID = "sales_force_id"
         DISCOUNT = "discount"
+        FORCE_ENROLLMENT = "force_enrollment"
 
     class CsvColumns:
         """

--- a/enterprise/admin/views.py
+++ b/enterprise/admin/views.py
@@ -678,7 +678,8 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             notify=True,
             enrollment_reason=None,
             sales_force_id=None,
-            discount=0.0
+            discount=0.0,
+            force_enrollment=False,
     ):
         """
         Enroll the users with the given email addresses to the course.
@@ -691,6 +692,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             mode: The enrollment mode the users will be enrolled in the course with
             course_id: The ID of the course in which we want to enroll
             notify: Whether to notify (by email) the users that have been enrolled
+            force_enrollment: Force enrollment into "Invite Only" courses
         """
         pending_messages = []
         paid_modes = ['verified', 'professional']
@@ -704,6 +706,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             enrollment_reason=enrollment_reason,
             discount=discount,
             sales_force_id=sales_force_id,
+            force_enrollment=force_enrollment,
         )
         all_successes = succeeded + pending
         if notify:
@@ -820,6 +823,7 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
             sales_force_id = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.SALES_FORCE_ID)
             course_mode = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE_MODE)
             course_id = None
+            force_enrollment = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.FORCE_ENROLLMENT)
 
             if not course_id_with_emails:
                 course_details = manage_learners_form.cleaned_data.get(ManageLearnersForm.Fields.COURSE) or {}
@@ -834,7 +838,8 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                         notify=notify,
                         enrollment_reason=manual_enrollment_reason,
                         sales_force_id=sales_force_id,
-                        discount=discount
+                        discount=discount,
+                        force_enrollment=force_enrollment,
                     )
             else:
                 for course_id, emails in course_id_with_emails.items():
@@ -849,7 +854,8 @@ class EnterpriseCustomerManageLearnersView(BaseEnterpriseCustomerView):
                             notify=notify,
                             enrollment_reason=manual_enrollment_reason,
                             sales_force_id=sales_force_id,
-                            discount=discount
+                            discount=discount,
+                            force_enrollment=force_enrollment,
                         )
 
             # Redirect to GET if everything went smooth.

--- a/enterprise/api_client/lms.py
+++ b/enterprise/api_client/lms.py
@@ -128,7 +128,15 @@ class EnrollmentApiClient(BackendServiceAPIClient):
         course_modes = self.get_course_modes(course_run_id)
         return any(course_mode for course_mode in course_modes if course_mode['slug'] == mode)
 
-    def enroll_user_in_course(self, username, course_id, mode, cohort=None, enterprise_uuid=None):
+    def enroll_user_in_course(
+        self,
+        username,
+        course_id,
+        mode,
+        cohort=None,
+        enterprise_uuid=None,
+        force_enrollment=False,
+    ):
         """
         Call the enrollment API to enroll the user in the course specified by course_id.
 
@@ -138,6 +146,7 @@ class EnrollmentApiClient(BackendServiceAPIClient):
             mode (str): The enrollment mode which should be used for the enrollment
             cohort (str): Add the user to this named cohort
             enterprise_uuid (str): Add course enterprise uuid
+            force_enrollment (bool): Force the enrollment even if course is Invite Only
 
         Returns:
             dict: A dictionary containing details of the enrollment, including course details, mode, username, etc.
@@ -152,7 +161,8 @@ class EnrollmentApiClient(BackendServiceAPIClient):
                 'is_active': True,
                 'mode': mode,
                 'cohort': cohort,
-                'enterprise_uuid': str(enterprise_uuid)
+                'enterprise_uuid': str(enterprise_uuid),
+                'force_enrollment': force_enrollment,
             }
         )
         response.raise_for_status()

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -84,9 +84,10 @@ from enterprise.validators import (
 )
 
 try:
-    from common.djangoapps.student.models import CourseEnrollment
+    from common.djangoapps.student.models import CourseEnrollment, CourseEnrollmentAllowed
 except ImportError:
     CourseEnrollment = None
+    CourseEnrollmentAllowed = None
 
 try:
     from common.djangoapps.entitlements.models import CourseEntitlement
@@ -746,7 +747,21 @@ class EnterpriseCustomer(TimeStampedModel):
             license_uuid = None
 
         new_enrollments = {}
+        enrollment_api_client = EnrollmentApiClient()
+
         for course_id in course_ids:
+            # Check if the course is "Invite Only" and add CEA if it is.
+            course_details = enrollment_api_client.get_course_details(course_id)
+
+            if course_details["invite_only"]:
+                if not CourseEnrollmentAllowed:
+                    raise NotConnectedToOpenEdX()
+
+                CourseEnrollmentAllowed.objects.update_or_create(
+                    email=email,
+                    course_id=course_id
+                )
+
             __, created = PendingEnrollment.objects.update_or_create(
                 user=pending_ecu,
                 course_id=course_id,

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1740,12 +1740,15 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
         user: The user model object who needs to be enrolled in the course
         course_mode: The string representation of the mode with which the enrollment should be created
         *course_ids: An iterable containing any number of course IDs to eventually enroll the user in.
-        kwargs: Should contain enrollment_client if it's already been instantiated and should be passed in.
+        kwargs: Contains optional params such as:
+            - enrollment_client, if it's already been instantiated and should be passed in
+            - force_enrollment, if the course is "Invite Only" and the "force_enrollment" is needed
 
     Returns:
         Boolean: Whether or not enrollment succeeded for all courses specified
     """
     enrollment_client = kwargs.pop('enrollment_client', None)
+    force_enrollment = kwargs.pop('force_enrollment', False)
     if not enrollment_client:
         from enterprise.api_client.lms import EnrollmentApiClient  # pylint: disable=import-outside-toplevel
         enrollment_client = EnrollmentApiClient()
@@ -1760,7 +1763,8 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
                 user.username,
                 course_id,
                 course_mode,
-                enterprise_uuid=str(enterprise_customer_user.enterprise_customer.uuid)
+                enterprise_uuid=str(enterprise_customer_user.enterprise_customer.uuid),
+                force_enrollment=force_enrollment,
             )
         except HttpClientError as exc:
             # Check if user is already enrolled then we should ignore exception
@@ -2113,6 +2117,7 @@ def enroll_users_in_course(
         enrollment_reason=None,
         discount=0.0,
         sales_force_id=None,
+        force_enrollment=False,
 ):
     """
     Enroll existing users in a course, and create a pending enrollment for nonexisting users.
@@ -2126,6 +2131,7 @@ def enroll_users_in_course(
         enrollment_reason (str): A reason for enrollment.
         discount (Decimal): Percentage discount for enrollment.
         sales_force_id (str): Salesforce opportunity id.
+        force_enrollment (bool): Force enrollment into 'Invite Only' courses.
 
     Returns:
         successes: A list of users who were successfully enrolled in the course.
@@ -2142,7 +2148,7 @@ def enroll_users_in_course(
     failures = []
 
     for user in existing_users:
-        succeeded = enroll_user(enterprise_customer, user, course_mode, course_id)
+        succeeded = enroll_user(enterprise_customer, user, course_mode, course_id, force_enrollment=force_enrollment)
         if succeeded:
             successes.append(user)
             if enrollment_requester and enrollment_reason:

--- a/test_utils/fake_enrollment_api.py
+++ b/test_utils/fake_enrollment_api.py
@@ -150,7 +150,8 @@ def get_course_details(course_id):
         return None
 
 
-def enroll_user_in_course(user, course_id, mode, cohort=None, enterprise_uuid=None):
+def enroll_user_in_course(user, course_id, mode, cohort=None, enterprise_uuid=None, force_enrollment=False):  # pylint: disable=unused-argument
+
     """
     Fake implementation.
     """

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -90,6 +90,7 @@ from test_utils.factories import (
     PendingEnterpriseCustomerUserFactory,
     UserFactory,
 )
+from test_utils.fake_enrollment_api import get_course_details
 from test_utils.fake_enterprise_api import get_default_branding_object
 
 Application = get_application_model()
@@ -3011,6 +3012,7 @@ class TestEnterprisesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
             True,
             enable_autocohorting=True
         )
+        mock_enrollment_client.return_value.get_course_details = get_course_details
 
         # Make the call!
         response = self.client.post(
@@ -3208,7 +3210,8 @@ class TestEnterprisesCustomerCourseEnrollments(BaseTestEnterpriseAPIViews):
             get_course_enrollment=mock.Mock(
                 side_effect=[None, {'is_active': True, 'mode': VERIFIED_SUBSCRIPTION_COURSE_MODE}]
             ),
-            enroll_user_in_course=mock.Mock()
+            enroll_user_in_course=mock.Mock(),
+            get_course_details=get_course_details
         )
 
         # Set up catalog_contains_course response.
@@ -4152,6 +4155,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 1,
             'expected_events': [mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course')],
+            'expected_cea': 0,
         },
         # Validation failure cases
         {
@@ -4160,6 +4164,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_response': {'non_field_errors': ['Must include the `enrollment_info` parameter in request.']},
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -4171,6 +4176,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -4188,6 +4194,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -4213,6 +4220,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -4231,6 +4239,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         {
             'body': {
@@ -4246,6 +4255,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 0,
             'expected_events': None,
+            'expected_cea': 0,
         },
         # Single learner, single course success
         {
@@ -4269,6 +4279,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             },
             'expected_num_pending_licenses': 1,
             'expected_events': [mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course')],
+            'expected_cea': 0,
         },
         # Multi-learner, single course success
         {
@@ -4309,6 +4320,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_events': [
                 mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
             ],
+            'expected_cea': 0,
         },
         # Multi-learner, multi-course success
         {
@@ -4326,12 +4338,12 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
                     },
                 ]
@@ -4354,13 +4366,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     }
@@ -4370,8 +4382,9 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_num_pending_licenses': 4,
             'expected_events': [
                 mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
-                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v2:edX+DemoX+Second_Demo_Course')
+                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:EnterpriseX+Training+2017')
             ],
+            'expected_cea': 2,
         },
         {
             'body': {
@@ -4388,12 +4401,12 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
                     },
                 ]
@@ -4416,13 +4429,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:EnterpriseX+Training+2017',
                         'created': True,
                         'activation_link': None,
                     }
@@ -4432,16 +4445,19 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             'expected_num_pending_licenses': 4,
             'expected_events': [
                 mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:edX+DemoX+Demo_Course'),
-                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v2:edX+DemoX+Second_Demo_Course')
+                mock.call(PATHWAY_CUSTOMER_ADMIN_ENROLLMENT, 1, 'course-v1:EnterpriseX+Training+2017')
             ],
+            'expected_cea': 2,
         },
     )
     @ddt.unpack
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment')
     @mock.patch("enterprise.models.EnterpriseCustomer.notify_enrolled_learners")
+    @mock.patch("enterprise.models.CourseEnrollmentAllowed")
     def test_bulk_enrollment_in_bulk_courses_pending_licenses(
         self,
+        mock_cea,
         mock_notify_task,
         mock_track_enroll,
         mock_get_course_mode,
@@ -4450,6 +4466,7 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         expected_response,
         expected_num_pending_licenses,
         expected_events,
+        expected_cea,
     ):
         """
         Tests the bulk enrollment endpoint at enroll_learners_in_courses.
@@ -4466,11 +4483,17 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
 
         self.assertEqual(len(PendingEnrollment.objects.all()), 0)
-        response = self.client.post(
-            settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
-            data=json.dumps(body),
-            content_type='application/json',
-        )
+
+        with mock.patch(
+            "enterprise.models.EnrollmentApiClient.get_course_details",
+            wraps=get_course_details
+        ):
+            response = self.client.post(
+                settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
+                data=json.dumps(body),
+                content_type='application/json',
+            )
+
         self.assertEqual(response.status_code, expected_code)
         if expected_response:
             response_json = response.json()
@@ -4484,6 +4507,8 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
             mock_track_enroll.assert_has_calls(expected_events[x] for x in range(len(expected_events) - 1))
         else:
             mock_track_enroll.assert_not_called()
+
+        self.assertEqual(mock_cea.objects.update_or_create.call_count, expected_cea)
 
         # no notifications to be sent unless 'notify' specifically asked for in payload
         mock_notify_task.assert_not_called()
@@ -4829,12 +4854,12 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac'
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'license_uuid': '2c58acdade7c4ede838f7111b42e18ac'
                     },
                 ]
@@ -4857,13 +4882,13 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
                     },
                     {
                         'email': 'abc@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'created': True,
                         'activation_link': None,
                     },
                     {
                         'email': 'xyz@test.com',
-                        'course_run_key': 'course-v2:edX+DemoX+Second_Demo_Course',
+                        'course_run_key': 'course-v1:HarvardX+CoolScience+2016',
                         'created': True,
                         'activation_link': None,
                     }
@@ -4908,13 +4933,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
 
         self.assertEqual(len(PendingEnrollment.objects.all()), 0)
 
-        response = self.client.post(
-            settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
-            data=json.dumps(body),
-            content_type='application/json',
-        )
-        self.assertEqual(response.status_code, expected_code)
+        with mock.patch("enterprise.models.EnrollmentApiClient.get_course_details", wraps=get_course_details):
+            response = self.client.post(
+                settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
+                data=json.dumps(body),
+                content_type='application/json',
+            )
 
+        self.assertEqual(response.status_code, expected_code)
         response_json = response.json()
         self.assertEqual(expected_response, response_json)
         self.assertEqual(len(PendingEnrollment.objects.all()), expected_num_pending_licenses)

--- a/tests/test_enterprise/api_client/test_lms.py
+++ b/tests/test_enterprise/api_client/test_lms.py
@@ -99,7 +99,8 @@ def test_enroll_user_in_course():
         'mode': mode,
         'cohort': cohort,
         'is_active': True,
-        'enterprise_uuid': 'None'
+        'enterprise_uuid': 'None',
+        'force_enrollment': False
     }
     responses.add(
         responses.POST,

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -26,6 +26,7 @@ from enterprise.utils import (
     truncate_string,
 )
 from test_utils import FAKE_UUIDS, TEST_PASSWORD, TEST_USERNAME, factories
+from test_utils.fake_enrollment_api import get_course_details
 
 LMS_BASE_URL = 'https://lms.base.url'
 
@@ -422,11 +423,12 @@ class TestUtils(unittest.TestCase):
         )
         licensed_users_info = [{
             'email': 'pending-user-email@example.com',
-            'course_run_key': 'course-key-v1',
+            'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
             'course_mode': 'verified',
             'license_uuid': '5b77bdbade7b4fcb838f8111b68e18ae'
         }]
-        result = enroll_subsidy_users_in_courses(ent_customer, licensed_users_info)
+        with mock.patch("enterprise.models.EnrollmentApiClient.get_course_details", wraps=get_course_details):
+            result = enroll_subsidy_users_in_courses(ent_customer, licensed_users_info)
 
         self.assertEqual(result['pending'][0]['email'], 'pending-user-email@example.com')
         self.assertFalse(result['successes'])


### PR DESCRIPTION
### Description

This PR introduces some improvements to the 'Manage Learners' page of Enterprise Customer admin that will allow enrolling learners into "Invite Only" courses.

Refer #1745 for full details about the issue.

### Testing instructions

* Follow the testing instructions in #1745 and reproduce the issue
* Switch to the PR branch
* Try enrolling learners into the course marked as "Invite Only", with the *Force Enrollment* checkbox checked, this time it should work without throwing an error.
* Test with both a learner who already has a registered account and an email which is not registered in the system to ensure, "enrollment on registration" also works for "Invite Only" courses.

![image](https://github.com/openedx/edx-enterprise/assets/383862/e6e17c83-6c69-459c-b8e8-9e22756562f3)


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files) - **No new requirements added**
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated - **Running make static didn't introduce any changes**
- [ ] `./manage.py makemigrations` has been run - **No DB migrations introduced**
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [x] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
