### PR TITLE
feat: include auth_org_id in enterprise customer api

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.62.5]
+--------
+feat: include auth_org_id in enterprise customer api
+
 [3.62.4]
 --------
 fix: duplicate records reading queryset length then splicing

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.62.4"
+__version__ = "3.62.5"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -184,7 +184,7 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCustomer
         fields = (
-            'uuid', 'name', 'slug', 'active', 'site', 'enable_data_sharing_consent',
+            'uuid', 'name', 'slug', 'active', 'auth_org_id', 'site', 'enable_data_sharing_consent',
             'enforce_data_sharing_consent', 'branding_configuration',
             'identity_provider', 'enable_audit_enrollment', 'replace_sensitive_sso_username',
             'enable_portal_code_management_screen', 'sync_learner_profile_data', 'enable_audit_data_reporting',

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -116,6 +116,7 @@ class EnterpriseCustomerFactory(factory.django.DjangoModelFactory):
     sender_alias = factory.LazyAttribute(lambda x: FAKER.word())
     reply_to = factory.LazyAttribute(lambda x: FAKER.email())
     hide_labor_market_data = False
+    auth_org_id = factory.LazyAttribute(lambda x: FAKER.lexify(text='??????????'))
 
 
 class EnrollmentNotificationEmailTemplateFactory(factory.django.DjangoModelFactory):

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -162,6 +162,12 @@ class TestEnterpriseCustomerSerializer(BaseSerializerTestWithEnterpriseRoleAssig
         self.assertCountEqual(enterprise_customer_1_admin_users, expected_enterprise_customer_1_admin_users)
         self.assertCountEqual(enterprise_customer_2_admin_users, expected_enterprise_customer_2_admin_users)
 
+    def test_serialize_auth_org_id(self):
+        serializer = EnterpriseCustomerSerializer(self.enterprise_customer_1)
+        expected_auth_org_id = self.enterprise_customer_1.auth_org_id
+        serialized_auth_org_id = serializer.data['auth_org_id']
+        self.assertEqual(serialized_auth_org_id, expected_auth_org_id)
+
 
 @ddt.ddt
 @mark.django_db

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1118,7 +1118,9 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             itemgetter('uuid'),
             [{
                 'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
-                'active': True, 'enable_data_sharing_consent': True,
+                'active': True,
+                'auth_org_id': 'asdf3e2wdas',
+                'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment', 'enable_audit_data_reporting': True,
                 'site__domain': 'example.com', 'site__name': 'example.com',
                 'contact_email': 'fake@example.com', 'sender_alias': 'Test Sender Alias',
@@ -1127,7 +1129,9 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             }],
             [{
                 'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
-                'admin_users': [], 'active': True, 'enable_data_sharing_consent': True,
+                'admin_users': [], 'active': True,
+                'auth_org_id': 'asdf3e2wdas',
+                'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': get_default_branding_object(FAKE_UUIDS[0], TEST_SLUG),
                 'enable_audit_enrollment': False, 'enable_audit_data_reporting': True, 'identity_provider': None,
@@ -1177,13 +1181,16 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enterprise_customer__sender_alias': 'Test Sender Alias',
                 'enterprise_customer__reply_to': 'fake_reply@example.com',
                 'enterprise_customer__hide_labor_market_data': False,
+                'enterprise_customer__auth_org_id': 'asdf3e2wdas',
             }],
             [{
                 'id': 1, 'user_id': 0, 'user': None, 'active': True, 'created': '2021-10-20T19:01:31Z',
                 'invite_key': None, 'role_assignments': [], 'data_sharing_consent_records': [], 'groups': [],
                 'enterprise_customer': {
                     'uuid': FAKE_UUIDS[0], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
-                    'admin_users': [], 'active': True, 'enable_data_sharing_consent': True,
+                    'admin_users': [], 'active': True,
+                    'auth_org_id': 'asdf3e2wdas',
+                    'enable_data_sharing_consent': True,
                     'enforce_data_sharing_consent': 'at_enrollment',
                     'branding_configuration': get_default_branding_object(FAKE_UUIDS[0], TEST_SLUG),
                     'enable_audit_enrollment': False, 'identity_provider': None,
@@ -1248,10 +1255,13 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enterprise_customer__reply_to': 'fake_reply@example.com',
                 'enterprise_customer__hide_labor_market_data': False,
                 'enterprise_customer__modified': '2021-10-20T19:01:31Z',
+                'enterprise_customer__auth_org_id': 'asdf3e2wdas',
             }],
             [{
                 'uuid': FAKE_UUIDS[1], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
-                'admin_users': [], 'active': True, 'enable_data_sharing_consent': True,
+                'admin_users': [], 'active': True,
+                'auth_org_id': 'asdf3e2wdas',
+                'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': get_default_branding_object(FAKE_UUIDS[1], TEST_SLUG),
                 'enable_audit_enrollment': False, 'identity_provider': FAKE_UUIDS[0],
@@ -1308,10 +1318,13 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enterprise_customer__reply_to': 'fake_reply@example.com',
                 'enterprise_customer__hide_labor_market_data': False,
                 'enterprise_customer__modified': '2021-10-20T19:01:31Z',
+                'enterprise_customer__auth_org_id': 'asdf3e2wdas',
             }],
             [{
                 'uuid': FAKE_UUIDS[1], 'name': 'Test Enterprise Customer', 'slug': TEST_SLUG,
-                'admin_users': [], 'active': True, 'enable_data_sharing_consent': True,
+                'admin_users': [], 'active': True,
+                'auth_org_id': 'asdf3e2wdas',
+                'enable_data_sharing_consent': True,
                 'enforce_data_sharing_consent': 'at_enrollment',
                 'branding_configuration': get_default_branding_object(FAKE_UUIDS[1], TEST_SLUG),
                 'enable_audit_enrollment': False,
@@ -1498,6 +1511,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             'reply_to': 'fake_reply@example.com',
             'hide_labor_market_data': False,
             'modified': '2021-10-20T19:32:12Z',
+            'auth_org_id': 'a34awed234'
         }
         enterprise_customer = factories.EnterpriseCustomerFactory(**enterprise_customer_data)
 
@@ -1556,6 +1570,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'hide_labor_market_data': False,
                 'enterprise_notification_banner': {'text': '', 'title': ''},
                 'modified': '2021-10-20T19:32:12Z',
+                'auth_org_id': enterprise_customer_data.get('auth_org_id'),
             }
         else:
             assert response == expected_error


### PR DESCRIPTION
## Description

- in order to include `auth_org_id` in GEAG requests, we need to be able to retrieve it in contexts outside enterprise (ecomm, subsidy service, etc)
- include `auth_org_id` in serializer, test factories, etc
- https://2u-internal.atlassian.net/browse/ENT-7079