### PR TITLE
feat: include obsolete attribute in degreed content transmissions

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.62.7]
+--------
+feat: include obsolete attribute in degreed content transmissions
+
 [3.62.6]
 --------
 chore: adding better logging to the remove dup audit management command
@@ -36,7 +40,7 @@ feat: Add idempotent catalog creation endpoint
 
 [3.62.2]
 --------
-fix: management command fix- reading queryset length in a mysql supported way 
+fix: management command fix- reading queryset length in a mysql supported way
 
 [3.62.1]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.62.6"
+__version__ = "3.62.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -148,7 +148,7 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
         """
         return content_metadata_item['uuid']
 
-    def transform_obsolete(self, content_metadata_item): # pylint: disable=unused-argument
+    def transform_obsolete(self, content_metadata_item):  # pylint: disable=unused-argument
         """
         Always set obsolete to false to fix externally deleted courses.
         """

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -148,7 +148,7 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
         """
         return content_metadata_item['uuid']
 
-    def transform_obsolete(self, content_metadata_item):
+    def transform_obsolete(self, content_metadata_item): # pylint: disable=unused-argument
         """
         Always set obsolete to false to fix externally deleted courses.
         """

--- a/integrated_channels/degreed2/exporters/content_metadata.py
+++ b/integrated_channels/degreed2/exporters/content_metadata.py
@@ -36,6 +36,7 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
         'external-id': 'key',
         'duration': 'duration',
         'duration-type': 'duration_type',
+        'obsolete': 'obsolete',
     }
 
     def transform_duration_type(self, content_metadata_item):  # pylint: disable=unused-argument
@@ -146,3 +147,9 @@ class Degreed2ContentMetadataExporter(ContentMetadataExporter):
         Return the identifier of the program content item.
         """
         return content_metadata_item['uuid']
+
+    def transform_obsolete(self, content_metadata_item):
+        """
+        Always set obsolete to false to fix externally deleted courses.
+        """
+        return False

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
@@ -369,5 +369,5 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "uuid": "3580463a-6f9c-48ed-ae8d-b5a012860d75",
             "advertised_course_run_uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
         }
-        transformed_items = exporter._transform_item(content_metadata_item)
-        assert 'obsolete' in transformed_items and transformed_items['obsolete'] is False
+        transformed_item = exporter._transform_item(content_metadata_item)
+        assert 'obsolete' in transformed_item and transformed_item['obsolete'] is False

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
@@ -356,7 +356,7 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
 
     def test_transform_obsolete(self):
         """
-        ensure obselete attribute is included and set to false
+        ensure obselete attribute is false
         """
         exporter = Degreed2ContentMetadataExporter('fake-user', self.config)
         content_metadata_item = {
@@ -369,5 +369,4 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "uuid": "3580463a-6f9c-48ed-ae8d-b5a012860d75",
             "advertised_course_run_uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
         }
-        transformed_item = exporter._transform_item(content_metadata_item)
-        assert 'obsolete' in transformed_item and transformed_item['obsolete'] is False
+        assert exporter.transform_obsolete(content_metadata_item) is False

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_content_metadata.py
@@ -353,3 +353,21 @@ class TestDegreed2ContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin
             "weeks_to_complete": 10,
         }
         assert exporter.transform_duration(content_metadata_item) == 0
+
+    def test_transform_obsolete(self):
+        """
+        ensure obselete attribute is included and set to false
+        """
+        exporter = Degreed2ContentMetadataExporter('fake-user', self.config)
+        content_metadata_item = {
+            "aggregation_key": "course:edX+0089786",
+            "content_type": "course",
+            "full_description": "<p>sdf</p>",
+            "key": "edX+0089786",
+            "short_description": "<p>ssdf</p>",
+            "title": "using exporter to set participation type",
+            "uuid": "3580463a-6f9c-48ed-ae8d-b5a012860d75",
+            "advertised_course_run_uuid": "7d238cc5-88e4-4831-a28e-4193ae4b2618",
+        }
+        transformed_items = exporter._transform_item(content_metadata_item)
+        assert 'obsolete' in transformed_items and transformed_items['obsolete'] is False


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
