### PR TITLE
fix: handle case where LearnerCreditEnterpriseCourseEnrollment already exists

### DIFF
--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.65.2"
+__version__ = "3.65.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -746,10 +746,10 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
             /enterprise/api/v1/subsidy-fulfillment/{fulfillment_source_uuid}/cancel-enrollment/
         """
         try:
-            enrollment = get_object_or_404(
+            subsidy_fulfillment = get_object_or_404(
                 self.get_subsidy_fulfillment_queryset(), uuid=fulfillment_source_uuid
             )
-            if enrollment.is_revoked:
+            if subsidy_fulfillment.is_revoked:
                 return Response(
                     status=HTTP_400_BAD_REQUEST,
                     data={'detail': 'Enrollment is already canceled.'}
@@ -761,19 +761,19 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
             )
 
         try:
-            username = enrollment.enterprise_course_enrollment.enterprise_customer_user.username
+            username = subsidy_fulfillment.enterprise_course_enrollment.enterprise_customer_user.username
             enrollment_api.update_enrollment(
                 username,
-                enrollment.enterprise_course_enrollment.course_id,
+                subsidy_fulfillment.enterprise_course_enrollment.course_id,
                 is_active=False,
             )
-            enrollment.revoke()
+            subsidy_fulfillment.revoke()
         except Exception as exc:  # pylint: disable=broad-except
             msg = (
-                f'Subsidized enrollment terminations error: unable to unenroll User {username}'
-                f'from Course {enrollment.course_id}  because: {str(exc)}'
+                f'Subsidized enrollment terminations error: unable to unenroll User {username} '
+                f'from Course {subsidy_fulfillment.enterprise_course_enrollment.course_id} because: {str(exc)}'
             )
-            LOGGER.error('{msg}: {exc}'.format(msg=msg, exc=exc))
+            LOGGER.error(msg)
             return Response(msg, status=HTTP_500_INTERNAL_SERVER_ERROR)
         return Response(status=HTTP_200_OK)
 

--- a/test_utils/factories.py
+++ b/test_utils/factories.py
@@ -12,6 +12,7 @@ from django.contrib.sites.models import Site
 from django.utils import timezone
 
 from consent.models import DataSharingConsent, DataSharingConsentTextOverrides
+from enterprise.constants import FulfillmentTypes
 from enterprise.models import (
     AdminNotification,
     EnrollmentNotificationEmailTemplate,
@@ -376,6 +377,7 @@ class LicensedEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactor
     license_uuid = factory.LazyAttribute(lambda x: UUID(FAKER.uuid4()))
     enterprise_course_enrollment = factory.SubFactory(EnterpriseCourseEnrollmentFactory)
     is_revoked = False
+    fulfillment_type = FulfillmentTypes.LICENSE
 
 
 class LearnerCreditEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelFactory):
@@ -393,6 +395,7 @@ class LearnerCreditEnterpriseCourseEnrollmentFactory(factory.django.DjangoModelF
     transaction_id = factory.LazyAttribute(lambda x: FAKER.uuid4())
     enterprise_course_enrollment = factory.SubFactory(EnterpriseCourseEnrollmentFactory)
     is_revoked = False
+    fulfillment_type = FulfillmentTypes.LEARNER_CREDIT
 
 
 class EnterpriseCatalogQueryFactory(factory.django.DjangoModelFactory):


### PR DESCRIPTION
When calling enroll_learners_in_courses (a.k.a. the bulk enrollment endpoint), gracefully handle the case when a subsidized enrollment (for learner credit 2) is being re-created after being revoked previously.

Before this change, the existing LearnerCreditEnterpriseCourseEnrollment object would not be found (due to transaction_id changing), then the view would fatally fail to create a new one due to a unique constraint on the `enterprise_course_enrollment_id` field.  After this change, it finds the existing object and updates a couple fields on it to re-use it.

ENT-7204