### PR TITLE
fix: Fixed url encoding issue with org_id in executive education course url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.66.1]
+--------
+fix: Fixed url encoding issue with org_id in executive education course url
+
 [3.66.0]
 --------
 feat: Added org_id for executive education courses landing page

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.66.0"
+__version__ = "3.66.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -1,7 +1,7 @@
 """
 enterprise_learner_portal serializer
 """
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 from rest_framework import serializers
 
@@ -96,6 +96,6 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
             params = {'org_id': ''}
             if active_enterprise_customer:
                 params = {'org_id': active_enterprise_customer.enterprise_customer.auth_org_id}
-            course_run_url = quote("{}?{}".format(exec_ed_base_url, urlencode(params)))
+            course_run_url = '{}?{}'.format(exec_ed_base_url, urlencode(params))
 
         return course_run_url

--- a/tests/test_enterprise_learner_portal/api/test_serializers.py
+++ b/tests/test_enterprise_learner_portal/api/test_serializers.py
@@ -4,7 +4,7 @@ Tests for the EnterpriseCourseEnrollmentview of the enterprise_learner_portal ap
 
 from collections import OrderedDict
 from unittest import mock
-from urllib.parse import quote, urlencode
+from urllib.parse import urlencode
 
 import ddt
 from pytest import mark
@@ -74,7 +74,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
         if is_exec_ed_course:
             exec_ed_landing_page = getattr(settings, 'EXEC_ED_LANDING_PAGE', None)
             params = {'org_id': self.enterprise_customer_user.enterprise_customer.auth_org_id}
-            expected_course_run_url = quote("{}?{}".format(exec_ed_landing_page, urlencode(params)))
+            expected_course_run_url = '{}?{}'.format(exec_ed_landing_page, urlencode(params))
 
         mock_get_course_run_url.return_value = course_run_url
         mock_get_emails_enabled.return_value = True


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
