### PR TITLE
fix: prevent org_id param addition to exec-ed course home url

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.66.3]
+--------
+fix: prevent org_id param addition to exec-ed course home url when auth_org_id is not present
+
 [3.66.2]
 --------
 chore: unique constraint on transmission audits to prevent duplicates

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.66.2"
+__version__ = "3.66.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -93,9 +93,8 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         exec_ed_base_url = getattr(settings, 'EXEC_ED_LANDING_PAGE', None)
         if exec_ed_base_url and exec_ed_base_url == course_run_url:
             active_enterprise_customer = EnterpriseCustomerUser.get_active_enterprise_users(request.user.id).first()
-            params = {'org_id': ''}
-            if active_enterprise_customer:
+            if active_enterprise_customer and active_enterprise_customer.enterprise_customer.auth_org_id:
                 params = {'org_id': active_enterprise_customer.enterprise_customer.auth_org_id}
-            course_run_url = '{}?{}'.format(exec_ed_base_url, urlencode(params))
+                course_run_url = '{}?{}'.format(exec_ed_base_url, urlencode(params))
 
         return course_run_url


### PR DESCRIPTION
**Description**
This PR prevents the org_id param addition to exec-ed course home url when auth_org_id is not present on the associated active EnterpriseCustomer record.

JIRA: ENT-7258

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
