### PR TITLE
feat: increase the throttle limit of service users for EnterpriseCust…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 * Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
   deprecated
 
+[3.66.6]
+--------
+feat: increase the throttle limit of service users for EnterpriseCustomerViewSet
+
 [3.66.5]
 --------
 chore: set default expiration_date for EnterpriseCustomerInviteKey

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.66.5"
+__version__ = "3.66.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -53,7 +53,7 @@ from enterprise.api.filters import (
     EnterpriseLinkedUserFilterBackend,
     UserFilterBackend,
 )
-from enterprise.api.throttles import ServiceUserThrottle
+from enterprise.api.throttles import HighServiceUserThrottle, ServiceUserThrottle
 from enterprise.api.utils import (
     create_message_body,
     get_ent_cust_from_enterprise_customer_key,
@@ -164,7 +164,7 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     """
     API views for the ``enterprise-customer`` API endpoint.
     """
-
+    throttle_classes = (HighServiceUserThrottle, )
     queryset = models.EnterpriseCustomer.active_customers.all()
     serializer_class = serializers.EnterpriseCustomerSerializer
     filter_backends = EnterpriseReadWriteModelViewSet.filter_backends + (EnterpriseLinkedUserFilterBackend,)

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -158,6 +158,7 @@ DEFAULT_FROM_EMAIL = 'course_staff@example.com'
 
 USER_THROTTLE_RATE = '190/minute'
 SERVICE_USER_THROTTLE_RATE = '200/minute'
+SERVICE_USER_HIGH_THROTTLE_RATE = '200/minute'
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
     'PAGE_SIZE': 10,
@@ -168,6 +169,7 @@ REST_FRAMEWORK = {
     'DEFAULT_THROTTLE_RATES': {
         'user': USER_THROTTLE_RATE,
         'service_user': SERVICE_USER_THROTTLE_RATE,
+        'high_service_user': SERVICE_USER_HIGH_THROTTLE_RATE,
     },
     'DATETIME_FORMAT': '%Y-%m-%dT%H:%M:%SZ',
 }
@@ -337,7 +339,7 @@ LOGIN_REDIRECT_WHITELIST = [
     'failure.url',
     'google.com',
     'facebook.com'
-    ]
+]
 
 ENTERPRISE_PLOTLY_SECRET = "I am a secret"
 ENTERPRISE_MANUAL_REPORTING_CUSTOMER_UUIDS = ['12aacfee8ffa4cb3bed1059565a57f06',]

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -22,6 +22,7 @@ from testfixtures import LogCapture
 
 from django.conf import settings
 from django.contrib.auth.models import Permission
+from django.core.cache import cache
 from django.test import override_settings
 from django.utils import timezone
 
@@ -3967,6 +3968,14 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         )
 
         return user, enterprise_user, enterprise_customer
+
+    def tearDown(self):
+        """
+        Clears the Django cache, which means that throttle limits
+        will be reset between test runs.
+        """
+        super().tearDown()
+        cache.clear()
 
     @ddt.data(
         # enrollment_info usage


### PR DESCRIPTION
**Description**
we were facing 429 errors on `https://courses.edx.org/enterprise/api/v1/enterprise-customer/{enterprise_uuid}/` endpoint. As we were facing these alerts simultaneously on a daily basis, I increased the throttle limit of service users for `EnterpriseCustomerViewSet`.

JIRA: [ENT-4727](https://2u-internal.atlassian.net/browse/ENT-4727)
 
…overviews

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
