### PR TITLE
feat: faux x-request-id logging in enterprise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,12 +15,16 @@ Change Log
 
 Unreleased
 ----------
-* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
-  deprecated
+
+[3.66.7]
+--------
+feat: optional x-request-id logging
 
 [3.66.6]
 --------
-feat: increase the throttle limit of service users for EnterpriseCustomerViewSet
+* feat: increase the throttle limit of service users for EnterpriseCustomerViewSet
+* Switch from ``edx-sphinx-theme`` to ``sphinx-book-theme`` since the former is
+  deprecated
 
 [3.66.5]
 --------

--- a/consent/models.py
+++ b/consent/models.py
@@ -2,7 +2,6 @@
 Models for edX Enterprise's Consent application.
 """
 
-import logging
 
 from simple_history.models import HistoricalRecords
 
@@ -17,10 +16,11 @@ from model_utils.models import TimeStampedModel
 from consent.errors import InvalidProxyConsent
 from consent.mixins import ConsentModelMixin
 from enterprise.api_client.discovery import get_course_catalog_api_service_client
+from enterprise.logging import getEnterpriseLogger
 from enterprise.models import EnterpriseCustomer
 
 mark_safe_lazy = lazy(mark_safe, str)
-LOGGER = logging.getLogger(__name__)
+LOGGER = getEnterpriseLogger(__name__)
 
 
 class DataSharingConsentQuerySet(models.query.QuerySet):

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.66.6"
+__version__ = "3.66.7"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -6,7 +6,6 @@ import copy
 import datetime
 from collections import defaultdict
 from collections.abc import Iterable
-from logging import getLogger
 
 import pytz
 from edx_rest_api_client.exceptions import HttpClientError
@@ -23,6 +22,7 @@ from enterprise import models, utils
 from enterprise.api.v1.fields import Base64EmailCSVField
 from enterprise.api_client.lms import ThirdPartyAuthApiClient
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_PERMISSION_GROUPS, DefaultColors
+from enterprise.logging import getEnterpriseLogger
 from enterprise.models import (
     AdminNotification,
     AdminNotificationRead,
@@ -40,7 +40,7 @@ from enterprise.utils import (
 )
 from enterprise.validators import validate_pgp_key
 
-LOGGER = getLogger(__name__)
+LOGGER = getEnterpriseLogger(__name__)
 User = auth.get_user_model()
 
 

--- a/enterprise/api/v1/views.py
+++ b/enterprise/api/v1/views.py
@@ -2,7 +2,6 @@
 Views for enterprise api version 1 endpoint.
 """
 
-from logging import getLogger
 from smtplib import SMTPException
 from time import time
 from urllib.parse import quote_plus, unquote
@@ -71,6 +70,7 @@ from enterprise.errors import (
     LinkUserToEnterpriseError,
     UnlinkUserFromEnterpriseError,
 )
+from enterprise.logging import getEnterpriseLogger
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     enroll_subsidy_users_in_courses,
@@ -96,7 +96,7 @@ except ImportError:
     CourseMode = None
     enrollment_api = None
 
-LOGGER = getLogger(__name__)
+LOGGER = getEnterpriseLogger(__name__)
 
 User = auth.get_user_model()
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -6,7 +6,6 @@ import collections
 import itertools
 import json
 from decimal import Decimal
-from logging import getLogger
 from urllib.parse import urljoin
 from uuid import UUID, uuid4
 
@@ -53,6 +52,7 @@ from enterprise.constants import (
     json_serialized_course_modes,
 )
 from enterprise.errors import LinkUserToEnterpriseError
+from enterprise.logging import getEnterpriseLogger
 from enterprise.tasks import send_enterprise_email_notification
 from enterprise.utils import (
     ADMIN_ENROLL_EMAIL_TEMPLATE_TYPE,
@@ -89,7 +89,7 @@ try:
 except ImportError:
     CourseEntitlement = None
 
-LOGGER = getLogger(__name__)
+LOGGER = getEnterpriseLogger(__name__)
 User = auth.get_user_model()
 mark_safe_lazy = lazy(mark_safe, str)
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -3,7 +3,6 @@ Utility functions for enterprise app.
 """
 import datetime
 import json
-import logging
 import os
 import re
 from urllib.parse import parse_qs, quote, urlencode, urljoin, urlparse, urlsplit, urlunsplit
@@ -44,6 +43,7 @@ from enterprise.constants import (
     PROGRAM_TYPE_DESCRIPTION,
     CourseModes,
 )
+from enterprise.logging import getEnterpriseLogger
 
 try:
     from openedx.features.enterprise_support.enrollments.utils import lms_enroll_user_in_course
@@ -104,7 +104,7 @@ except ImportError:
 SELF_ENROLL_EMAIL_TEMPLATE_TYPE = 'SELF_ENROLL'
 ADMIN_ENROLL_EMAIL_TEMPLATE_TYPE = 'ADMIN_ENROLL'
 
-LOGGER = logging.getLogger(__name__)
+LOGGER = getEnterpriseLogger(__name__)
 
 User = auth.get_user_model()
 

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -6,7 +6,6 @@ import datetime
 import json
 import re
 from collections import namedtuple
-from logging import getLogger
 from urllib.parse import parse_qs, urlencode, urljoin, urlsplit, urlunsplit
 from uuid import UUID
 
@@ -52,6 +51,7 @@ from enterprise.forms import (
     EnterpriseLoginForm,
     EnterpriseSelectionForm,
 )
+from enterprise.logging import getEnterpriseLogger
 from enterprise.models import (
     EnterpriseCourseEnrollment,
     EnterpriseCustomerCatalog,
@@ -104,7 +104,7 @@ try:
 except ImportError:
     get_provider_login_url = None
 
-LOGGER = getLogger(__name__)
+LOGGER = getEnterpriseLogger(__name__)
 BASKET_URL = urljoin(settings.ECOMMERCE_PUBLIC_URL_ROOT, '/basket/add/')
 LMS_DASHBOARD_URL = urljoin(settings.LMS_ROOT_URL, '/dashboard')
 LMS_PROGRAMS_DASHBOARD_URL = urljoin(settings.LMS_ROOT_URL, '/dashboard/programs/{uuid}')


### PR DESCRIPTION
## Description

- we've implemented X-Request-ID logging in a number of Enterprise IDAs via logger middleware
- we'd like to avoid adding that middleware in the core LMS platform code
- this is a proposal for a logging adapter, wont cover absolutely everything but gives us something
- based on https://docs.python.org/3/howto/logging-cookbook.html#using-loggeradapters-to-impart-contextual-information

## Notes

You may ask yourself "Why doesn't he just extend `Logger` and use `logging.setLoggerClass(klass)`? Well, that seems to pop in our logger in globally.


## Example Usage

```
from enterprise.logging import getEnterpriseLogger

logger = getEnterpriseLogger(__name__)

logger.info("...and how!")
```

