### PR TITLE
chore: more orphaned content transmission logging

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+ 
+[3.67.1]
+--------
+chore: more orphaned content transmission logging
 
 [3.67.0]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.67.0"
+__version__ = "3.67.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -436,8 +436,16 @@ class ContentMetadataExporter(Exporter):
         ) & content_query
 
         # Grab orphaned content metadata items for the customer, ordered by oldest to newest
-        return OrphanedContentTransmissions.objects.filter(base_query).order_by('created')[:max_set_count]
+        orphaned_content = OrphanedContentTransmissions.objects.filter(base_query)
+        num_records = len(orphaned_content)
+        self._log_info(
+            f'Found {num_records} orphaned content records for customer: '
+            f'{self.enterprise_customer.uuid}. Returning {min(max_set_count, num_records)} records.'
+        )
+        ordered_and_chunked_orphaned_content = orphaned_content.order_by('created')[:max_set_count]
+        return ordered_and_chunked_orphaned_content
 
+    # pylint: disable=too-many-statements
     def export(self, **kwargs):
         """
         Export transformed content metadata if there has been an update to the consumer's catalogs
@@ -529,8 +537,20 @@ class ContentMetadataExporter(Exporter):
                 delete_payload[key] = item
 
         # If we're not at the max payload count, we can check for orphaned content and shove it in the delete payload
-        current_payload_count = len(items_to_create) + len(items_to_update) + len(items_to_delete)
+        current_payload_count = len(create_payload) + len(update_payload) + len(delete_payload)
+
+        self._log_info(
+            f'Exporter finished iterating over catalogs for customer: {self.enterprise_customer.uuid},'
+            f'with a current payload count of: {current_payload_count}. Is there room for orphaned content'
+            f'in the exporter payload?: {current_payload_count < max_payload_count}'
+        )
+
         if current_payload_count < max_payload_count:
+            self._log_info(
+                f'Exporter has {max_payload_count - current_payload_count} slots left in the payload for customer: '
+                f'{self.enterprise_customer.uuid}, searching for orphaned content to append'
+            )
+
             space_left_in_payload = max_payload_count - current_payload_count
             orphaned_content_to_delete = self._get_customer_config_orphaned_content(
                 max_set_count=space_left_in_payload,


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
