### PR TITLE
feat: adding managent command to clear error state

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,7 +15,10 @@ Change Log
 
 Unreleased
 ----------
- 
+[3.67.3]
+--------
+feat: adding managent command to clear error state 
+
 [3.67.2]
 --------
 fix: fixing name of table used by model fetching method

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.67.2"
+__version__ = "3.67.3"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/management/commands/update_config_last_errored_at.py
+++ b/enterprise/management/commands/update_config_last_errored_at.py
@@ -73,7 +73,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         """
         try:
             has_learner_errors, has_content_errors = True, True
-            yesterday = datetime.now() - timedelta(days=1)
+            yesterday = datetime.utcnow() - timedelta(days=1)
             for channel_code, (ConfigModel, LearnerAuditModel) in MODELS.items():
                 configs = ConfigModel.objects.all()
                 for config in configs:
@@ -108,7 +108,7 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
                         LOGGER.info(
                             'Config with id {}, channel code {}, enterprise customer {}'
                             ' error information has been updated'.format(
-                            config.id, channel_code, config.enterprise_customer.uuid
+                                config.id, channel_code, config.enterprise_customer.uuid
                             )
                         )
                     config.save()
@@ -123,4 +123,3 @@ class Command(IntegratedChannelCommandMixin, BaseCommand):
         LOGGER.info('Begin nulling out outdated last_sync_errored_at in configs')
         self.update_config_last_errored_at()
         LOGGER.info('Finished nulling out outdated last_sync_errored_at in configs')
-

--- a/enterprise/management/commands/update_config_last_errored_at.py
+++ b/enterprise/management/commands/update_config_last_errored_at.py
@@ -1,0 +1,117 @@
+"""
+Backfill missing audit record foreign keys.
+"""
+import logging
+from datetime import datetime, timedelta
+
+from django.core.management.base import BaseCommand
+from django.utils.translation import gettext as _
+
+from integrated_channels.blackboard.models import (
+    BlackboardEnterpriseCustomerConfiguration,
+    BlackboardLearnerAssessmentDataTransmissionAudit,
+    BlackboardLearnerDataTransmissionAudit,
+)
+from integrated_channels.canvas.models import (
+    CanvasEnterpriseCustomerConfiguration,
+    CanvasLearnerAssessmentDataTransmissionAudit,
+    CanvasLearnerDataTransmissionAudit,
+)
+from integrated_channels.cornerstone.models import (
+    CornerstoneEnterpriseCustomerConfiguration,
+    CornerstoneLearnerDataTransmissionAudit,
+)
+from integrated_channels.degreed2.models import (
+    Degreed2EnterpriseCustomerConfiguration,
+    Degreed2LearnerDataTransmissionAudit,
+)
+from integrated_channels.degreed.models import (
+    DegreedEnterpriseCustomerConfiguration,
+    DegreedLearnerDataTransmissionAudit,
+)
+from integrated_channels.integrated_channel.management.commands import IntegratedChannelCommandMixin
+from integrated_channels.integrated_channel.models import (
+    ContentMetadataItemTransmission,
+    GenericEnterpriseCustomerPluginConfiguration,
+    GenericLearnerDataTransmissionAudit,
+)
+from integrated_channels.moodle.models import MoodleEnterpriseCustomerConfiguration, MoodleLearnerDataTransmissionAudit
+from integrated_channels.sap_success_factors.models import (
+    SAPSuccessFactorsEnterpriseCustomerConfiguration,
+    SapSuccessFactorsLearnerDataTransmissionAudit,
+)
+
+MODELS = {
+    'MOODLE': [MoodleEnterpriseCustomerConfiguration, MoodleLearnerDataTransmissionAudit],
+    'CSOD': [CornerstoneEnterpriseCustomerConfiguration, CornerstoneLearnerDataTransmissionAudit],
+    'BLACKBOARD': [BlackboardEnterpriseCustomerConfiguration, BlackboardLearnerDataTransmissionAudit],
+    'BLACKBOARD_ASMT': [BlackboardEnterpriseCustomerConfiguration, BlackboardLearnerAssessmentDataTransmissionAudit],
+    'CANVAS': [CanvasEnterpriseCustomerConfiguration, CanvasLearnerDataTransmissionAudit],
+    'CANVAS_ASMT': [CanvasEnterpriseCustomerConfiguration, CanvasLearnerAssessmentDataTransmissionAudit],
+    'DEGREED': [DegreedEnterpriseCustomerConfiguration, DegreedLearnerDataTransmissionAudit],
+    'DEGREED2': [Degreed2EnterpriseCustomerConfiguration, Degreed2LearnerDataTransmissionAudit],
+    'GENERIC': [GenericEnterpriseCustomerPluginConfiguration, GenericLearnerDataTransmissionAudit],
+    'SAP': [SAPSuccessFactorsEnterpriseCustomerConfiguration, SapSuccessFactorsLearnerDataTransmissionAudit],
+}
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(IntegratedChannelCommandMixin, BaseCommand):
+    """
+    Management command which backfills missing audit record foreign keys.
+    """
+    help = _('''
+    Set error state for configurations.
+    ''')
+
+    def update_config_last_errored_at(self):
+        """
+        For each audit record kind (learner and content), find all the records in batch, and lookup
+        if they've had recent sync errors in the last day. If not, clear out the last_content_sync_errored_at
+        value associated with the configuration.
+        """
+        try:
+            has_learner_errors, has_content_errors = True, True
+            yesterday = datetime.now() - timedelta(days=1)
+            for channel_code, (ConfigModel, LearnerAuditModel) in MODELS.items():
+                configs = ConfigModel.objects.all().filter()
+                for config in configs:
+                    if config.last_sync_errored_at is None:
+                        continue
+                    customer_uuid = config.enterprise_customer.uuid
+                    plugin_id = config.id
+
+                    errored_learner_audits = LearnerAuditModel.objects.filter(
+                        created__date__gt=yesterday,
+                        status__gt=299,
+                        enterprise_customer_uuid=customer_uuid,
+                        plugin_configuration_id=plugin_id,
+                    )
+                    if not errored_learner_audits:
+                        config.last_learner_sync_errored_at = None
+                        has_learner_errors = False
+
+                    errored_content_audits = ContentMetadataItemTransmission.objects.filter(
+                        remote_created_at__gt=yesterday,
+                        enterprise_customer=config.enterprise_customer,
+                        integrated_channel_code=channel_code,
+                        plugin_configuration_id=plugin_id,
+                        api_response_status_code__gt=299
+                    )
+                    if not errored_content_audits:
+                        config.last_content_sync_errored_at = None
+                        has_content_errors = False
+
+                    if not has_learner_errors and not has_content_errors:
+                        config.last_sync_errored_at = None
+                    config.save()
+        except Exception as exc:
+            LOGGER.exception('backfill_missing_foreign_keys failed', exc_info=exc)
+            raise exc
+
+    def handle(self, *args, **options):
+        """
+        Set error state for configurations.
+        """
+        self.update_config_last_errored_at()

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1982,9 +1982,7 @@ class TestUpdateConfigLastErroredAt(unittest.TestCase, EnterpriseMockMixin):
         Verify that the management command runs when all records have the same subdomain
         """
         old_timestamp = datetime.now() - timedelta(days=5)
-        print('before ', old_timestamp)
         old_timestamp = old_timestamp.replace(tzinfo=pytz.UTC)
-        print('after ', old_timestamp)
         moodle_config = factories.MoodleEnterpriseCustomerConfigurationFactory(
             enterprise_customer=self.enterprise_customer_2,
             last_sync_errored_at=old_timestamp,


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- x ] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
