### PR TITLE
feat: add button to update customer modified time

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[3.67.4]
+--------
+feat: add button to update customer modified time
+
 [3.67.3]
 --------
 feat: adding managent command to clear error state 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.67.3"
+__version__ = "3.67.4"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -91,20 +91,16 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The blackboard enterprise customer content metadata "
-                "“<BlackboardEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The blackboard enterprise customer content metadata
+                “<BlackboardEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The blackboard enterprise customer content metadata "
-                "“<BlackboardEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The blackboard enterprise customer content metadata
+                “<BlackboardEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
             "/admin/blackboard/blackboardenterprisecustomerconfiguration"

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -54,7 +54,7 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.
     )
 
     search_fields = ("enterprise_customer_name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = BlackboardEnterpriseCustomerConfiguration
@@ -82,7 +82,7 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.
         else:
             return None
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -91,29 +91,28 @@ class BlackboardEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The blackboard enterprise customer modified time "
+                "The blackboard enterprise customer content metadata "
                 "“<BlackboardEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The blackboard enterprise customer modified time "
+                "The blackboard enterprise customer content metadata "
                 "“<BlackboardEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         return HttpResponseRedirect(
             "/admin/blackboard/blackboardenterprisecustomerconfiguration"
         )
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(BlackboardLearnerDataTransmissionAudit)

--- a/integrated_channels/blackboard/admin/__init__.py
+++ b/integrated_channels/blackboard/admin/__init__.py
@@ -2,11 +2,11 @@
 Admin integration for configuring Blackboard app to communicate with Blackboard systems.
 """
 from config_models.admin import ConfigurationModelAdmin
+from django_object_actions import DjangoObjectActions
 
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 from django.utils.html import format_html
 
 from integrated_channels.blackboard.models import (

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -38,7 +38,7 @@ class CanvasEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
     )
 
     search_fields = ("enterprise_customer_name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = CanvasEnterpriseCustomerConfiguration
@@ -66,7 +66,7 @@ class CanvasEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
         else:
             return None
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -75,29 +75,28 @@ class CanvasEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The canvas enterprise customer modified time "
+                "The canvas enterprise customer content metadata "
                 "“<CanvasEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The canvas enterprise customer modified time "
+                "The canvas enterprise customer content metadata "
                 "“<CanvasEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         return HttpResponseRedirect(
             "/admin/canvas/canvasenterprisecustomerconfiguration"
         )
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(CanvasLearnerDataTransmissionAudit)

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -75,20 +75,16 @@ class CanvasEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The canvas enterprise customer content metadata "
-                "“<CanvasEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The canvas enterprise customer content metadata
+                “<CanvasEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The canvas enterprise customer content metadata "
-                "“<CanvasEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The canvas enterprise customer content metadata
+                “<CanvasEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
             "/admin/canvas/canvasenterprisecustomerconfiguration"

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -1,8 +1,10 @@
 """
 Admin integration for configuring Canvas app to communicate with Canvas systems.
 """
-
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django_object_actions import DjangoObjectActions
 from django.utils.html import format_html
 
 from integrated_channels.canvas.models import CanvasEnterpriseCustomerConfiguration, CanvasLearnerDataTransmissionAudit
@@ -10,7 +12,7 @@ from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmis
 
 
 @admin.register(CanvasEnterpriseCustomerConfiguration)
-class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
+class CanvasEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     """
     Django admin model for CanvasEnterpriseCustomerConfiguration.
     """
@@ -35,6 +37,7 @@ class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     )
 
     search_fields = ("enterprise_customer_name",)
+    change_actions = ("update_modified_time",)
 
     class Meta:
         model = CanvasEnterpriseCustomerConfiguration
@@ -61,6 +64,39 @@ class CanvasEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
             return format_html((f'<a href="{obj.oauth_authorization_url}">Authorize Link</a>'))
         else:
             return None
+
+    def update_modified_time(self, request, obj):
+        """
+        Updates the modified time of the customer record to retransmit courses metadata
+        and redirects to configuration view with success or error message.
+        """
+        try:
+            obj.enterprise_customer.save()
+            messages.success(
+                request,
+                "The canvas enterprise customer modified time "
+                "“<CanvasEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        except ValidationError:
+            messages.error(
+                request,
+                "The canvas enterprise customer modified time "
+                "“<CanvasEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was not saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        return HttpResponseRedirect(
+            "/admin/canvas/canvasenterprisecustomerconfiguration"
+        )
+    update_modified_time.label = "Update Customer Modified Time"
+    update_modified_time.short_description = (
+        "Update modified time for this Enterprise Customer "
+    )
+    "to retransmit courses metadata"
 
 
 @admin.register(CanvasLearnerDataTransmissionAudit)

--- a/integrated_channels/canvas/admin/__init__.py
+++ b/integrated_channels/canvas/admin/__init__.py
@@ -1,10 +1,11 @@
 """
 Admin integration for configuring Canvas app to communicate with Canvas systems.
 """
+from django_object_actions import DjangoObjectActions
+
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 from django.utils.html import format_html
 
 from integrated_channels.canvas.models import CanvasEnterpriseCustomerConfiguration, CanvasLearnerDataTransmissionAudit

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -4,7 +4,10 @@ Django admin integration for configuring cornerstone ondemand app to communicate
 
 from config_models.admin import ConfigurationModelAdmin
 
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django_object_actions import DjangoObjectActions
 
 from integrated_channels.cornerstone.models import (
     CornerstoneEnterpriseCustomerConfiguration,
@@ -31,7 +34,7 @@ class CornerstoneGlobalConfigurationAdmin(ConfigurationModelAdmin):
 
 
 @admin.register(CornerstoneEnterpriseCustomerConfiguration)
-class CornerstoneEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
+class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     """
     Django admin model for CornerstoneEnterpriseCustomerConfiguration.
     """
@@ -53,8 +56,8 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     )
 
     list_filter = ("active",)
-
     search_fields = ("enterprise_customer_name",)
+    change_actions = ("update_modified_time",)
 
     class Meta:
         model = CornerstoneEnterpriseCustomerConfiguration
@@ -68,6 +71,39 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    def update_modified_time(self, request, obj):
+        """
+        Updates the modified time of the customer record to retransmit courses metadata
+        and redirects to configuration view with success or error message.
+        """
+        try:
+            obj.enterprise_customer.save()
+            messages.success(
+                request,
+                "The cornerstone enterprise customer modified time "
+                "“<CornerstoneEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        except ValidationError:
+            messages.error(
+                request,
+                "The cornerstone enterprise customer modified time "
+                "“<CornerstoneEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was not saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        return HttpResponseRedirect(
+            "/admin/cornerstone/cornerstoneenterprisecustomerconfiguration"
+        )
+    update_modified_time.label = "Update Customer Modified Time"
+    update_modified_time.short_description = (
+        "Update modified time for this Enterprise Customer "
+    )
+    "to retransmit courses metadata"
 
 
 @admin.register(CornerstoneLearnerDataTransmissionAudit)

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -57,7 +57,7 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = CornerstoneEnterpriseCustomerConfiguration
@@ -72,7 +72,7 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
         """
         return obj.enterprise_customer.name
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -81,29 +81,28 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The cornerstone enterprise customer modified time "
+                "The cornerstone enterprise customer content metadata "
                 "“<CornerstoneEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The cornerstone enterprise customer modified time "
+                "The cornerstone enterprise customer content metadata "
                 "“<CornerstoneEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         return HttpResponseRedirect(
             "/admin/cornerstone/cornerstoneenterprisecustomerconfiguration"
         )
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(CornerstoneLearnerDataTransmissionAudit)

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -81,20 +81,16 @@ class CornerstoneEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The cornerstone enterprise customer content metadata "
-                "“<CornerstoneEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The cornerstone enterprise customer content metadata
+                “<CornerstoneEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The cornerstone enterprise customer content metadata "
-                "“<CornerstoneEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The cornerstone enterprise customer content metadata
+                “<CornerstoneEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
             "/admin/cornerstone/cornerstoneenterprisecustomerconfiguration"

--- a/integrated_channels/cornerstone/admin/__init__.py
+++ b/integrated_channels/cornerstone/admin/__init__.py
@@ -3,11 +3,11 @@ Django admin integration for configuring cornerstone ondemand app to communicate
 """
 
 from config_models.admin import ConfigurationModelAdmin
+from django_object_actions import DjangoObjectActions
 
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 
 from integrated_channels.cornerstone.models import (
     CornerstoneEnterpriseCustomerConfiguration,

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -4,7 +4,10 @@ Django admin integration for configuring degreed app to communicate with Degreed
 
 from config_models.admin import ConfigurationModelAdmin
 
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django_object_actions import DjangoObjectActions
 
 from integrated_channels.degreed.models import (
     DegreedEnterpriseCustomerConfiguration,
@@ -31,7 +34,7 @@ class DegreedGlobalConfigurationAdmin(ConfigurationModelAdmin):
 
 
 @admin.register(DegreedEnterpriseCustomerConfiguration)
-class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
+class DegreedEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     """
     Django admin model for DegreedEnterpriseCustomerConfiguration.
     """
@@ -58,6 +61,7 @@ class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
+    change_actions = ("update_modified_time",)
 
     class Meta:
         model = DegreedEnterpriseCustomerConfiguration
@@ -71,6 +75,40 @@ class DegreedEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    def update_modified_time(self, request, obj):
+        """
+        Updates the modified time of the customer record to retransmit courses metadata
+        and redirects to configuration view with success or error message.
+        """
+        try:
+            obj.enterprise_customer.save()
+            messages.success(
+                request,
+                "The degreed enterprise customer modified time "
+                "“<DegreedEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        except ValidationError:
+            messages.error(
+                request,
+                "The degreed enterprise customer modified time "
+                "“<DegreedEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was not saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        return HttpResponseRedirect(
+            "/admin/degreed/degreedenterprisecustomerconfiguration"
+        )
+
+    update_modified_time.label = "Update Customer Modified Time"
+    update_modified_time.short_description = (
+        "Update modified time for this Enterprise Customer "
+    )
+    "to retransmit courses metadata"
 
 
 @admin.register(DegreedLearnerDataTransmissionAudit)

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -3,11 +3,11 @@ Django admin integration for configuring degreed app to communicate with Degreed
 """
 
 from config_models.admin import ConfigurationModelAdmin
+from django_object_actions import DjangoObjectActions
 
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 
 from integrated_channels.degreed.models import (
     DegreedEnterpriseCustomerConfiguration,

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -61,7 +61,7 @@ class DegreedEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mod
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = DegreedEnterpriseCustomerConfiguration
@@ -76,7 +76,7 @@ class DegreedEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mod
         """
         return obj.enterprise_customer.name
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -85,18 +85,18 @@ class DegreedEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mod
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The degreed enterprise customer modified time "
+                "The degreed enterprise customer content metadata "
                 "“<DegreedEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The degreed enterprise customer modified time "
+                "The degreed enterprise customer content metadata "
                 "“<DegreedEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
@@ -104,11 +104,10 @@ class DegreedEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mod
             "/admin/degreed/degreedenterprisecustomerconfiguration"
         )
 
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(DegreedLearnerDataTransmissionAudit)

--- a/integrated_channels/degreed/admin/__init__.py
+++ b/integrated_channels/degreed/admin/__init__.py
@@ -85,20 +85,16 @@ class DegreedEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mod
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The degreed enterprise customer content metadata "
-                "“<DegreedEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The degreed enterprise customer content metadata
+                “<DegreedEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The degreed enterprise customer content metadata "
-                "“<DegreedEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The degreed enterprise customer content metadata
+                “<DegreedEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
             "/admin/degreed/degreedenterprisecustomerconfiguration"

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -3,7 +3,10 @@
 Django admin integration for configuring degreed app to communicate with Degreed systems.
 """
 
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django_object_actions import DjangoObjectActions
 
 from integrated_channels.degreed2.models import (
     Degreed2EnterpriseCustomerConfiguration,
@@ -13,7 +16,7 @@ from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmis
 
 
 @admin.register(Degreed2EnterpriseCustomerConfiguration)
-class Degreed2EnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
+class Degreed2EnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     """
     Django admin model for Degreed2EnterpriseCustomerConfiguration.
     """
@@ -37,6 +40,7 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
+    change_actions = ("update_modified_time",)
 
     class Meta:
         model = Degreed2EnterpriseCustomerConfiguration
@@ -50,6 +54,31 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    def update_modified_time(self, request, obj):
+        """
+        Updates the modified time of the customer record to retransmit courses metadata
+        and redirects to configuration view with success or error message.
+        """
+        try:
+            obj.enterprise_customer.save()
+            messages.success(
+                request,
+                'The degreed2 enterprise customer modified time '
+                '“<Degreed2EnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” '
+                'was saved successfully.'.format(enterprise_name=obj.enterprise_customer.name))
+        except ValidationError:
+            messages.error(
+                request,
+                'The degreed2 enterprise customer modified time '
+                '“<Degreed2EnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” '
+                'was not saved successfully.'.format(enterprise_name=obj.enterprise_customer.name))
+        return HttpResponseRedirect('/admin/degreed2/degreed2enterprisecustomerconfiguration')
+    update_modified_time.label = "Update Customer Modified Time"
+    update_modified_time.short_description = (
+        "Update modified time for this Enterprise Customer "
+    )
+    "to retransmit courses metadata"
 
 
 @admin.register(Degreed2LearnerDataTransmissionAudit)

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -3,10 +3,11 @@
 Django admin integration for configuring degreed app to communicate with Degreed systems.
 """
 
+from django_object_actions import DjangoObjectActions
+
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 
 from integrated_channels.degreed2.models import (
     Degreed2EnterpriseCustomerConfiguration,

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -41,7 +41,7 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mo
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer_name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = Degreed2EnterpriseCustomerConfiguration
@@ -56,7 +56,7 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mo
         """
         return obj.enterprise_customer.name
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -65,21 +65,20 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mo
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                'The degreed2 enterprise customer modified time '
+                'The degreed2 enterprise customer content metadata '
                 '“<Degreed2EnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” '
-                'was saved successfully.'.format(enterprise_name=obj.enterprise_customer.name))
+                'was updated successfully.'.format(enterprise_name=obj.enterprise_customer.name))
         except ValidationError:
             messages.error(
                 request,
-                'The degreed2 enterprise customer modified time '
+                'The degreed2 enterprise customer content metadata '
                 '“<Degreed2EnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” '
-                'was not saved successfully.'.format(enterprise_name=obj.enterprise_customer.name))
+                'was not updated successfully.'.format(enterprise_name=obj.enterprise_customer.name))
         return HttpResponseRedirect('/admin/degreed2/degreed2enterprisecustomerconfiguration')
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(Degreed2LearnerDataTransmissionAudit)

--- a/integrated_channels/degreed2/admin/__init__.py
+++ b/integrated_channels/degreed2/admin/__init__.py
@@ -65,15 +65,17 @@ class Degreed2EnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mo
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                'The degreed2 enterprise customer content metadata '
-                '“<Degreed2EnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” '
-                'was updated successfully.'.format(enterprise_name=obj.enterprise_customer.name))
+                f'''The degreed2 enterprise customer content metadata
+                “<Degreed2EnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
+            )
         except ValidationError:
             messages.error(
                 request,
-                'The degreed2 enterprise customer content metadata '
-                '“<Degreed2EnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” '
-                'was not updated successfully.'.format(enterprise_name=obj.enterprise_customer.name))
+                f'''The degreed2 enterprise customer content metadata
+                “<Degreed2EnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
+            )
         return HttpResponseRedirect('/admin/degreed2/degreed2enterprisecustomerconfiguration')
     force_content_metadata_transmission.label = "Force content metadata transmission"
     force_content_metadata_transmission.short_description = (

--- a/integrated_channels/moodle/admin/__init__.py
+++ b/integrated_channels/moodle/admin/__init__.py
@@ -44,9 +44,9 @@ class MoodleEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
     )
 
     form = MoodleEnterpriseCustomerConfigurationForm
-    change_actions = ('update_modified_time',)
+    change_actions = ('force_content_metadata_transmission',)
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -55,29 +55,28 @@ class MoodleEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The moodle enterprise customer modified time "
+                "The moodle enterprise customer content metadata "
                 "“<MoodleEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The moodle enterprise customer modified time "
+                "The moodle enterprise customer content metadata "
                 "“<MoodleEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         return HttpResponseRedirect(
             "/admin/moodle/moodleenterprisecustomerconfiguration"
         )
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(MoodleLearnerDataTransmissionAudit)

--- a/integrated_channels/moodle/admin/__init__.py
+++ b/integrated_channels/moodle/admin/__init__.py
@@ -2,11 +2,12 @@
 Django admin integration for configuring moodle app to communicate with Moodle systems.
 """
 
+from django_object_actions import DjangoObjectActions
+
 from django import forms
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 from django.utils.translation import gettext_lazy as _
 
 from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin

--- a/integrated_channels/moodle/admin/__init__.py
+++ b/integrated_channels/moodle/admin/__init__.py
@@ -3,8 +3,10 @@ Django admin integration for configuring moodle app to communicate with Moodle s
 """
 
 from django import forms
-from django.contrib import admin
+from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django_object_actions import DjangoObjectActions
 from django.utils.translation import gettext_lazy as _
 
 from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin
@@ -31,7 +33,7 @@ class MoodleEnterpriseCustomerConfigurationForm(forms.ModelForm):
 
 
 @admin.register(MoodleEnterpriseCustomerConfiguration)
-class MoodleEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
+class MoodleEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     """
     Django admin model for MoodleEnterpriseCustomerConfiguration.
     """
@@ -41,6 +43,40 @@ class MoodleEnterpriseCustomerConfigurationAdmin(admin.ModelAdmin):
     )
 
     form = MoodleEnterpriseCustomerConfigurationForm
+    change_actions = ('update_modified_time',)
+
+    def update_modified_time(self, request, obj):
+        """
+        Updates the modified time of the customer record to retransmit courses metadata
+        and redirects to configuration view with success or error message.
+        """
+        try:
+            obj.enterprise_customer.save()
+            messages.success(
+                request,
+                "The moodle enterprise customer modified time "
+                "“<MoodleEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        except ValidationError:
+            messages.error(
+                request,
+                "The moodle enterprise customer modified time "
+                "“<MoodleEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
+                "was not saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        return HttpResponseRedirect(
+            "/admin/moodle/moodleenterprisecustomerconfiguration"
+        )
+    update_modified_time.label = "Update Customer Modified Time"
+    update_modified_time.short_description = (
+        "Update modified time for this Enterprise Customer "
+    )
+    "to retransmit courses metadata"
 
 
 @admin.register(MoodleLearnerDataTransmissionAudit)

--- a/integrated_channels/moodle/admin/__init__.py
+++ b/integrated_channels/moodle/admin/__init__.py
@@ -55,20 +55,16 @@ class MoodleEnterpriseCustomerConfigurationAdmin(DjangoObjectActions, admin.Mode
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The moodle enterprise customer content metadata "
-                "“<MoodleEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The moodle enterprise customer content metadata
+                “<MoodleEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The moodle enterprise customer content metadata "
-                "“<MoodleEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The moodle enterprise customer content metadata
+                “<MoodleEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
             "/admin/moodle/moodleenterprisecustomerconfiguration"

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -3,12 +3,12 @@ Django admin integration for configuring sap_success_factors app to communicate 
 """
 
 from config_models.admin import ConfigurationModelAdmin
+from django_object_actions import DjangoObjectActions
 from requests import RequestException
 
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.admin import BaseLearnerDataTransmissionAuditAdmin

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -77,7 +77,7 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(DjangoObjectActions,
 
     list_filter = ("active",)
     search_fields = ("enterprise_customer__name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = SAPSuccessFactorsEnterpriseCustomerConfiguration
@@ -119,7 +119,7 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(DjangoObjectActions,
     has_access_token.boolean = True
     has_access_token.short_description = "Has Access Token?"
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -128,29 +128,28 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(DjangoObjectActions,
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The sap success factors enterprise customer modified time "
+                "The sap success factors enterprise customer content metadata "
                 "“<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The sap success factors enterprise customer modified time "
+                "The sap success factors enterprise customer content metadata "
                 "“<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         return HttpResponseRedirect(
             "/admin/sap_success_factors/sapsuccessfactorsenterprisecustomerconfiguration"
         )
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"
 
 
 @admin.register(SapSuccessFactorsLearnerDataTransmissionAudit)

--- a/integrated_channels/sap_success_factors/admin/__init__.py
+++ b/integrated_channels/sap_success_factors/admin/__init__.py
@@ -128,20 +128,16 @@ class SAPSuccessFactorsEnterpriseCustomerConfigurationAdmin(DjangoObjectActions,
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The sap success factors enterprise customer content metadata "
-                "“<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The sap success factors enterprise customer content metadata
+                “<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The sap success factors enterprise customer content metadata "
-                "“<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The sap success factors enterprise customer content metadata
+                “<SAPSuccessFactorsEnterpriseCustomerConfiguration for Enterprise
+                {obj.enterprise_customer.name}>” was not updated successfully.''',
             )
         return HttpResponseRedirect(
             "/admin/sap_success_factors/sapsuccessfactorsenterprisecustomerconfiguration"

--- a/integrated_channels/xapi/admin/__init__.py
+++ b/integrated_channels/xapi/admin/__init__.py
@@ -2,39 +2,41 @@
 Django admin integration for xAPI.
 """
 
-from django.contrib import admin
+from django.contrib import admin, messages
+from django.core.exceptions import ValidationError
+from django.http import HttpResponseRedirect
+from django_object_actions import DjangoObjectActions
 
 from integrated_channels.xapi.models import XAPILRSConfiguration
 
 
 @admin.register(XAPILRSConfiguration)
-class XAPILRSConfigurationAdmin(admin.ModelAdmin):
+class XAPILRSConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     """
     Django admin model for XAPILRSConfiguration.
     """
     fields = (
-        'enterprise_customer',
-        'active',
-        'endpoint',
-        'version',
-        'key',
-        'secret',
+        "enterprise_customer",
+        "active",
+        "endpoint",
+        "version",
+        "key",
+        "secret",
     )
 
     list_display = (
-        'enterprise_customer_name',
-        'active',
-        'endpoint',
-        'modified',
+        "enterprise_customer_name",
+        "active",
+        "endpoint",
+        "modified",
     )
 
-    raw_id_fields = (
-        'enterprise_customer',
-    )
+    raw_id_fields = ("enterprise_customer",)
 
-    ordering = ('enterprise_customer__name', )
-    list_filter = ('active', )
-    search_fields = ('enterprise_customer__name',)
+    ordering = ("enterprise_customer__name",)
+    list_filter = ("active",)
+    search_fields = ("enterprise_customer__name",)
+    change_actions = ("update_modified_time",)
 
     class Meta:
         model = XAPILRSConfiguration
@@ -48,3 +50,34 @@ class XAPILRSConfigurationAdmin(admin.ModelAdmin):
                 being rendered with this admin form.
         """
         return obj.enterprise_customer.name
+
+    def update_modified_time(self, request, obj):
+        """
+        Updates the modified time of the customer record to retransmit courses metadata
+        and redirects to configuration view with success or error message.
+        """
+        try:
+            obj.enterprise_customer.save()
+            messages.success(
+                request,
+                "The xapilrs enterprise customer modified time "
+                "“<XAPILRSConfiguration for Enterprise {enterprise_name}>” "
+                "was saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        except ValidationError:
+            messages.error(
+                request,
+                "The xapilrs enterprise customer modified time "
+                "“<XAPILRSConfiguration for Enterprise {enterprise_name}>” "
+                "was not saved successfully.".format(
+                    enterprise_name=obj.enterprise_customer.name
+                ),
+            )
+        return HttpResponseRedirect("/admin/xapi/xapilrsconfiguration/")
+    update_modified_time.label = "Update Customer Modified Time"
+    update_modified_time.short_description = (
+        "Update modified time for this Enterprise Customer "
+    )
+    "to retransmit courses metadata"

--- a/integrated_channels/xapi/admin/__init__.py
+++ b/integrated_channels/xapi/admin/__init__.py
@@ -37,7 +37,7 @@ class XAPILRSConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
     ordering = ("enterprise_customer__name",)
     list_filter = ("active",)
     search_fields = ("enterprise_customer__name",)
-    change_actions = ("update_modified_time",)
+    change_actions = ("force_content_metadata_transmission",)
 
     class Meta:
         model = XAPILRSConfiguration
@@ -52,7 +52,7 @@ class XAPILRSConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
         """
         return obj.enterprise_customer.name
 
-    def update_modified_time(self, request, obj):
+    def force_content_metadata_transmission(self, request, obj):
         """
         Updates the modified time of the customer record to retransmit courses metadata
         and redirects to configuration view with success or error message.
@@ -61,24 +61,23 @@ class XAPILRSConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The xapilrs enterprise customer modified time "
+                "The xapilrs enterprise customer content metadata "
                 "“<XAPILRSConfiguration for Enterprise {enterprise_name}>” "
-                "was saved successfully.".format(
+                "was updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         except ValidationError:
             messages.error(
                 request,
-                "The xapilrs enterprise customer modified time "
+                "The xapilrs enterprise customer content metadata "
                 "“<XAPILRSConfiguration for Enterprise {enterprise_name}>” "
-                "was not saved successfully.".format(
+                "was not updated successfully.".format(
                     enterprise_name=obj.enterprise_customer.name
                 ),
             )
         return HttpResponseRedirect("/admin/xapi/xapilrsconfiguration/")
-    update_modified_time.label = "Update Customer Modified Time"
-    update_modified_time.short_description = (
-        "Update modified time for this Enterprise Customer "
+    force_content_metadata_transmission.label = "Force content metadata transmission"
+    force_content_metadata_transmission.short_description = (
+        "Force content metadata transmission for this Enterprise Customer"
     )
-    "to retransmit courses metadata"

--- a/integrated_channels/xapi/admin/__init__.py
+++ b/integrated_channels/xapi/admin/__init__.py
@@ -61,20 +61,16 @@ class XAPILRSConfigurationAdmin(DjangoObjectActions, admin.ModelAdmin):
             obj.enterprise_customer.save()
             messages.success(
                 request,
-                "The xapilrs enterprise customer content metadata "
-                "“<XAPILRSConfiguration for Enterprise {enterprise_name}>” "
-                "was updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The xapilrs enterprise customer content metadata
+                “<XAPILRSConfiguration for Enterprise {obj.enterprise_customer.name}>”
+                was updated successfully.''',
             )
         except ValidationError:
             messages.error(
                 request,
-                "The xapilrs enterprise customer content metadata "
-                "“<XAPILRSConfiguration for Enterprise {enterprise_name}>” "
-                "was not updated successfully.".format(
-                    enterprise_name=obj.enterprise_customer.name
-                ),
+                f'''The xapilrs enterprise customer content metadata
+                “<XAPILRSConfiguration for Enterprise {obj.enterprise_customer.name}>”
+                was not updated successfully.''',
             )
         return HttpResponseRedirect("/admin/xapi/xapilrsconfiguration/")
     force_content_metadata_transmission.label = "Force content metadata transmission"

--- a/integrated_channels/xapi/admin/__init__.py
+++ b/integrated_channels/xapi/admin/__init__.py
@@ -2,10 +2,11 @@
 Django admin integration for xAPI.
 """
 
+from django_object_actions import DjangoObjectActions
+
 from django.contrib import admin, messages
 from django.core.exceptions import ValidationError
 from django.http import HttpResponseRedirect
-from django_object_actions import DjangoObjectActions
 
 from integrated_channels.xapi.models import XAPILRSConfiguration
 


### PR DESCRIPTION
## Description
Currently, to force a customer’s catalog to be retransmitted (updated) through the integrated channels, our team relies on the modified at times of the customer’s catalog object in the enterprise catalog service. While this is perfectly fine to use for our immediate team members, we’d like to have a more straight forward and intuitive approach. 

## Solution
A button to customers' integrated channel configuration admin page that will trigger an update on all content on the next transmission run by updating the the enterprise customer’s modified time.
<img width="1211" alt="Screenshot 2023-06-22 at 10 24 41 PM" src="https://github.com/openedx/edx-enterprise/assets/71999631/908b42ba-1845-4568-acff-f8c4342571b9">

On success, we will notify the user that the modified time was updated.
<img width="1218" alt="Screenshot 2023-06-23 at 11 41 38 AM" src="https://github.com/openedx/edx-enterprise/assets/71999631/2bc7a80f-ba7f-4f72-93b4-727075d9f186">

On error, we will notify the user that the modified time was not successfully updated.
<img width="1219" alt="Screenshot 2023-06-23 at 11 42 17 AM" src="https://github.com/openedx/edx-enterprise/assets/71999631/0e30510c-2510-4f00-b5d8-e9768205418d">

[JIRA ENT-2713](https://2u-internal.atlassian.net/browse/ENT-6713)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
