### PR TITLE
chore: upgrade course_enrollment from audit to verified

### DIFF
--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -46,9 +46,13 @@ from enterprise.constants import (
 from enterprise.logging import getEnterpriseLogger
 
 try:
-    from openedx.features.enterprise_support.enrollments.utils import lms_enroll_user_in_course
+    from openedx.features.enterprise_support.enrollments.utils import (
+        lms_enroll_user_in_course,
+        lms_update_or_create_enrollment,
+    )
 except ImportError:
     lms_enroll_user_in_course = None
+    lms_update_or_create_enrollment = None
 
 try:
     from openedx.core.djangoapps.course_groups.models import CourseUserGroup
@@ -1792,17 +1796,30 @@ def customer_admin_enroll_user_with_status(
     succeeded = False
     new_enrollment = False
     enterprise_fulfillment_source_uuid = None
+    emet_enable_auto_upgrade_enrollment_mode = getattr(
+        settings,
+        'ENABLE_ENTERPRISE_BACKEND_EMET_AUTO_UPGRADE_ENROLLMENT_MODE',
+        False,
+    )
     try:
-        # enrolls a user in a course per LMS flow, but this method does not create enterprise records yet so we need to
-        # create it immediately after calling lms_enroll_user_in_course. lms_enroll_user_in_course can return None if
-        # Enrollment already exists, does not fail in this case.
-        new_enrollment = lms_enroll_user_in_course(
-            user.username,
-            course_id,
-            course_mode,
-            enterprise_customer.uuid,
-            is_active=True,
-        )
+        # enrolls a user in a course per LMS flow, but this method doesn't create enterprise records
+        # yet so we need to create it immediately after calling lms_update_or_create_enrollment.
+        if emet_enable_auto_upgrade_enrollment_mode:
+            new_enrollment = lms_update_or_create_enrollment(
+                user.username,
+                course_id,
+                course_mode,
+                is_active=True,
+                enterprise_uuid=enterprise_customer.uuid,
+            )
+        else:
+            new_enrollment = lms_enroll_user_in_course(
+                user.username,
+                course_id,
+                course_mode,
+                enterprise_customer.uuid,
+                is_active=True,
+            )
         succeeded = True
         LOGGER.info("Successfully enrolled user %s in course %s", user.id, course_id)
     except (CourseEnrollmentError, CourseUserGroup.DoesNotExist) as error:


### PR DESCRIPTION
## Description

If an enterprise learner has enrolled in the audit course mode, we would like to support an automatic upgrade to the paid (verified) enrollment track.
In [edx-platform](https://github.com/openedx/edx-platform/pull/32595), the `lms_enroll_user_in_course` function is updated to `lms_update_or_create_enrollment`to allow for an update to the course_mode.
This PR updates the name of the function and any related comments.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
