### PR TITLE
fix: exporter sanitizing content to delete 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[3.69.1]
+--------
+fix: content metadata exporter sanitizing content to delete
+
 [3.69.0]
 --------
 refactor: Replaced the deprecated `NullBooleanField` with `BooleanField(null=True)`

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "3.69.0"
+__version__ = "3.69.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -204,6 +204,10 @@ HTTP_STATUS_STRINGS = {
     503: 'The server is temporarily unavailable.',
 }
 
+IC_CREATE_ACTION = 'create'
+IC_UPDATE_ACTION = 'update'
+IC_DELETE_ACTION = 'delete'
+
 
 class FulfillmentTypes:
     LICENSE = 'license'

--- a/integrated_channels/integrated_channel/models.py
+++ b/integrated_channels/integrated_channel/models.py
@@ -251,12 +251,16 @@ class EnterpriseCustomerPluginConfiguration(SoftDeletionModel):
             self.enterprise_customer.enterprise_customer_catalogs.all()
 
         customer_catalog_uuids = enterprise_customer_catalogs.values_list('uuid', flat=True)
+
+        non_existent_catalogs_filter = Q(enterprise_customer_catalog_uuid__in=customer_catalog_uuids)
+        null_catalogs_filter = Q(enterprise_customer_catalog_uuid__isnull=True)
+
         return ContentMetadataItemTransmission.objects.filter(
             integrated_channel_code=self.channel_code(),
             enterprise_customer=self.enterprise_customer,
             remote_deleted_at__isnull=True,
             remote_created_at__isnull=False,
-        ).exclude(enterprise_customer_catalog_uuid__in=customer_catalog_uuids)
+        ).filter(~non_existent_catalogs_filter | null_catalogs_filter)
 
     def update_content_synced_at(self, action_happened_at, was_successful):
         """

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -136,7 +136,7 @@ class ContentMetadataTransmitter(Transmitter):
             self.enterprise_configuration.channel_code()
         )
 
-        # If we're deleting, fetch all orphaned, uneresolved content transmissions
+        # If we're deleting, fetch all orphaned, unresolved content transmissions
         is_delete_action = action_name == 'delete'
         if is_delete_action:
             OrphanedContentTransmissions = apps.get_model(

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -6,6 +6,7 @@ from logging import getLogger
 
 from django.utils.translation import gettext_lazy as _
 
+from enterprise.constants import IC_DELETE_ACTION
 from enterprise.utils import (
     get_advertised_course_run,
     get_closest_course_run,
@@ -52,12 +53,12 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         """
         return self.enterprise_configuration.provider_id
 
-    def transform_status(self, content_metadata_item):
+    def transform_for_action_status(self, _content_metadata_item, action):
         """
         Return the status of the content item.
         """
         # lets not overwrite something we've already tried to set INACTIVE
-        if content_metadata_item.get('status') == 'INACTIVE':
+        if action == IC_DELETE_ACTION:
             return 'INACTIVE'
         else:
             return 'ACTIVE'

--- a/integrated_channels/sap_success_factors/transmitters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/transmitters/content_metadata.py
@@ -19,16 +19,6 @@ class SapSuccessFactorsContentMetadataTransmitter(ContentMetadataTransmitter):
             client=client
         )
 
-    def _transmit_action(self, content_metadata_item_map, client_method, action_name):
-        """
-        Set status to INACTIVE for items that should be deleted.
-        """
-        if action_name == 'delete':
-            for _, item in content_metadata_item_map.items():
-                item.channel_metadata['status'] = 'INACTIVE'
-                item.save()
-        return super()._transmit_action(content_metadata_item_map, client_method, action_name)
-
     def _prepare_items_for_transmission(self, channel_metadata_items):
         return {
             'ocnCourses': channel_metadata_items

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -1544,11 +1544,10 @@ def get_fake_catalog_diff_create_w_program():
     Returns a fake response from the EnterpriseCatalogApiClient.get_catalog_diff where two courses and a program are to
     be created
     """
-    # items_to_create, items_to_delete, matched_items
     return [
-        {'content_key': FAKE_COURSE_RUN_TO_CREATE['key']},
-        {'content_key': FAKE_COURSE_TO_CREATE['key']},
-        {'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1_TO_CREATE['uuid']}
+        {'content_key': FAKE_COURSE_RUN['key']},
+        {'content_key': FAKE_COURSE['key']},
+        {'content_key': FAKE_SEARCH_ALL_PROGRAM_RESULT_1['uuid']}
     ], [], []
 
 

--- a/tests/test_integrated_channels/test_cornerstone/test_views.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_views.py
@@ -14,6 +14,7 @@ from rest_framework.reverse import reverse
 from django.conf import settings
 from django.utils.http import http_date
 
+from enterprise.constants import IC_CREATE_ACTION
 from enterprise.utils import get_enterprise_worker_user
 from integrated_channels.integrated_channel.models import ContentMetadataItemTransmission
 from test_utils import APITest, factories
@@ -85,7 +86,10 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
             )
             worker_user = get_enterprise_worker_user()
             exporter = self.config.get_content_metadata_exporter(worker_user)
-            transformed_item = exporter._transform_item(content_item.channel_metadata)  # pylint: disable=protected-access
+            transformed_item = exporter._transform_item(  # pylint: disable=protected-access
+                content_item.channel_metadata,
+                action=IC_CREATE_ACTION,
+            )
             content_item.channel_metadata = transformed_item
             content_item.save()
 
@@ -126,7 +130,10 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
             )
             worker_user = get_enterprise_worker_user()
             exporter = self.config.get_content_metadata_exporter(worker_user)
-            transformed_item = exporter._transform_item(content_item.channel_metadata)  # pylint: disable=protected-access
+            transformed_item = exporter._transform_item(  # pylint: disable=protected-access
+                content_item.channel_metadata,
+                action=IC_CREATE_ACTION,
+            )
             content_item.channel_metadata = transformed_item
             content_item.save()
 
@@ -173,7 +180,10 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
             )
             worker_user = get_enterprise_worker_user()
             exporter = self.config.get_content_metadata_exporter(worker_user)
-            transformed_item = exporter._transform_item(content_item.channel_metadata)  # pylint: disable=protected-access
+            transformed_item = exporter._transform_item(  # pylint: disable=protected-access
+                content_item.channel_metadata,
+                action=IC_CREATE_ACTION,
+            )
             content_item.channel_metadata = transformed_item
             content_item.save()
 
@@ -211,7 +221,10 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
             )
             worker_user = get_enterprise_worker_user()
             exporter = self.config.get_content_metadata_exporter(worker_user)
-            transformed_item = exporter._transform_item(content_item.channel_metadata)  # pylint: disable=protected-access
+            transformed_item = exporter._transform_item(  # pylint: disable=protected-access
+                content_item.channel_metadata,
+                action=IC_CREATE_ACTION,
+            )
             content_item.channel_metadata = transformed_item
             content_item.save()
 

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -17,6 +17,7 @@ from enterprise.constants import EXEC_ED_COURSE_TYPE
 from enterprise.utils import get_content_metadata_item_id
 from integrated_channels.integrated_channel.exporters.content_metadata import ContentMetadataExporter
 from integrated_channels.integrated_channel.models import ContentMetadataItemTransmission
+from integrated_channels.sap_success_factors.exporters.content_metadata import SapSuccessFactorsContentMetadataExporter
 from test_utils import FAKE_UUIDS, factories
 from test_utils.factories import ContentMetadataItemTransmissionFactory
 from test_utils.fake_catalog_api import (
@@ -58,11 +59,123 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         }
         super().setUp()
 
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
-    def test_exporter_get_catalog_diff_works_with_orphaned_content(
+    def test_exporter_transforms_metadata_of_items_to_be_deleted(
         self,
         mock_get_catalog_diff,
+        mock_get_content_metadata,
     ):
+        """
+        Test that the exporter properly transforms the metadata of items that are to be deleted.
+        """
+        sap_config = factories.SAPSuccessFactorsEnterpriseCustomerConfiguration(
+            enterprise_customer=self.enterprise_customer_catalog.enterprise_customer,
+        )
+
+        # Existing audit metadata, needs to be updated/transformed.
+        # According to the SAP channel, upon deletion we need to set each content metadata blob's status to `INACTIVE`.
+        # Additionally, according to the mocked catalog metadata, the transformed mappings of the record need ot be
+        # updated. We will assert that both of these transformations are applied by the exporter.
+        channel_metadata = {
+            "courseID": "NYIF+BOPC.4x",
+            "providerID": "EDX",
+            # This status should be transformed to `INACTIVE` by the exporter
+            "status": "ACTIVE",
+            "title": [{
+                "locale": "English",
+                "value": "Brokerage Operations Professional Certificate Examination"
+            }],
+            "content": [
+                {
+                    "providerID": "EDX",
+                    "contentTitle": "Brokerage Operations Professional Certificate Examination",
+                    "contentID": "NYIF+BOPC.4x",
+                    "launchType": 3,
+                    "mobileEnabled": True,
+                }
+            ],
+            "schedule": [
+                {
+                    "startDate": "",
+                    "endDate": "",
+                    "active": False,
+                    "duration": "0 days"
+                }
+            ],
+            "price": [
+                {
+                    "currency": "USD",
+                    "value": 0.0
+                }
+            ]
+        }
+        content_id = "NYIF+BOPC.4x"
+        mock_metadata = {
+            "aggregation_key": "course:NYIF+BOPC.4x",
+            "content_type": "course",
+            "full_description": "ayylmao",
+            "key": content_id,
+            "title": "Brokerage Operations Professional Certificate Examination",
+            "course_runs": [
+                {
+                    "key": "course-v1:NYIF+BOPC.4x+3T2017",
+                    "uuid": "69b38e2f-e041-4634-b537-fc8d8e12c87e",
+                    "title": "Brokerage Operations Professional Certificate Examination",
+                    "short_description": "ayylmao",
+                    "availability": "Archived",
+                    "pacing_type": "self_paced",
+                    "seats": [
+                        {
+                            "type": "professional",
+                            "price": "500.00",
+                            "currency": "USD",
+                            "upgrade_deadline": None,
+                            "upgrade_deadline_override": None,
+                            "credit_provider": None,
+                            "credit_hours": None,
+                            "sku": "0C1BF31",
+                            "bulk_sku": "668527E"
+                        }
+                    ],
+                    "start": "2017-09-07T00:00:00Z",
+                    # A none value here will cause the sanitization to remove the schedule blob
+                    "end": None,
+                }
+            ],
+            "uuid": "bbbf059e-b9fb-4ad7-a53e-4c6f85f47f4e",
+            "end_date": "2019-09-07T00:00:00Z",
+            "course_ends": "Future",
+            "entitlements": [],
+            "modified": "2023-07-10T04:29:38.934204Z",
+            "additional_information": None,
+            "course_run_keys": [
+                "course-v1:NYIF+BOPC.4x+3T2017",
+                "course-v1:NYIF+BOPC.4x+1T2017"
+            ],
+            "enrollment_url": "https://foobar.com"
+        }
+        # Create the transmission audit with the out of date channel metadata
+        transmission_audit = factories.ContentMetadataItemTransmissionFactory(
+            content_id=content_id,
+            enterprise_customer=self.config.enterprise_customer,
+            plugin_configuration_id=sap_config.id,
+            integrated_channel_code=sap_config.channel_code(),
+            channel_metadata=channel_metadata,
+            remote_created_at=datetime.datetime.utcnow(),
+            enterprise_customer_catalog_uuid=self.enterprise_customer_catalog.uuid,
+        )
+        # Mock the catalog service to return the metadata of the content to be deleted
+        mock_get_content_metadata.return_value = [mock_metadata]
+        # Mock the catalog service to return the content to be deleted in the delete payload
+        mock_get_catalog_diff.return_value = ([], [{'content_key': transmission_audit.content_id}], [])
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', sap_config)
+        _, _, delete_payload = exporter.export()
+        assert delete_payload[transmission_audit.content_id].channel_metadata.get('schedule') == []
+        assert delete_payload[transmission_audit.content_id].channel_metadata.get('status') == 'INACTIVE'
+
+    @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
+    def test_exporter_get_catalog_diff_works_with_orphaned_content(self, mock_get_catalog_diff):
         """
         Test that the exporter _get_catalog_diff function properly marks orphaned content that is requested to be
         created by another, linked catalog as resolved.
@@ -149,6 +262,14 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         ``ContentMetadataExporter``'s ``export`` produces a JSON dump of the course data.
         """
+        ContentMetadataExporter.DATA_TRANSFORM_MAPPING = {
+            'contentId': 'key',
+            'title': 'title',
+            'description': 'description',
+            'imageUrl': 'image',
+            'url': 'enrollment_url',
+            'language': 'content_language'
+        }
         mock_get_content_metadata.return_value = get_fake_content_metadata()
         mock_get_catalog_diff.return_value = get_fake_catalog_diff_create()
         exporter = ContentMetadataExporter('fake-user', self.config)
@@ -160,8 +281,7 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         assert mock_get_content_metadata.get(FAKE_COURSE_RUN['key'])
 
         for key in create_payload:
-            assert key in ['edX+DemoX', 'course-v1:edX+DemoX+Demo_Course', FAKE_UUIDS[3]]
-
+            assert key in [FAKE_COURSE['key'], FAKE_COURSE_RUN.get('key'), FAKE_UUIDS[3]]
         cmit = ContentMetadataItemTransmission.objects.get(content_id=FAKE_COURSE['key'])
         assert cmit.content_title is not None
 
@@ -244,13 +364,12 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         mock_delete_items = [{'content_key': FAKE_COURSE_RUN['key']}]
         mock_matched_items = []
         mock_get_catalog_diff.return_value = mock_create_items, mock_delete_items, mock_matched_items
+        mock_get_content_metadata.return_value = [FAKE_COURSE_RUN]
         exporter = ContentMetadataExporter('fake-user', self.config)
         create_payload, update_payload, delete_payload = exporter.export()
         assert not create_payload
         assert not update_payload
         assert delete_payload.get(FAKE_COURSE_RUN['key']) == past_transmission
-        # Sanity check
-        mock_get_content_metadata.assert_not_called()
 
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_content_metadata')
     @mock.patch('enterprise.api_client.enterprise_catalog.EnterpriseCatalogApiClient.get_catalog_diff')
@@ -329,6 +448,9 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
             [FAKE_COURSE_RUN['key']]
         )
 
+        mock_api_client.return_value.get_catalog_diff.reset_mock()
+        mock_api_client.return_value.get_content_metadata.reset_mock()
+
         past_transmission_to_update.content_last_changed = datetime.datetime.now()
         past_transmission_to_update.save()
 
@@ -353,7 +475,9 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         assert not update_payload
         assert not create_payload
         assert delete_payload.get(FAKE_COURSE_RUN2['key']) == past_transmission_to_delete
-        assert mock_api_client.return_value.get_catalog_diff.call_count == 2
+        # get_catalog_diff is called once per customer catalog
+        assert mock_api_client.return_value.get_catalog_diff.call_count == 1
+        # get_content_metadata is called once for the single item to delete
         assert mock_api_client.return_value.get_content_metadata.call_count == 1
 
     @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
@@ -417,9 +541,10 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         """
         ``ContentMetadataExporter``'s ``export`` raises an exception when DATA_TRANSFORM_MAPPING is invalid.
         """
-        content_id = 'course:DemoX'
+        fake_content_metadata = get_fake_content_metadata()
+        content_id = fake_content_metadata[0].get('key')
 
-        mock_api_client.return_value.get_content_metadata.return_value = get_fake_content_metadata()
+        mock_api_client.return_value.get_content_metadata.return_value = fake_content_metadata
         mock_create_items = [{'content_key': content_id}]
         mock_delete_items = {}
         mock_matched_items = []

--- a/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_exporters/test_content_metadata.py
@@ -8,6 +8,7 @@ import ddt
 import responses
 from pytest import mark
 
+from enterprise.constants import IC_DELETE_ACTION
 from enterprise.utils import parse_lms_api_datetime
 from integrated_channels.sap_success_factors.exporters.content_metadata import SapSuccessFactorsContentMetadataExporter
 from integrated_channels.utils import parse_datetime_to_epoch_millis
@@ -29,6 +30,56 @@ class TestSapSuccessFactorsContentMetadataExporter(unittest.TestCase, Enterprise
         )
 
         super().setUp()
+
+    def test_exporter_delete_transform(self):
+        exporter = SapSuccessFactorsContentMetadataExporter('fake-user', self.config)
+        # pylint: disable=protected-access
+        transformed_delete_metadata = exporter._transform_item({
+            "aggregation_key": "course:NYIF+BOPC.4x",
+            "content_type": "course",
+            "full_description": "ayylmao",
+            "key": 'ayylmao',
+            "title": "Brokerage Operations Professional Certificate Examination",
+            "course_runs": [
+                {
+                    "key": "course-v1:NYIF+BOPC.4x+3T2017",
+                    "uuid": "69b38e2f-e041-4634-b537-fc8d8e12c87e",
+                    "title": "Brokerage Operations Professional Certificate Examination",
+                    "short_description": "ayylmao",
+                    "availability": "Archived",
+                    "pacing_type": "self_paced",
+                    "seats": [
+                        {
+                            "type": "professional",
+                            "price": "500.00",
+                            "currency": "USD",
+                            "upgrade_deadline": None,
+                            "upgrade_deadline_override": None,
+                            "credit_provider": None,
+                            "credit_hours": None,
+                            "sku": "0C1BF31",
+                            "bulk_sku": "668527E"
+                        }
+                    ],
+                    "start": "2017-09-07T00:00:00Z",
+                    # A none value here will cause the sanitization to remove the schedule blob
+                    "end": None,
+                }
+            ],
+            "uuid": "bbbf059e-b9fb-4ad7-a53e-4c6f85f47f4e",
+            "end_date": "2019-09-07T00:00:00Z",
+            "course_ends": "Future",
+            "entitlements": [],
+            "modified": "2023-07-10T04:29:38.934204Z",
+            "additional_information": None,
+            "course_run_keys": [
+                "course-v1:NYIF+BOPC.4x+3T2017",
+                "course-v1:NYIF+BOPC.4x+1T2017"
+            ],
+            "enrollment_url": "https://foobar.com"
+        }, action=IC_DELETE_ACTION)
+        assert transformed_delete_metadata['status'] == 'INACTIVE'
+        assert transformed_delete_metadata['schedule'] == []
 
     @ddt.data(
         (

--- a/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_content_metadata.py
@@ -251,7 +251,6 @@ class TestSapSuccessFactorsContentMetadataTransmitter(unittest.TestCase):
             content_id=content_id_2,
         ).first()
         assert item_deleted.remote_deleted_at
-        assert item_deleted.channel_metadata.get('status') == 'INACTIVE'
         item_created = ContentMetadataItemTransmission.objects.filter(
             enterprise_customer_catalog_uuid=self.enterprise_customer_catalog.uuid,
             content_id=content_id_3,

--- a/tests/test_management.py
+++ b/tests/test_management.py
@@ -1932,6 +1932,15 @@ class TestMarkOrphanedContentMetadataAuditsManagementCommand(unittest.TestCase, 
         orphaned_content = OrphanedContentTransmissions.objects.first()
         assert orphaned_content.content_id == self.orphaned_content.content_id
 
+    @override_settings(ALLOW_ORPHANED_CONTENT_REMOVAL=True)
+    def test_orphaned_content_without_catalog_uuids(self):
+        self.orphaned_content.enterprise_customer_catalog_uuid = None
+        self.orphaned_content.save()
+        assert not OrphanedContentTransmissions.objects.all()
+        call_command('mark_orphaned_content_metadata_audits')
+        num_orphaned_content = OrphanedContentTransmissions.objects.count()
+        assert num_orphaned_content == 1
+
 
 @mark.django_db
 @ddt.ddt


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
