### PR TITLE
docs: Replace paver update_db.

### DIFF
--- a/docs/development.rst
+++ b/docs/development.rst
@@ -146,7 +146,7 @@ as an example) and run migrations:
 
 .. code-block:: bash
 
-    $ paver update_db
+    $ make migrate
     # Or use a more down-to-the-root command (replace aws with your version of config)
     $ ./manage.py lms migrate --settings=devstack
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -15,7 +15,7 @@ perform database migrations.
 
 .. code-block:: bash
 
-    $ paver update_db
+    $ make migrate
 
     # Or use a more down-to-the-root command (replace aws with your version of config)
     $ ./manage.py lms migrate --settings=aws


### PR DESCRIPTION
We are planning on removing paver, and
we have created an alternative Make command for
running migrations. This updates the documentation.

https://github.com/openedx/devstack/issues/1085

I haven't bumped the version or added a changelog entry because this is a minor docs change.
