### PR TITLE
fix: use a valid nodeenv version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,7 +84,7 @@ RUN pip install nodeenv
 # Must be done after Python requirements, since nodeenv is installed
 # via pip.
 # The node environment is already 'activated' because its .../bin was put on $PATH.
-RUN nodeenv /edx/app/nodeenv --node=18.15 --prebuilt
+RUN nodeenv /edx/app/nodeenv --node=18.15.0 --prebuilt
 
 RUN mkdir -p /edx/var/log
 


### PR DESCRIPTION
nodeenv needs a more specific version than `18.15` -> `18.15.0`

```
 => ERROR [test-shell 13/15] RUN nodeenv /edx/app/nodeenv --node=18.15 --prebuilt                                                                                          0.4s 
------                                                                                                                                                                          
 > [test-shell 13/15] RUN nodeenv /edx/app/nodeenv --node=18.15 --prebuilt:                                                                                                     
0.346  * Install prebuilt node (18.15) .Failed to download from https://nodejs.org/download/release/v18.15/node-v18.15-linux-x64.tar.gz                                         
0.402 ..                                                                                                                                                                        
0.403 Traceback (most recent call last):                                                                                                                                        
0.403   File "/edx/app/venvs/edx-enterprise/bin/nodeenv", line 8, in <module>
0.403     sys.exit(main())
0.403   File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/nodeenv.py", line 1122, in main
0.403     create_environment(env_dir, args)
0.403   File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/nodeenv.py", line 998, in create_environment
0.403     install_node(env_dir, src_dir, args)
0.403   File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/nodeenv.py", line 755, in install_node
0.403     install_node_wrapped(env_dir, src_dir, args)
0.403   File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/nodeenv.py", line 790, in install_node_wrapped
0.403     copy_node_from_prebuilt(env_dir, src_dir, args.node)
0.403   File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/nodeenv.py", line 681, in copy_node_from_prebuilt
0.403     src_folder, = glob.glob(src_folder_tpl)
0.403 ValueError: not enough values to unpack (expected 1, got 0)
------
failed to solve: process "/bin/sh -c nodeenv /edx/app/nodeenv --node=18.15 --prebuilt" did not complete successfully: exit code: 1
(3.8.12/envs/venv) ubuntu@ip-172-31-38-188:~/edx-repos/src/edx-enterprise$ 
```