### PR TITLE
fix: removing items to delete dependency on the catalog service

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.0.2]
+-------
+fix: removing items to delete dependency on the catalog service
+
 [4.0.1]
 --------
 chore: upgrade course_enrollment from audit to verified

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.1"
+__version__ = "4.0.2"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/sap_success_factors/exporters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/exporters/content_metadata.py
@@ -47,6 +47,21 @@ class SapSuccessFactorsContentMetadataExporter(ContentMetadataExporter):
         'price': 'price',
     }
 
+    def _apply_delete_transformation(self, metadata):
+        """
+        Specific transformations required for "deleting" a course on a SAP external service.
+        """
+        # Applying the metadata payload update to "delete" the course on SAP instances
+        metadata['status'] = 'INACTIVE'
+
+        # Sanity check as we've seen issues with schedule structure
+        metadata_schedule = metadata.get('schedule')
+        if metadata_schedule:
+            schedule = metadata_schedule[0]
+            if not schedule.get('startDate') or not schedule.get('endDate'):
+                metadata['schedule'] = []
+        return metadata
+
     def transform_provider_id(self, content_metadata_item):  # pylint: disable=unused-argument
         """
         Return the provider ID from the integrated channel configuration.

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_content_metadata.py
@@ -477,8 +477,8 @@ class TestContentMetadataExporter(unittest.TestCase, EnterpriseMockMixin):
         assert delete_payload.get(FAKE_COURSE_RUN2['key']) == past_transmission_to_delete
         # get_catalog_diff is called once per customer catalog
         assert mock_api_client.return_value.get_catalog_diff.call_count == 1
-        # get_content_metadata is called once for the single item to delete
-        assert mock_api_client.return_value.get_content_metadata.call_count == 1
+        # get_content_metadata isn't called for the item to delete
+        assert mock_api_client.return_value.get_content_metadata.call_count == 0
 
     @mock.patch('integrated_channels.integrated_channel.exporters.content_metadata.EnterpriseCatalogApiClient')
     def test_content_exporter_update_not_needed_export(self, mock_api_client):


### PR DESCRIPTION
https://splunk.edx.org/en-US/app/search/search?q=search%20_sanitize_and_set_item_metadata%20NYIF%2BBOPC.4x&earliest=-24h%40h&latest=now&display.page.search.mode=smart&dispatch.sample_ratio=1&sid=1689635604.3264070

follow up/iteration on https://2u-internal.atlassian.net/browse/ENT-7406

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
