### PR TITLE
chore: upgrades to requirements

### DIFF
--- a/.github/workflows/mysql8-migrations.yml
+++ b/.github/workflows/mysql8-migrations.yml
@@ -57,6 +57,7 @@ jobs:
         pip install --no-binary mysqlclient mysqlclient
         pip uninstall -y xmlsec
         pip install --no-binary xmlsec xmlsec
+        pip install backports.zoneinfo
     - name: Initiate Services
       run: |
         sudo /etc/init.d/mysql start

--- a/requirements/celery50.txt
+++ b/requirements/celery50.txt
@@ -1,9 +1,9 @@
 amqp==5.1.1
-billiard==3.6.4.0
-celery==5.0.4
-click==7.1.2
+billiard==4.1.0
+celery==5.3.1
+click==8.1.5
 click-didyoumean==0.3.0
 click-repl==0.2.0
-kombu==5.2.4
+kombu==5.3.1
 prompt-toolkit==3.0.38
 vine==5.0.0

--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -28,10 +28,7 @@ factory-boy<4.0
 pytest<7.0
 
 # pinning it to latest release.
-celery==5.0.4
-
-# pip-tools>=6.11.0 requires click>=8.0.0, which is not yet compatible.
-pip-tools<6.11.0
+celery>=5.2.2,<6.0.0
 
 # tox>=4.4.11 require filelock>=3.10.7, which is not yet compatible.
 tox<4

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -55,7 +55,7 @@ beautifulsoup4==4.12.2
     # via
     #   -r requirements/doc.txt
     #   pydata-sphinx-theme
-billiard==3.6.4.0
+billiard==4.1.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -69,7 +69,7 @@ bleach[css]==6.0.0
     #   readme-renderer
 build==0.10.0
     # via pip-tools
-celery==5.0.4
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
@@ -101,7 +101,7 @@ charset-normalizer==2.0.12
     #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
-click==7.1.2
+click==8.1.5
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -389,7 +389,7 @@ jsonfield==3.1.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -460,7 +460,7 @@ pillow==9.5.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-pip-tools==6.10.0
+pip-tools==7.0.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/dev.in

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -32,7 +32,7 @@ babel==2.12.1
     #   sphinx
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-billiard==3.6.4.0
+billiard==4.1.0
     # via
     #   -r requirements/test-master.txt
     #   celery
@@ -40,7 +40,7 @@ bleach[css]==6.0.0
     # via
     #   -r requirements/test-master.txt
     #   readme-renderer
-celery==5.0.4
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test-master.txt
@@ -60,7 +60,7 @@ charset-normalizer==2.0.12
     #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
-click==7.1.2
+click==8.1.5
     # via
     #   -r requirements/test-master.txt
     #   celery
@@ -213,7 +213,7 @@ jsondiff==2.0.0
     # via -r requirements/test-master.txt
 jsonfield==3.1.0
     # via -r requirements/test-master.txt
-kombu==5.2.4
+kombu==5.3.1
     # via
     #   -r requirements/test-master.txt
     #   celery

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -20,13 +20,13 @@ asn1crypto==1.5.1
     #   -c requirements/edx-platform-constraints.txt
     #   oscrypto
     #   snowflake-connector-python
-billiard==3.6.4.0
+billiard==4.1.0
     # via celery
 bleach[css]==6.0.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-celery==5.0.4
+celery==5.3.1
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in
@@ -46,7 +46,7 @@ charset-normalizer==2.0.12
     #   -c requirements/edx-platform-constraints.txt
     #   requests
     #   snowflake-connector-python
-click==7.1.2
+click==8.1.5
     # via
     #   celery
     #   click-didyoumean
@@ -219,7 +219,7 @@ jsonfield==3.1.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-kombu==5.2.4
+kombu==5.3.1
     # via celery
 markupsafe==2.1.2
     # via


### PR DESCRIPTION
- grabbing versions from edx-platform
- mysql8 migration checks needed a backport

```
pip install -qr requirements/dev.txt --exists-action w
DEPRECATION: celery 5.0.4 has a non-standard dependency specifier pytz>dev. pip 23.3 will enforce this behaviour change. A possible replacement is to upgrade to a newer version of celery or contact the author to suggest that they release a version with a conforming dependency specifiers. Discussion can be found at https://github.com/pypa/pip/issues/12063
pip-sync requirements/test-master.txt requirements/dev.txt requirements/private.* requirements/test.txt
Traceback (most recent call last):
  File "/edx/app/venvs/edx-enterprise/bin/pip-sync", line 5, in <module>
    from piptools.scripts.sync import cli
  File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/piptools/scripts/sync.py", line 16, in <module>
    from .. import sync
  File "/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/piptools/sync.py", line 11, in <module>
    from pip._internal.commands.freeze import DEV_PKGS
ImportError: cannot import name 'DEV_PKGS' from 'pip._internal.commands.freeze' (/edx/app/venvs/edx-enterprise/lib/python3.8/site-packages/pip/_internal/commands/freeze.py)
make: *** [Makefile:138: requirements] Error 1
root@app:/edx/app/edx-enterprise# 
```