### PR TITLE
fix: variable name conflicts in monthly_impact_report command

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.0.6]
+--------
+fix: variable name conflicts in monthly_impact_report command
+
 [4.0.5]
 --------
 feat: incorporate additional attributes to degreed v2

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.5"
+__version__ = "4.0.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/management/commands/monthly_impact_report.py
+++ b/enterprise/management/commands/monthly_impact_report.py
@@ -176,9 +176,9 @@ QUERY = '''
         on
             s.id=cs.skill_id
         WHERE
-            enterprise_enrollment_created >=(SELECT two_months_ago_start_range FROM dynamic_dates)
+            enterprise_enrollment_created_at >=(SELECT two_months_ago_start_range FROM dynamic_dates)
         AND
-             enterprise_enrollment_created <= (SELECT two_months_ago_end_range FROM dynamic_dates)
+             enterprise_enrollment_created_at <= (SELECT two_months_ago_end_range FROM dynamic_dates)
         GROUP BY
             1,2
         ORDER BY
@@ -493,9 +493,9 @@ QUERY = '''
         on
             s.id=cs.skill_id
         WHERE
-            enterprise_enrollment_created >= (SELECT last_month_start_range FROM dynamic_dates)
+            enterprise_enrollment_created_at >= (SELECT last_month_start_range FROM dynamic_dates)
         AND
-            enterprise_enrollment_created <= (SELECT last_month_end_range FROM dynamic_dates)
+            enterprise_enrollment_created_at <= (SELECT last_month_end_range FROM dynamic_dates)
         GROUP BY
             1,2
         ORDER BY


### PR DESCRIPTION
**Description**
JIRA ->  [ENT-7410](https://2u-internal.atlassian.net/browse/ENT-7410)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
