### PR TITLE
feat: add grade value to degreed v2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.0.6]
+--------
+feat: add grade value to learner transmission for degreed v2
+
 [4.0.5]
 --------
 feat: incorporate additional attributes to degreed v2

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.5"
+__version__ = "4.0.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -114,7 +114,6 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         Returns: status_code, response_text
         """
         json_payload = json.loads(payload)
-        json_payload['data']['attributes']['percentile'] = json_payload['data']['attributes']['percentile'] * 100
         LOGGER.info(self.make_log_msg(
             json_payload.get('data').get('attributes').get('content-id'),
             f'Attempting find course via url: {self.get_completions_url()}'),

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -114,6 +114,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         Returns: status_code, response_text
         """
         json_payload = json.loads(payload)
+        json_payload['data']['attributes']['percentile'] = json_payload['data']['attributes']['percentile'] * 100
         LOGGER.info(self.make_log_msg(
             json_payload.get('data').get('attributes').get('content-id'),
             f'Attempting find course via url: {self.get_completions_url()}'),

--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -32,7 +32,7 @@ class Degreed2LearnerExporter(LearnerExporter):
 
         If no remote ID can be found, return None.
         """
-        percent_grade = kwargs.get('grade_percent', None)
+        percent_grade = kwargs.get('grade_percent') * 100 if kwargs.get('grade_percent') else None
         # Degreed expects completion dates of the form 'yyyy-mm-ddTHH:MM:SS'.
         degreed_completed_timestamp = completed_date.strftime('%Y-%m-%dT%H:%M:%S') if isinstance(
             completed_date, datetime

--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -32,6 +32,7 @@ class Degreed2LearnerExporter(LearnerExporter):
 
         If no remote ID can be found, return None.
         """
+        percent_grade = kwargs.get('grade_percent', None)
         # Degreed expects completion dates of the form 'yyyy-mm-ddTHH:MM:SS'.
         degreed_completed_timestamp = completed_date.strftime('%Y-%m-%dT%H:%M:%S') if isinstance(
             completed_date, datetime
@@ -54,6 +55,7 @@ class Degreed2LearnerExporter(LearnerExporter):
                     completed_timestamp=completed_date,
                     degreed_completed_timestamp=degreed_completed_timestamp,
                     course_completed=course_completed,
+                    grade=percent_grade,
                     enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id,
                 ),
@@ -65,6 +67,7 @@ class Degreed2LearnerExporter(LearnerExporter):
                     completed_timestamp=completed_date,
                     degreed_completed_timestamp=degreed_completed_timestamp,
                     course_completed=course_completed,
+                    grade=percent_grade,
                     enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id,
                 )

--- a/integrated_channels/degreed2/models.py
+++ b/integrated_channels/degreed2/models.py
@@ -217,6 +217,7 @@ class Degreed2LearnerDataTransmissionAudit(LearnerDataTransmissionAudit):
                     "content-id-type": "externalId",
                     "content-type": "course",
                     "completed-at": self.degreed_completed_timestamp,
+                    "percentile": self.grade,
                 }
             }
         }

--- a/tests/test_integrated_channels/test_degreed2/test_client.py
+++ b/tests/test_integrated_channels/test_degreed2/test_client.py
@@ -132,6 +132,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
                     "content-id-type": "externalId",
                     "content-type": "course",
                     "completed-at": NOW_TIMESTAMP_FORMATTED,
+                    "percentile": 80,
                 }
             }
         }

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_learner_data.py
@@ -63,12 +63,12 @@ class TestDegreed2LearnerExporter(unittest.TestCase):
         super().setUp()
 
     @ddt.data(
-        (None,),
-        (NOW,),
+        (None, None,),
+        (NOW, .83),
     )
     @ddt.unpack
     @freeze_time(NOW)
-    def test_get_learner_data_record(self, completed_date):
+    def test_get_learner_data_record(self, completed_date, grade_percent):
         """
         The base ``get_learner_data_record`` method returns a ``LearnerDataTransmissionAudit`` with appropriate values.
         """
@@ -80,6 +80,7 @@ class TestDegreed2LearnerExporter(unittest.TestCase):
         learner_data_records = exporter.get_learner_data_records(
             enterprise_course_enrollment,
             completed_date=completed_date,
+            grade_percent=grade_percent,
         )
         assert len(learner_data_records) == 2
         assert learner_data_records[0].course_id == self.course_key
@@ -91,6 +92,7 @@ class TestDegreed2LearnerExporter(unittest.TestCase):
             assert learner_data_record.degreed_completed_timestamp == (
                 self.NOW.strftime('%Y-%m-%dT%H:%M:%S') if completed_date is not None else None
             )
+            assert learner_data_record.grade == (grade_percent * 100 if grade_percent else None)
 
     def test_no_remote_id(self):
         """


### PR DESCRIPTION
## Description
The Degreed v2 API incorporated the option to add the value a learner's grade. 
https://developer.degreed.com/reference/post_api-v2-completions

## Solution
Add the `percentile` field to support passing the grade value.

[JIRA](https://2u-internal.atlassian.net/browse/ENT-5809)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
