### PR TITLE
feat: keycloak devstack service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,12 @@ isort: ## call isort on packages/files that are checked in quality tests
 test-shell: ## Run a shell, as root, on the specified service container
 	docker-compose run -u 0 test-shell env TERM=$(TERM) /bin/bash
 
+dev.up.keycloak:
+	docker-compose up --detach keycloak
+
+dev.stop.keycloak:
+	docker-compose stop keycloak
+
 .PHONY: clean clean.static compile_translations coverage docs dummy_translations extract_translations \
 	fake_translations help pull_translations push_translations requirements test test-all upgrade validate isort \
 	static static.dev static.watch

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,26 @@ services:
     environment:
       DJANGO_SETTINGS_MODULE: enterprise.settings.test
 
+  keycloak:
+    container_name: "edx.devstack.keycloak"
+    hostname: keycloak.devstack.edx
+    image: quay.io/keycloak/keycloak:22.0.1
+    command: start-dev
+    networks:
+      default:
+        aliases:
+          - edx.devstack.keycloak
+    ports:
+      - "8080:8080"
+    environment:
+      KEYCLOAK_ADMIN: admin
+      KEYCLOAK_ADMIN_PASSWORD: admin
+    volumes:
+      - keycloak_data:/opt/keycloak/data
+
 networks:
   devstack_default:
     external: true
+
+volumes:
+  keycloak_data:


### PR DESCRIPTION
## Description

- a [keycloak](https://www.keycloak.org/) devstack entry for testing
- data is persisted to a local volume
- `make dev.up.keycloak` & `make dev.stop.keycloak`
- http://localhost:8080 for local testing
- `ngrok http 8080` for stage/prod testing