### PR TITLE
fix: allow sub directories in moodle base URLs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Change Log
 Unreleased
 ----------
 
+[4.0.12]
+fix: allow sub directories in moodle base URLs
+
 [4.0.11]
 feat: upgrade django-simple-history to 3.1.1
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.11"
+__version__ = "4.0.12"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/moodle/client.py
+++ b/integrated_channels/moodle/client.py
@@ -122,6 +122,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         super().__init__(enterprise_configuration)
         self.config = apps.get_app_config('moodle')
         self.token = enterprise_configuration.token or self._get_access_token()
+        self.api_url = urljoin(self.enterprise_configuration.moodle_base_url, self.MOODLE_API_PATH)
 
     def _post(self, additional_params):
         """
@@ -137,7 +138,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         params.update(additional_params)
 
         response = requests.post(
-            url=self._get_api_url(),
+            url=self.api_url,
             data=params,
             headers=headers
         )
@@ -151,12 +152,6 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         for when the caller wants to examine errors
         """
         return self._post(additional_params)
-
-    def _get_api_url(self):
-        return urljoin(
-            self.enterprise_configuration.moodle_base_url,
-            self.MOODLE_API_PATH
-        )
 
     def _get_access_token(self):
         """
@@ -239,7 +234,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
             'moodlewsrestformat': 'json'
         }
         response = requests.get(
-            self._get_api_url(),
+            self.api_url,
             params=params
         )
         return response
@@ -286,7 +281,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
             'moodlewsrestformat': 'json'
         }
         response = requests.get(
-            self._get_api_url(),
+            self.api_url,
             params=params
         )
         return response

--- a/integrated_channels/moodle/client.py
+++ b/integrated_channels/moodle/client.py
@@ -109,7 +109,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         - Customer's Moodle service short name
     """
 
-    MOODLE_API_PATH = '/webservice/rest/server.php'
+    MOODLE_API_PATH = 'webservice/rest/server.php'
 
     def __init__(self, enterprise_configuration):
         """
@@ -137,10 +137,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         params.update(additional_params)
 
         response = requests.post(
-            url=urljoin(
-                self.enterprise_configuration.moodle_base_url,
-                self.MOODLE_API_PATH,
-            ),
+            url=self._get_api_url(),
             data=params,
             headers=headers
         )
@@ -155,6 +152,12 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         """
         return self._post(additional_params)
 
+    def _get_api_url(self):
+        return urljoin(
+            self.enterprise_configuration.moodle_base_url,
+            self.MOODLE_API_PATH
+        )
+
     def _get_access_token(self):
         """
         Obtains a new access token from Moodle using username and password.
@@ -166,7 +169,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
         response = requests.post(
             urljoin(
                 self.enterprise_configuration.moodle_base_url,
-                '/login/token.php',
+                'login/token.php',
             ),
             params=querystring,
             headers={
@@ -236,10 +239,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
             'moodlewsrestformat': 'json'
         }
         response = requests.get(
-            urljoin(
-                self.enterprise_configuration.moodle_base_url,
-                self.MOODLE_API_PATH,
-            ),
+            self._get_api_url(),
             params=params
         )
         return response
@@ -286,10 +286,7 @@ class MoodleAPIClient(IntegratedChannelApiClient):
             'moodlewsrestformat': 'json'
         }
         response = requests.get(
-            urljoin(
-                self.enterprise_configuration.moodle_base_url,
-                self.MOODLE_API_PATH,
-            ),
+            self._get_api_url(),
             params=params
         )
         return response

--- a/tests/test_integrated_channels/test_moodle/test_client.py
+++ b/tests/test_integrated_channels/test_moodle/test_client.py
@@ -91,12 +91,12 @@ class TestMoodleApiClient(unittest.TestCase):
             grade_assignment_name='edX Grade Test'
         )
 
-    def test_get_api_url(self):
+    def test_api_url(self):
         moodle_api_client = MoodleAPIClient(self.enterprise_config)
         moodle_api_client_with_sub_dir = MoodleAPIClient(self.enterprise_custom_config)
 
-        assert moodle_api_client._get_api_url() == 'http://testing/webservice/rest/server.php'
-        assert moodle_api_client_with_sub_dir._get_api_url() == 'http://testing/subdir/webservice/rest/server.php'
+        assert moodle_api_client.api_url == 'http://testing/webservice/rest/server.php'
+        assert moodle_api_client_with_sub_dir.api_url == 'http://testing/subdir/webservice/rest/server.php'
 
     def test_moodle_config_is_set(self):
         """
@@ -113,7 +113,7 @@ class TestMoodleApiClient(unittest.TestCase):
         client = MoodleAPIClient(self.enterprise_config)
         responses.add(
             responses.GET,
-            client._get_api_url(),
+            client.api_url,
             json={'courses': [{'id': 2}]},
             status=200
         )
@@ -240,7 +240,7 @@ class TestMoodleApiClient(unittest.TestCase):
         """Test that we properly raise exceptions if the client receives a 404 from Moodle"""
         with responses.RequestsMock() as rsps:
             client = MoodleAPIClient(self.enterprise_config)
-            moodle_api_path = client._get_api_url()
+            moodle_api_path = client.api_url
             moodle_get_courses_query = 'wstoken={}&wsfunction=core_course_get_courses_by_field&field=idnumber' \
                                        '&value={}&moodlewsrestformat=json'.format(self.token, self.moodle_course_id)
             request_url = '{}?{}'.format(moodle_api_path, moodle_get_courses_query)

--- a/tests/test_integrated_channels/test_moodle/test_client.py
+++ b/tests/test_integrated_channels/test_moodle/test_client.py
@@ -4,7 +4,6 @@ Tests for clients in integrated_channels.
 
 import random
 import unittest
-from urllib.parse import urljoin
 
 import pytest
 import responses
@@ -64,11 +63,11 @@ class TestMoodleApiClient(unittest.TestCase):
     def setUp(self):
         super().setUp()
         self.moodle_base_url = 'http://testing/'
+        self.custom_moodle_base_url = 'http://testing/subdir/'
         self.token = 'token'
         self.password = 'pass'
         self.user = 'user'
         self.user_email = 'testemail@example.com'
-        self.moodle_api_path = '/webservice/rest/server.php'
         self.moodle_course_id = random.randint(1, 1000)
         self._get_courses_response = bytearray('{{"courses": [{{"id": {}}}]}}'.format(self.moodle_course_id), 'utf-8')
         self.empty_get_courses_response = bytearray('{"courses": []}', 'utf-8')
@@ -84,13 +83,20 @@ class TestMoodleApiClient(unittest.TestCase):
             token=self.token,
         )
         self.enterprise_custom_config = factories.MoodleEnterpriseCustomerConfigurationFactory(
-            moodle_base_url=self.moodle_base_url,
+            moodle_base_url=self.custom_moodle_base_url,
             username=self.user,
             password=self.password,
             token=self.token,
             grade_scale=10,
             grade_assignment_name='edX Grade Test'
         )
+
+    def test_get_api_url(self):
+        moodle_api_client = MoodleAPIClient(self.enterprise_config)
+        moodle_api_client_with_sub_dir = MoodleAPIClient(self.enterprise_custom_config)
+
+        assert moodle_api_client._get_api_url() == 'http://testing/webservice/rest/server.php'
+        assert moodle_api_client_with_sub_dir._get_api_url() == 'http://testing/subdir/webservice/rest/server.php'
 
     def test_moodle_config_is_set(self):
         """
@@ -107,7 +113,7 @@ class TestMoodleApiClient(unittest.TestCase):
         client = MoodleAPIClient(self.enterprise_config)
         responses.add(
             responses.GET,
-            urljoin(self.enterprise_config.moodle_base_url, self.moodle_api_path),
+            client._get_api_url(),
             json={'courses': [{'id': 2}]},
             status=200
         )
@@ -233,10 +239,8 @@ class TestMoodleApiClient(unittest.TestCase):
     def test_course_completion_with_no_course(self):
         """Test that we properly raise exceptions if the client receives a 404 from Moodle"""
         with responses.RequestsMock() as rsps:
-            moodle_api_path = urljoin(
-                self.enterprise_config.moodle_base_url,
-                self.moodle_api_path,
-            )
+            client = MoodleAPIClient(self.enterprise_config)
+            moodle_api_path = client._get_api_url()
             moodle_get_courses_query = 'wstoken={}&wsfunction=core_course_get_courses_by_field&field=idnumber' \
                                        '&value={}&moodlewsrestformat=json'.format(self.token, self.moodle_course_id)
             request_url = '{}?{}'.format(moodle_api_path, moodle_get_courses_query)
@@ -246,7 +250,7 @@ class TestMoodleApiClient(unittest.TestCase):
                 body=b'{}',
                 status=200
             )
-            client = MoodleAPIClient(self.enterprise_config)
+
             with pytest.raises(ClientError) as client_error:
                 client.create_course_completion(self.user_email, self.learner_data_payload)
 


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-7509

This fixes an issue with constructing moodle API urls when the base URL contains a sub directory. Previously, we were dropping the subdirectory in the call to `urljoin`. Removing the first slash in the API path constant fixes that issue.

I tested this change with all of the existing moodle configs in production to ensure that none of them would break.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
