### PR TITLE
bug: swapping grades api grade_percent return value type from string to float

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,13 +16,20 @@ Change Log
 Unreleased
 ----------
 
+[4.0.14]
+--------
+bug: swapping grades api grade_percent return value type from string to float
+
 [4.0.13]
+--------
 fix: more flexible default site 
 
 [4.0.12]
+--------
 fix: allow sub directories in moodle base URLs
 
 [4.0.11]
+--------
 feat: upgrade django-simple-history to 3.1.1
 
 [4.0.10]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.13"
+__version__ = "4.0.14"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -332,6 +332,21 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                     f' Passed timestamp: {passed_timestamp}'
                 ))
 
+        # In the past we have been inconsistent about the format/source/typing of the grade_percent value.
+        # Initial investigations have lead us to believe that grade percents from the source are seemingly more
+        # accurate now, so we're enforcing float typing. To account for the chance that old documentation is
+        # right and grade percents are reported as letter grade values, the float conversion is wrapped in a try/except
+        # in order to both not blow up and also log said instance of letter grade values.
+        try:
+            if grade_percent is not None:
+                grade_percent = float(grade_percent)
+        except ValueError as exc:
+            LOGGER.error(generate_formatted_log(
+                channel_name, enterprise_customer_uuid, lms_user_id, course_id,
+                f'Grade percent is not a valid float: {grade_percent}. Failed with exc: {exc}'
+            ))
+            grade_percent = None
+
         return completed_date_from_api, grade_from_api, is_passing_from_api, grade_percent, passed_timestamp
 
     def get_incomplete_content_count(self, enterprise_enrollment, channel_name):

--- a/tests/test_enterprise/management/test_manufacture_data.py
+++ b/tests/test_enterprise/management/test_manufacture_data.py
@@ -72,7 +72,7 @@ def call_command(command_name, *args, **options):
     def get_actions(parser):
         # Parser actions and actions from sub-parser choices.
         for opt in parser._actions:  # pylint: disable=protected-access
-            if isinstance(opt, _SubParsersAction):  # pylint: disable=protected-access
+            if isinstance(opt, _SubParsersAction):
                 for sub_opt in opt.choices.values():
                     yield from get_actions(sub_opt)
             else:


### PR DESCRIPTION
We believe tests that "claim" the grade value coming from the certificate API is a letter grade are full of baloney

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
