### PR TITLE
fix: more flexible default site

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,9 @@ Change Log
 Unreleased
 ----------
 
+[4.0.13]
+fix: more flexible default site 
+
 [4.0.12]
 fix: allow sub directories in moodle base URLs
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.12"
+__version__ = "4.0.13"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -165,7 +165,7 @@ def get_default_site():
     In stage it should be 'courses.stage.edx.org'.
     """
     value = settings.LMS_BASE
-    site, __ = Site.objects.get_or_create(domain=value, name=value)
+    site, __ = Site.objects.get_or_create(domain=value, defaults={"name": value})
     return site.id
 
 


### PR DESCRIPTION
## Description

- 500 error on stage due to this method (stacktrace below)
- this is because the `courses.stage.edx.org` site is not also named `courses.stage.edx.org` so this code is not finding it and trying to create, causing a unique constraint on domain
- move name into defaults since its not part of the unique constraint
- https://docs.djangoproject.com/en/4.2/ref/models/querysets/#get-or-create

 ![Screenshot 2023-08-14 at 2 23 23 PM](https://github.com/openedx/edx-enterprise/assets/31442/4c49013d-5d72-425d-8173-be200c2fe016)

```
2023-08-14 18:05:21,785 ERROR 7622 [django.request] [user 5262769] [ip 10.97.14.69] log.py:224 - Internal Server Error: /admin/enterprise/enterprisecustomer/add/
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 581, in get_or_create
    return self.get(**kwargs), False
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 435, in get
    raise self.model.DoesNotExist(
django.contrib.sites.models.Site.DoesNotExist: Site matching query does not exist.
During handling of the above exception, another exception occurred:
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/mysql/base.py", line 73, in execute
    return self.cursor.execute(query, args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/database_dbapi2.py", line 37, in execute
    return self.__wrapped__.execute(sql, parameters,
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/connections.py", line 255, in query
    _mysql.connection.query(self, query)
MySQLdb.IntegrityError: (1062, "Duplicate entry 'courses.stage.edx.org' for key 'django_site_domain_a2e37b91_uniq'")
The above exception was the direct cause of the following exception:
Traceback (most recent call last):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/exception.py", line 47, in inner
    response = get_response(request)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/handlers/base.py", line 181, in _get_response
    response = wrapped_callback(request, *callback_args, **callback_kwargs)
  File "/usr/lib/python3.8/contextlib.py", line 75, in inner
    return func(*args, **kwds)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/framework_django.py", line 552, in wrapper
    return wrapped(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/admin/options.py", line 616, in wrapper
    return self.admin_site.admin_view(view)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/views/decorators/cache.py", line 44, in _wrapped_view_func
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/admin/sites.py", line 232, in inner
    return view(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/admin/options.py", line 1657, in add_view
    return self.changeform_view(request, None, form_url, extra_context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 43, in _wrapper
    return bound_method(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/utils/decorators.py", line 130, in _wrapped_view
    response = view_func(request, *args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/admin/options.py", line 1540, in changeform_view
    return self._changeform_view(request, object_id, form_url, extra_context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/contrib/admin/options.py", line 1600, in _changeform_view
    form = ModelForm(initial=initial)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/forms/models.py", line 298, in __init__
    self.instance = opts.model()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 477, in __init__
    val = field.get_default()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/related.py", line 960, in get_default
    field_default = super().get_default()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/fields/__init__.py", line 850, in get_default
    return self._get_default()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/models.py", line 168, in get_default_site
    site, __ = Site.objects.get_or_create(domain=value, name=value)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 588, in get_or_create
    return self.create(**params), True
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 453, in create
    obj.save(force_insert=True, using=self.db)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 739, in save
    self.save_base(using=using, force_insert=force_insert,
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 776, in save_base
    updated = self._save_table(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 881, in _save_table
    results = self._do_insert(cls._base_manager, using, fields, returning_fields, raw)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/base.py", line 919, in _do_insert
    return manager._insert(
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/manager.py", line 85, in manager_method
    return getattr(self.get_queryset(), name)(*args, **kwargs)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/query.py", line 1270, in _insert
    return query.get_compiler(using=using).execute_sql(returning_fields)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/models/sql/compiler.py", line 1416, in execute_sql
    cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 66, in execute
    return self._execute_with_wrappers(sql, params, many=False, executor=self._execute)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 75, in _execute_with_wrappers
    return executor(sql, params, many, context)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/utils.py", line 90, in __exit__
    raise dj_exc_value.with_traceback(traceback) from exc_value
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/db/backends/mysql/base.py", line 73, in execute
    return self.cursor.execute(query, args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/newrelic/hooks/database_dbapi2.py", line 37, in execute
    return self.__wrapped__.execute(sql, parameters,
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/cursors.py", line 179, in execute
    res = self._query(mogrified_query)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/cursors.py", line 330, in _query
    db.query(q)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/MySQLdb/connections.py", line 255, in query
    _mysql.connection.query(self, query)
django.db.utils.IntegrityError: (1062, "Duplicate entry 'courses.stage.edx.org' for key 'django_site_domain_a2e37b91_uniq'")
```
