### PR TITLE
fix: enrolled course card grouping behavior for exec-ed courses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.0.18]
+--------
+fix: enrolled course card grouping behavior for exec-ed courses
+
 [4.0.17]
 --------
 chore: restoring licensed enrollment table if it does not exist

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.0.17"
+__version__ = "4.0.18"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -77,6 +77,7 @@ COURSE_MODE_SORT_ORDER = [
 ]
 
 EXEC_ED_COURSE_TYPE = "executive-education-2u"
+PRODUCT_SOURCE_2U = "2u"
 EXEC_ED_CONTENT_DESCRIPTION_TAG = ("This instructor-led Executive Education course is "
                                    "presented by GetSmarter, an edX partner. ")
 

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -8,9 +8,10 @@ from rest_framework import serializers
 from django.conf import settings
 from django.utils.translation import gettext as _
 
+from enterprise.constants import EXEC_ED_COURSE_TYPE, PRODUCT_SOURCE_2U
 from enterprise.models import EnterpriseCustomerUser
 from enterprise.utils import NotConnectedToOpenEdX
-from enterprise_learner_portal.utils import get_course_run_status
+from enterprise_learner_portal.utils import get_course_run_status, get_exec_ed_course_run_status
 
 try:
     from lms.djangoapps.bulk_email.api import get_emails_enabled
@@ -86,6 +87,14 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
                 representation['start_date'] = course_details.start_date or representation['start_date']
                 representation['end_date'] = course_details.end_date or representation['end_date']
                 representation['enroll_by'] = course_details.enroll_by
+
+                if (course_details.product_source == PRODUCT_SOURCE_2U and
+                        course_details.course_type == EXEC_ED_COURSE_TYPE):
+                    representation['course_run_status'] = get_exec_ed_course_run_status(
+                        course_details,
+                        certificate_info,
+                        instance
+                    )
 
         return representation
 

--- a/enterprise_learner_portal/utils.py
+++ b/enterprise_learner_portal/utils.py
@@ -1,6 +1,9 @@
 """
 enterprise_learner_portal utils.
 """
+from datetime import datetime
+
+from pytz import utc
 
 
 class CourseRunProgressStatuses:
@@ -42,5 +45,42 @@ def get_course_run_status(course_overview, certificate_info, enterprise_enrollme
     if course_overview['has_ended'] or is_certificate_passing:
         return CourseRunProgressStatuses.COMPLETED
     if course_overview['has_started']:
+        return CourseRunProgressStatuses.IN_PROGRESS
+    return CourseRunProgressStatuses.UPCOMING
+
+
+def get_exec_ed_course_run_status(course_details, certificate_info, enterprise_enrollment):
+    """
+    Get the status of a exec ed course run, given the state of a user's certificate in the course.
+
+    A run is considered "complete" when either the course run has ended OR the user has earned a
+    passing certificate.
+
+    Arguments:
+        course_details : the details for the exececutive education course run
+        certificate_info: A dict containing the following key:
+            ``is_passing``: whether the  user has a passing certificate in the course run
+
+    Returns:
+        status: one of (
+            CourseRunProgressStatuses.SAVED_FOR_LATER,
+            CourseRunProgressStatuses.COMPLETE,
+            CourseRunProgressStatuses.IN_PROGRESS,
+            CourseRunProgressStatuses.UPCOMING,
+        )
+    """
+    if enterprise_enrollment and enterprise_enrollment.saved_for_later:
+        return CourseRunProgressStatuses.SAVED_FOR_LATER
+
+    is_certificate_passing = certificate_info.get('is_passing', False)
+    start_date = course_details.start_date
+    end_date = course_details.end_date
+
+    has_started = datetime.now(utc) > start_date if start_date is not None else True
+    has_ended = datetime.now(utc) > end_date if end_date is not None else False
+
+    if has_ended or is_certificate_passing:
+        return CourseRunProgressStatuses.COMPLETED
+    if has_started:
         return CourseRunProgressStatuses.IN_PROGRESS
     return CourseRunProgressStatuses.UPCOMING


### PR DESCRIPTION
##Description
**Problem**
A course that is in progress is erroneously appearing in the completed course list

**Solution**
I have updated the logic for calculating the course_status for executive education courses. Now the status is calculated on the base of CourseDetail model dates.

JIRA -> [ENT-7496](https://2u-internal.atlassian.net/browse/ENT-7496)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
