### PR TITLE
feat: add patch endpoint to update enterprise customer catalog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.1.1]
+-------
+feat: Added patch endpoint to update an enterprise customer catalog.
+
 [4.1.0]
 -------
 feat: Added the ability to get AI generated learner engagement and learner progress summary.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.1.0"
+__version__ = "4.1.1"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -73,6 +73,13 @@ router.register(
 
 urlpatterns = [
     re_path(
+        r'^enterprise_customer_catalog/',
+        enterprise_customer_catalog.EnterpriseCustomerCatalogWriteViewSet.as_view(
+            {'patch': 'partial_update', 'post': 'create'},
+        ),
+        name='create_or_update'
+    ),
+    re_path(
         r'enterprise-subsidy-fulfillment/(?P<fulfillment_source_uuid>[A-Za-z0-9-]+)/?$',
         enterprise_subsidy_fulfillment.EnterpriseSubsidyFulfillmentViewSet.as_view({'get': 'retrieve'}),
         name='enterprise-subsidy-fulfillment'

--- a/enterprise/api/v1/views/base_views.py
+++ b/enterprise/api/v1/views/base_views.py
@@ -7,7 +7,7 @@ from edx_rest_framework_extensions.auth.jwt.authentication import JwtAuthenticat
 from rest_framework import filters, permissions, viewsets
 from rest_framework.authentication import SessionAuthentication
 from rest_framework.exceptions import NotFound
-from rest_framework.mixins import CreateModelMixin
+from rest_framework.mixins import CreateModelMixin, UpdateModelMixin
 
 from enterprise.api.filters import UserFilterBackend
 from enterprise.api.throttles import ServiceUserThrottle
@@ -67,7 +67,7 @@ class EnterpriseReadWriteModelViewSet(EnterpriseModelViewSet, viewsets.ModelView
     permission_classes = (permissions.IsAuthenticated, permissions.DjangoModelPermissions,)
 
 
-class EnterpriseWriteOnlyModelViewSet(EnterpriseModelViewSet, CreateModelMixin, viewsets.GenericViewSet):
+class EnterpriseWriteOnlyModelViewSet(EnterpriseModelViewSet, CreateModelMixin, UpdateModelMixin, viewsets.GenericViewSet):
     """
     Base class for all write only Enterprise model view sets.
     """

--- a/enterprise/api/v1/views/base_views.py
+++ b/enterprise/api/v1/views/base_views.py
@@ -67,7 +67,12 @@ class EnterpriseReadWriteModelViewSet(EnterpriseModelViewSet, viewsets.ModelView
     permission_classes = (permissions.IsAuthenticated, permissions.DjangoModelPermissions,)
 
 
-class EnterpriseWriteOnlyModelViewSet(EnterpriseModelViewSet, CreateModelMixin, UpdateModelMixin, viewsets.GenericViewSet):
+class EnterpriseWriteOnlyModelViewSet(
+    EnterpriseModelViewSet,
+    CreateModelMixin,
+    UpdateModelMixin,
+    viewsets.GenericViewSet,
+):
     """
     Base class for all write only Enterprise model view sets.
     """

--- a/enterprise/api/v1/views/enterprise_customer_catalog.py
+++ b/enterprise/api/v1/views/enterprise_customer_catalog.py
@@ -101,7 +101,10 @@ class EnterpriseCustomerCatalogWriteViewSet(EnterpriseWriteOnlyModelViewSet):
         enterprise_customer_catalog_uuid = request.data.get('uuid')
         found_catalog = self.has_enterprise_customer_catalog(enterprise_customer_catalog_uuid)
         if not found_catalog:
-            return Response({'detail': 'Could not find catalog uuid'}, status=status.HTTP_404_NOT_FOUND)
+            return Response(
+                {'detail': f'Could not find catalog uuid {enterprise_customer_catalog_uuid}'},
+                status=status.HTTP_404_NOT_FOUND
+            )
 
         serializer = self.get_serializer(found_catalog, data=request.data, partial=True)
         if serializer.is_valid(raise_exception=True):

--- a/enterprise/api/v1/views/enterprise_customer_catalog.py
+++ b/enterprise/api/v1/views/enterprise_customer_catalog.py
@@ -91,8 +91,9 @@ class EnterpriseCustomerCatalogWriteViewSet(EnterpriseWriteOnlyModelViewSet):
         Method: PATCH
 
         Payload::
+
           {
-            "uuid": string - UUID of an existing enterprise customer catalog
+            "uuid": string - UUID of an existing enterprise customer catalog,
             "title":  string - Title of the catalog,
           }
 

--- a/enterprise/api/v1/views/enterprise_customer_catalog.py
+++ b/enterprise/api/v1/views/enterprise_customer_catalog.py
@@ -99,6 +99,7 @@ class EnterpriseCustomerCatalogWriteViewSet(EnterpriseWriteOnlyModelViewSet):
 
         Returns 200 along with the updated object.
         """
+
         enterprise_customer_catalog_uuid = request.data.get('uuid')
         found_catalog = self.has_enterprise_customer_catalog(enterprise_customer_catalog_uuid)
         if not found_catalog:

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1895,6 +1895,8 @@ class TestEnterpriseCustomerCatalogWriteViewSet(BaseTestEnterpriseAPIViews):
         post_response_output = self.load_json(post_response.content)
         enterprise_customer_catalog_uuid = post_response_output['uuid']
 
+        assert post_response_output['title'] == 'Test Catalog'
+
         patch_response = self.client.patch(ENTERPRISE_CUSTOMER_CATALOG_ENDPOINT, {
             "title": "Test title update",
             "uuid": enterprise_customer_catalog_uuid,
@@ -1911,19 +1913,19 @@ class TestEnterpriseCustomerCatalogWriteViewSet(BaseTestEnterpriseAPIViews):
         Test that a catalog cannot be partially updated with incorrect UUID
         """
         enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
-
+        catalog_uuid = str(FAKE_UUIDS[0])
         self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, str(enterprise_customer.uuid))
         self.user.is_staff = True
         self.user.save()
 
         patch_response = self.client.patch(ENTERPRISE_CUSTOMER_CATALOG_ENDPOINT, {
             "title": "Test title update",
-            "uuid": str(FAKE_UUIDS[0]),
+            "uuid": catalog_uuid,
         }, format='json')
         patch_response_output = self.load_json(patch_response.content)
 
         assert patch_response.status_code == 404
-        assert "Could not find catalog uuid" in patch_response_output['detail']
+        assert f'Could not find catalog uuid {catalog_uuid}' in patch_response_output['detail']
 
 
 @ddt.ddt

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1876,6 +1876,33 @@ class TestEnterpriseCustomerCatalogWriteViewSet(BaseTestEnterpriseAPIViews):
         if response.status_code == 400:
             assert "Invalid pk" in response_output['enterprise_customer'][0]
 
+    def test_partially_update_enterprise_customer_catalog(self, is_staff, expected_status_code):
+        """
+        Test that a catalog can be partially updated
+        """
+        enterprise_customer_catalog_uuid = {
+            'uuid': FAKE_UUIDS[0]
+        }
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, str(enterprise_customer.uuid))
+        self.user.is_staff = is_staff
+        self.user.save()
+
+        response = self.client.patch(ENTERPRISE_CUSTOMER_CATALOG_ENDPOINT, {
+            "title": "Test title update",
+            "uuid": str(enterprise_customer_catalog_uuid['uuid']),
+        }, format='json')
+        response_output = self.load_json(response.content)
+
+        assert response.status_code == expected_status_code
+
+        if expected_status_code == 200:
+            assert response_output['title'] == 'Test title update'
+            assert response_output['enterprise_customer'] == str(enterprise_customer.uuid)
+            assert response_output['uuid'] == str(enterprise_customer_catalog_uuid['uuid'])
+        if expected_status_code == 404:
+            assert response_output['detail'] == 'Could not find catalog uuid'
+
 
 @ddt.ddt
 @mark.django_db


### PR DESCRIPTION
# Description
We need an endpoint that supports updating the title of an enterprise customer catalog.

# Solution
Added a PATCH endpoint to url `enterprise_customer_catalog` to support the PATCH request.

[JIRA](https://2u-internal.atlassian.net/browse/ENT-7583)

This PR is part of an epic to implement an edit/view learner credit plan details in support tools. Below are the previous tickets associated:

|Implementation|PR|
| ------------- | ------------- |
|Add feature flag| https://2u-internal.atlassian.net/browse/ENT-7517| 
|Create List View of Learner Credit Plans with Muted Standalone Hyperlinks|https://github.com/openedx/frontend-app-support-tools/pull/349|
|Implements Detailed Plan View with Edit Mode Button|https://github.com/openedx/frontend-app-support-tools/pull/352|

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
