### PR TITLE
fix: put api_credentials bool in api response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Change Log
 
 Unreleased
 ----------
+[4.1.6]
+-------
+fix: putting api_credentials bool in api response to access in admin portal
 
 [4.1.5]
 -------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,6 @@
 Your project description goes here.
 """
 
-__version__ = "4.1.5"
+__version__ = "4.1.6"
 
 default_app_config = "enterprise.apps.EnterpriseConfig"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -217,7 +217,7 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
             'enable_executive_education_2U_fulfillment', 'enable_portal_reporting_config_screen',
             'enable_portal_saml_configuration_screen', 'contact_email',
             'enable_portal_subscription_management_screen', 'hide_course_original_price', 'enable_analytics_screen',
-            'enable_integrated_customer_learner_portal_search',
+            'enable_integrated_customer_learner_portal_search', 'enable_generation_of_api_credentials',
             'enable_portal_lms_configurations_screen', 'sender_alias', 'identity_providers',
             'enterprise_customer_catalogs', 'reply_to', 'enterprise_notification_banner', 'hide_labor_market_data',
             'modified', 'enable_universal_link', 'enable_browse_and_request', 'admin_users'

--- a/enterprise/api/v1/views/enterprise_customer_api_credentials.py
+++ b/enterprise/api/v1/views/enterprise_customer_api_credentials.py
@@ -49,7 +49,7 @@ class APICredentialsViewSet(EnterpriseReadWriteModelViewSet):
 
         Method: POST
 
-        URL: /enterprise/api/v1/enterprise_customer_api_credentials/{enterprise_uuid}
+        URL: /enterprise/api/v1/enterprise-customer-api-credentials/{enterprise_uuid}
 
         Returns 201 if a new API application credentials was created.
         If an application already exists for the user, throw a 409.
@@ -94,7 +94,7 @@ class APICredentialsViewSet(EnterpriseReadWriteModelViewSet):
         """
         Method: DELETE
 
-        URL: /enterprise/api/v1/enterprise_customer_api_credentials/{enterprise_uuid}
+        URL: /enterprise/api/v1/enterprise-customer-api-credentials/{enterprise_uuid}
         """
         enterprise_uuid = kwargs['enterprise_uuid']
         if not enterprise_uuid:
@@ -112,7 +112,7 @@ class APICredentialsViewSet(EnterpriseReadWriteModelViewSet):
         """
         Method: GET
 
-        URL: /enterprise/api/v1/enterprise_customer_api_credentials/{enterprise_uuid}
+        URL: /enterprise/api/v1/enterprise-customer-api-credentials/{enterprise_uuid}
         """
         enterprise_uuid = kwargs['enterprise_uuid']
         if not enterprise_uuid:
@@ -130,7 +130,7 @@ class APICredentialsViewSet(EnterpriseReadWriteModelViewSet):
         """
         Method: PUT
 
-        URL: /enterprise/api/v1/enterprise_customer_api_credentials/{enterprise_uuid}
+        URL: /enterprise/api/v1/enterprise-customer-api-credentials/{enterprise_uuid}
         """
         # Verifies the requesting user is connected to an enterprise that has API credentialing bool set to True
         user = request.user
@@ -182,7 +182,7 @@ class APICredentialsRegenerateViewSet(APICredentialsViewSet):
         """
         Method: PUT
 
-        URL: /enterprise/api/v1/enterprise_customer_api_credentials/{enterprise_uuid}/regenerate_credentials
+        URL: /enterprise/api/v1/enterprise-customer-api-credentials/{enterprise_uuid}/regenerate_credentials
         """
         enterprise_uuid = kwargs['enterprise_uuid']
 

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1179,7 +1179,8 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'modified': '2021-10-20T19:01:31Z',
                 'enable_universal_link': False,
                 'enable_browse_and_request': False,
-                'admin_users': []
+                'admin_users': [],
+                'enable_generation_of_api_credentials': False,
             }],
         ),
         (
@@ -1232,6 +1233,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'hide_labor_market_data': False, 'modified': '2021-10-20T19:01:31Z',
                     'enable_universal_link': False, 'enable_browse_and_request': False,
                     'admin_users': [],
+                    'enable_generation_of_api_credentials': False,
                 },
                 'active': True, 'user_id': 0, 'user': None,
                 'data_sharing_consent_records': [], 'groups': [],
@@ -1316,6 +1318,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enable_universal_link': False,
                 'enable_browse_and_request': False,
                 'admin_users': [],
+                'enable_generation_of_api_credentials': False,
             }],
         ),
         (
@@ -1376,6 +1379,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enable_universal_link': False,
                 'enable_browse_and_request': False,
                 'admin_users': [],
+                'enable_generation_of_api_credentials': False,
             }],
         ),
         (
@@ -1594,7 +1598,8 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'modified': '2021-10-20T19:32:12Z',
                 'enable_universal_link': False,
                 'enable_browse_and_request': False,
-                'admin_users': []
+                'admin_users': [],
+                'enable_generation_of_api_credentials': False,
             }
         else:
             assert response == expected_error


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
