### PR TITLE
fix: Remove unnecessary default_app_config definitions.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,15 @@ Change Log
 
 Unreleased
 ----------
+
+[4.1.7]
+fix: Remove unnecessary default_app_config definitions.
+
+Django now detects this configuration automatically. You can remove
+default_app_config.  This removes 11 warnings from edx-platform startup
+and deals with something that's going to be fully ignored in django
+4.1
+
 [4.1.6]
 -------
 fix: putting api_credentials bool in api response to access in admin portal

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,7 +16,9 @@ Change Log
 Unreleased
 ----------
 
+
 [4.1.7]
+-------
 fix: Remove unnecessary default_app_config definitions.
 
 Django now detects this configuration automatically. You can remove

--- a/consent/__init__.py
+++ b/consent/__init__.py
@@ -12,5 +12,3 @@ of gate that an enterprise stands at.
 """
 
 __version__ = "0.1.0"
-
-default_app_config = "consent.apps.ConsentConfig"

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,6 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.1.6"
-
-default_app_config = "enterprise.apps.EnterpriseConfig"
+__version__ = "4.1.7"

--- a/integrated_channels/blackboard/__init__.py
+++ b/integrated_channels/blackboard/__init__.py
@@ -3,6 +3,3 @@ The Blackboard Integrated Channel package.
 """
 
 __version__ = "0.0.1"
-
-default_app_config = ("integrated_channels.blackboard.apps."
-                      "BlackboardConfig")

--- a/integrated_channels/canvas/__init__.py
+++ b/integrated_channels/canvas/__init__.py
@@ -1,2 +1,5 @@
+"""
+This is the integrated channels integration with Canvas.
+"""
 
 __version__ = "0.0.1"

--- a/integrated_channels/canvas/__init__.py
+++ b/integrated_channels/canvas/__init__.py
@@ -1,8 +1,2 @@
-"""
-The Canvas Integrated Channel package.
-"""
 
 __version__ = "0.0.1"
-
-default_app_config = ("integrated_channels.canvas.apps."
-                      "CanvasConfig")

--- a/integrated_channels/cornerstone/__init__.py
+++ b/integrated_channels/cornerstone/__init__.py
@@ -3,6 +3,3 @@ The Cornerstone Integrated Channel package.
 """
 
 __version__ = "0.1.0"
-
-default_app_config = ("integrated_channels.cornerstone.apps."
-                      "CornerstoneConfig")

--- a/integrated_channels/degreed/__init__.py
+++ b/integrated_channels/degreed/__init__.py
@@ -3,6 +3,3 @@ The Degreed Integrated Channel package.
 """
 
 __version__ = "0.1.0"
-
-default_app_config = ("integrated_channels.degreed.apps."
-                      "DegreedConfig")

--- a/integrated_channels/degreed2/__init__.py
+++ b/integrated_channels/degreed2/__init__.py
@@ -4,6 +4,3 @@ The Degreed2 Integrated Channel package.
 """
 
 __version__ = "0.0.1"
-
-default_app_config = ("integrated_channels.degreed2.apps."
-                      "Degreed2Config")

--- a/integrated_channels/integrated_channel/__init__.py
+++ b/integrated_channels/integrated_channel/__init__.py
@@ -3,6 +3,3 @@ Base Integrated Channel application for specific integrated channels to use as a
 """
 
 __version__ = "0.1.0"
-
-default_app_config = ("integrated_channels.integrated_channel.apps."
-                      "IntegratedChannelConfig")

--- a/integrated_channels/moodle/__init__.py
+++ b/integrated_channels/moodle/__init__.py
@@ -3,6 +3,3 @@ The Moodle Integrated Channel package.
 """
 
 __version__ = "0.1.0"
-
-default_app_config = ("integrated_channels.moodle.apps."
-                      "MoodleConfig")

--- a/integrated_channels/sap_success_factors/__init__.py
+++ b/integrated_channels/sap_success_factors/__init__.py
@@ -3,6 +3,3 @@ SAP SuccessFactors module.
 """
 
 __version__ = "0.1.0"
-
-default_app_config = ("integrated_channels.sap_success_factors.apps."
-                      "SAPSuccessFactorsConfig")

--- a/integrated_channels/xapi/__init__.py
+++ b/integrated_channels/xapi/__init__.py
@@ -3,6 +3,3 @@ xAPI module.
 """
 
 __version__ = "0.1.0"
-
-default_app_config = ("integrated_channels.xapi.apps."
-                      "XAPIConfig")


### PR DESCRIPTION
Django now detects this configuration automatically. You can remove
default_app_config.  This removes 11 warnings from edx-platform startup
and deals with something that's going to be fully ignored in django
4.1
