### PR TITLE
feat: adding read only field to EnterpriseCustomerCatalogSerializer model

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.1.14]
+--------
+feat: adding read only field to EnterpriseCustomerCatalogSerializer model
+
 [4.1.13]
 --------
 feat: adding braze email task to sso orchestration endpoint

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.1.13"
+__version__ = "4.1.14"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -444,7 +444,7 @@ class EnterpriseCustomerCatalogSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCustomerCatalog
         fields = (
-            'uuid', 'title', 'enterprise_customer',
+            'uuid', 'title', 'enterprise_customer', 'enterprise_catalog_query',
         )
 
 

--- a/test_utils/fake_enterprise_api.py
+++ b/test_utils/fake_enterprise_api.py
@@ -151,7 +151,8 @@ class EnterpriseMockMixin:
 
 # pylint: disable=dangerous-default-value
 def build_fake_enterprise_catalog_detail(enterprise_catalog_uuid=FAKE_UUIDS[1], title='All Content',
-                                         enterprise_customer_uuid=FAKE_UUIDS[0], previous_url=None, next_url=None,
+                                         enterprise_customer_uuid=FAKE_UUIDS[0], enterprise_catalog_query=1,
+                                         previous_url=None, next_url=None,
                                          paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS,
                                          include_enterprise_context=False, add_utm_info=True,
                                          count=None):
@@ -169,6 +170,7 @@ def build_fake_enterprise_catalog_detail(enterprise_catalog_uuid=FAKE_UUIDS[1], 
         'title': title,
         'enterprise_customer': enterprise_customer_uuid,
         'results': paginated_content['results'],
+        'enterprise_catalog_query': enterprise_catalog_query,
     }
 
 

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1982,7 +1982,8 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
                 'results': [{
                     'uuid': catalog_uuid,
                     'title': catalog_title,
-                    'enterprise_customer': enterprise_customer.uuid
+                    'enterprise_customer': enterprise_customer.uuid,
+                    'enterprise_catalog_query': 1
                 }]
             }
         else:


### PR DESCRIPTION
# Description
We need a way to determine on the FE support tools which catalogs are custom versus open courses, exec ed, everything. 

# Solution
Add read only field `enterprise_catalog_query` to the `EnterpriseCustomerCatalogSerializer` so that the FE can determine if the catalog is an open course, exec ed, everything or custom. 

[JIRA Ticket](https://2u-internal.atlassian.net/browse/ENT-7697)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
