### PR TITLE
chore: sso orchestrator configs should start inactive and be activated upon successful configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.5.5]
+-------
+chore: sso orchestrator configs should start inactive and be activated upon successful configuration
+
 [4.5.4]
 -------
 feat: inactive moodle course instead of true delete

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.5.4"
+__version__ = "4.5.5"

--- a/enterprise/api/v1/views/enterprise_customer_sso_configuration.py
+++ b/enterprise/api/v1/views/enterprise_customer_sso_configuration.py
@@ -146,6 +146,10 @@ class EnterpriseCustomerSsoConfigurationViewSet(viewsets.ModelViewSet):
                 ' not been marked as submitted.'
             )
 
+        # Mark the configuration record as active IFF this the record has never been configured.
+        if not sso_configuration_record.configured_at:
+            sso_configuration_record.active = True
+
         sso_configuration_record.configured_at = localized_utcnow()
         # Completing the orchestration process for the first time means the configuration record is now configured and
         # can be considered active. However, subsequent configurations to update the record should not be reactivated,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -4055,7 +4055,13 @@ class EnterpriseCustomerSsoConfiguration(TimeStampedModel, SoftDeletableModel):
             is_sap = True
         else:
             for field in self.base_saml_config_fields:
-                config_data[utils.camelCase(field)] = getattr(self, field)
+                if field == "active":
+                    if not updating_existing_record:
+                        config_data['enable'] = True
+                    else:
+                        config_data['enable'] = getattr(self, field)
+                else:
+                    config_data[utils.camelCase(field)] = getattr(self, field)
 
         EnterpriseSSOOrchestratorApiClient().configure_sso_orchestration_record(
             config_data=config_data,

--- a/enterprise/tpa_pipeline.py
+++ b/enterprise/tpa_pipeline.py
@@ -65,7 +65,7 @@ def validate_provider_config(enterprise_customer, sso_provider_id):
     enterprise_orchestration_config = enterprise_customer.sso_orchestration_records.filter(
         active=True
     )
-    if enterprise_orchestration_config.exists():
+    if enterprise_orchestration_config.exists() and not enterprise_orchestration_config.first().validated_at:
         enterprise_orchestration_config.update(validated_at=datetime.now())
 
     # With a successful SSO login, validate the enterprise customer's IDP config if it hasn't already been validated


### PR DESCRIPTION
The ideal behavior is that:
- we always tell the orchestrator to create the integrations as "active"
- we show the config as inactive until the point the enterprise is able to use their IDP
  - this point should happen when the oauth complete endpoint is hit by the orchestrator
- we don't need to update the validated at every time the integration is used
- 
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
