### PR TITLE
fix: remove not required fields from serializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.6.3]
+-------
+fix: Remove not required fields
+
 [4.6.2]
 -------
 fix: clarify contact email helper text for enterprise customer

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.6.2"
+__version__ = "4.6.3"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1526,7 +1526,6 @@ class AnalyticsSummarySerializer(serializers.Serializer):
         at_risk_enrollment_less_than_one_hour = serializers.IntegerField(required=True)
         at_risk_enrollment_end_date_soon = serializers.IntegerField(required=True)
         at_risk_enrollment_dormant = serializers.IntegerField(required=True)
-        created_at = serializers.DateTimeField(required=True)
 
     class LearnerEngagementSerializer(serializers.Serializer):
         """
@@ -1543,8 +1542,6 @@ class AnalyticsSummarySerializer(serializers.Serializer):
         hours = serializers.IntegerField(required=True)
         hours_prior = serializers.IntegerField(required=True)
         active_contract = serializers.BooleanField(required=True)
-        contract_end_date = serializers.DateTimeField(required=True)
-        created_at = serializers.DateTimeField(required=True)
 
     learner_progress = LearnerProgressSerializer()
     learner_engagement = LearnerEngagementSerializer()

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -6795,7 +6795,6 @@ class TestAnalyticsSummaryView(APITest):
             'at_risk_enrollment_less_than_one_hour': 3,
             'at_risk_enrollment_end_date_soon': 2,
             'at_risk_enrollment_dormant': 2,
-            'created_at': '2023-08-10T12:39:35.388936Z'
         }
 
         self.learner_engagement = {
@@ -6809,9 +6808,7 @@ class TestAnalyticsSummaryView(APITest):
             'engage_prior': 50,
             'hours': 2000,
             'hours_prior': 3000,
-            'contract_end_date': '2023-12-10T12:39:28.792421Z',
             'active_contract': True,
-            'created_at': '2023-08-11T13:25:40.197061Z'
         }
 
         self.payload = {


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
