### PR TITLE
feat: added new endpoint to fetch assigned courses details

### DIFF
--- a/enterprise_learner_portal/api/v1/urls.py
+++ b/enterprise_learner_portal/api/v1/urls.py
@@ -4,10 +4,13 @@ URL definitions for enterprise_learner_portal API endpoint.
 
 from django.urls import path
 
-from enterprise_learner_portal.api.v1.views import EnterpriseCourseEnrollmentView
+from enterprise_learner_portal.api.v1.views import EnterpriseAssignedCoursesView, EnterpriseCourseEnrollmentView
 
 urlpatterns = [
     path('enterprise_course_enrollments/', EnterpriseCourseEnrollmentView.as_view(),
          name="enterprise-learner-portal-course-enrollment-list"
+         ),
+    path('enterprise_assigned_courses/', EnterpriseAssignedCoursesView.as_view(),
+         name="enterprise-learner-portal-assigned-courses-list"
          ),
 ]

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -18,6 +18,19 @@ from test_utils import factories
 
 SERIALIZED_MOCK_ACTIVE_ENROLLMENT = {'course_id': 'foo', 'is_enrollment_active': True}
 SERIALIZED_MOCK_INACTIVE_ENROLLMENT = {'course_id': 'bar', 'is_enrollment_active': False}
+SERIALIZED_MOCK_ASSIGNED_COURSE_META = [
+    {
+        "course_run_id": 'course-v1:edX+DemoX+Demo_Course_1',
+        "created": "2023-08-28T13:21:55.913099Z",
+        "start_date": "2023-08-30T13:21:55Z",
+        "end_date": "2023-10-17T13:21:55Z",
+        "display_name": "Works of Ivan Turgenev",
+        "course_run_url": "http://localhost:2000/course/course-v1:edX+DemoX+Demo_Course_1/home",
+        "course_run_status": "completed",
+        "pacing": "instructor",
+        "org_name": "edX"
+    }
+]
 
 
 @mark.django_db
@@ -317,3 +330,63 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         )
         assert resp.status_code == 404
         assert resp.json() == {'detail': 'Not found.'}
+
+
+@mark.django_db
+class TestEnterpriseAssignedCoursesView(TestCase):
+    """
+    EnterpriseAssignedCoursesView tests.
+    """
+
+    class MockSerializer:
+        """ Returns obj with data property. """
+
+        @property
+        def data(self):
+            """ Return fake serialized data. """
+            return SERIALIZED_MOCK_ASSIGNED_COURSE_META
+
+    def setUp(self):
+        super().setUp()
+
+        self.enterprise_customer = factories.EnterpriseCustomerFactory.create()
+
+        # Create our user
+        self.user = factories.UserFactory.create(is_staff=True, is_active=True)
+        self.user.set_password("QWERTY")
+        self.user.save()
+
+        self.client = Client()
+        self.client.login(username=self.user.username, password="QWERTY")
+
+    @mock.patch('enterprise_learner_portal.api.v1.views.EnterpriseAssignedCoursesSerializer')
+    @mock.patch('enterprise_learner_portal.api.v1.views.get_course_overviews')
+    def test_view_returns_information(self, mock_get_overviews, mock_serializer):
+        mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
+        mock_serializer.return_value = self.MockSerializer()
+
+        resp = self.client.get(
+            '{host}{path}?course_ids={course_ids}'.format(
+                host=settings.TEST_SERVER,
+                path=reverse('enterprise-learner-portal-assigned-courses-list'),
+                course_ids='course-v1:edX+DemoX+Demo_Course_1'
+            )
+        )
+        assert resp.status_code == 200
+        assert resp.json() == SERIALIZED_MOCK_ASSIGNED_COURSE_META
+
+    @mock.patch('enterprise_learner_portal.api.v1.views.get_course_overviews')
+    def test_view_returns_bad_request_without_course_ids(self, mock_get_overviews):
+        """
+        View should return a 400 when called with missing course_ids parameter.
+        """
+        mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
+
+        resp = self.client.get(
+            '{host}{path}'.format(
+                host=settings.TEST_SERVER,
+                path=reverse('enterprise-learner-portal-assigned-courses-list')
+            )
+        )
+        assert resp.status_code == 400
+        assert resp.json() == {'error': 'course_ids must be provided as query parameters'}


### PR DESCRIPTION
**Jira Ticket**: https://2u-internal.atlassian.net/browse/ENT-7666
**Description**: Added new endpoint to fetch details against given assigned courses.

**Endpoint Url**: https://courses.stage.edx.org/enterprise_learner_portal/api/v1/enterprise_assigned_courses/?course_ids=course-v1:edX%2BP315%2B2T2023&course_ids=course-v1:edX%2BL153%2B2T2023

**FYI**: The `course_ids` should be URL-encoded, replacing the '**+**' sign with '%2B' because the **+** sign is a reserved character in URLs that is used to represent spaces.
Example: course-v1:edX%2BL153%2B2T2023


**Response:**
```
[
    {
        "course_run_id": "course-v1:edX+L153+2T2023",
        "created": "2023-08-28T13:21:55.913099Z",
        "start_date": "2023-10-19T10:46:36Z",
        "end_date": "2023-12-30T10:46:44Z",
        "display_name": "Works of Ivan Turgenev",
        "course_run_url": "http://localhost:2000/course/course-v1:edX+L153+2T2023/home",
        "course_run_status": "in_progress",
        "pacing": "instructor",
        "org_name": "edX",
        "certificate_download_url": null,
        "enroll_by": "2023-10-25T10:46:49Z",
        "course_type": "executive-education-2u",
        "product_source": "2u"
    },
    {
        "course_run_id": "course-v1:edX+P315+2T2023",
        "created": "2023-08-28T13:21:46.584659Z",
        "start_date": "2023-08-30T13:21:46Z",
        "end_date": "2023-10-17T13:21:46Z",
        "display_name": "Quantum Entanglement",
        "course_run_url": "http://localhost:2000/course/course-v1:edX+P315+2T2023/home",
        "course_run_status": "completed",
        "pacing": "instructor",
        "org_name": "edX",
        "certificate_download_url": null
    }
]
```

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
