### PR TITLE
[ENT-7725] - Add try catch block for enhanced debugging

### DIFF
--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -32,72 +32,82 @@ class Degreed2LearnerExporter(LearnerExporter):
 
         If no remote ID can be found, return None.
         """
-        percent_grade = kwargs.get('grade_percent') * 100 if kwargs.get('grade_percent') else None
-        # Degreed expects completion dates of the form 'yyyy-mm-ddTHH:MM:SS'.
-        degreed_completed_timestamp = completed_date.strftime('%Y-%m-%dT%H:%M:%S') if isinstance(
-            completed_date, datetime
-        ) else None
-        LOGGER.info(generate_formatted_log(
-            self.enterprise_configuration.channel_code(),
-            enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-            enterprise_enrollment.enterprise_customer_user.user_id,
-            enterprise_enrollment.course_id,
-            '[Degreed2Client] - Attempting get_learner_data_records:'
-            f'percent_grade={percent_grade}, degreed_completed_timestamp={degreed_completed_timestamp}'
-            f'completed_date={completed_date}, course_completed={course_completed}'
-        ))
-        if enterprise_enrollment.enterprise_customer_user.get_remote_id(
-            self.enterprise_configuration.idp_id
-        ) is not None:
+        try:
+            percent_grade = kwargs.get('grade_percent') * 100 if kwargs.get('grade_percent') else None
+            # Degreed expects completion dates of the form 'yyyy-mm-ddTHH:MM:SS'.
+            degreed_completed_timestamp = completed_date.strftime('%Y-%m-%dT%H:%M:%S') if isinstance(
+                completed_date, datetime
+            ) else None
             LOGGER.info(generate_formatted_log(
                 self.enterprise_configuration.channel_code(),
                 enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                 enterprise_enrollment.enterprise_customer_user.user_id,
                 enterprise_enrollment.course_id,
-                '[Degreed2Client] - Found remote id:'
+                '[Degreed2Client] - Attempting get_learner_data_records:'
                 f'percent_grade={percent_grade}, degreed_completed_timestamp={degreed_completed_timestamp}'
                 f'completed_date={completed_date}, course_completed={course_completed}'
-                f'course_id={get_course_id_for_enrollment(enterprise_enrollment)}'
             ))
-            Degreed2LearnerDataTransmissionAudit = apps.get_model(
-                'degreed2',
-                'Degreed2LearnerDataTransmissionAudit'
-            )
-            # We return two records here, one with the course key and one with the course run id, to account for
-            # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
-            return [
-                Degreed2LearnerDataTransmissionAudit(
-                    enterprise_course_enrollment_id=enterprise_enrollment.id,
-                    degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=get_course_id_for_enrollment(enterprise_enrollment),
-                    completed_timestamp=completed_date,
-                    degreed_completed_timestamp=degreed_completed_timestamp,
-                    course_completed=course_completed,
-                    grade=percent_grade,
-                    enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-                    plugin_configuration_id=self.enterprise_configuration.id,
-                ),
-                Degreed2LearnerDataTransmissionAudit(
-                    enterprise_course_enrollment_id=enterprise_enrollment.id,
-                    degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=enterprise_enrollment.course_id,
-                    completed_timestamp=completed_date,
-                    degreed_completed_timestamp=degreed_completed_timestamp,
-                    course_completed=course_completed,
-                    grade=percent_grade,
-                    enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-                    plugin_configuration_id=self.enterprise_configuration.id,
+            if enterprise_enrollment.enterprise_customer_user.get_remote_id(
+                self.enterprise_configuration.idp_id
+            ) is not None:
+                LOGGER.info(generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
+                    enterprise_enrollment.enterprise_customer_user.user_id,
+                    enterprise_enrollment.course_id,
+                    '[Degreed2Client] - Found remote id:'
+                    f'percent_grade={percent_grade}, degreed_completed_timestamp={degreed_completed_timestamp}'
+                    f'completed_date={completed_date}, course_completed={course_completed}'
+                    f'course_id={get_course_id_for_enrollment(enterprise_enrollment)}'
+                ))
+                Degreed2LearnerDataTransmissionAudit = apps.get_model(
+                    'degreed2',
+                    'Degreed2LearnerDataTransmissionAudit'
                 )
-            ]
-        LOGGER.info(generate_formatted_log(
-            self.enterprise_configuration.channel_code(),
-            enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-            enterprise_enrollment.enterprise_customer_user.user_id,
-            enterprise_enrollment.course_id,
-            ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
-             'Degreed2 User ID not found for [{name}]'.format(
-                 name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-             ))))
-        return None
+                # We return two records here, one with the course key and one with the course run id, to account for
+                # uncertainty about the type of content (course vs. course run) that was sent to the integrated channel.
+                return [
+                    Degreed2LearnerDataTransmissionAudit(
+                        enterprise_course_enrollment_id=enterprise_enrollment.id,
+                        degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                        user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                        course_id=get_course_id_for_enrollment(enterprise_enrollment),
+                        completed_timestamp=completed_date,
+                        degreed_completed_timestamp=degreed_completed_timestamp,
+                        course_completed=course_completed,
+                        grade=percent_grade,
+                        enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
+                        plugin_configuration_id=self.enterprise_configuration.id,
+                    ),
+                    Degreed2LearnerDataTransmissionAudit(
+                        enterprise_course_enrollment_id=enterprise_enrollment.id,
+                        degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                        user_email=enterprise_enrollment.enterprise_customer_user.user_email,
+                        course_id=enterprise_enrollment.course_id,
+                        completed_timestamp=completed_date,
+                        degreed_completed_timestamp=degreed_completed_timestamp,
+                        course_completed=course_completed,
+                        grade=percent_grade,
+                        enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
+                        plugin_configuration_id=self.enterprise_configuration.id,
+                    )
+                ]
+            LOGGER.info(generate_formatted_log(
+                self.enterprise_configuration.channel_code(),
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
+                enterprise_enrollment.enterprise_customer_user.user_id,
+                enterprise_enrollment.course_id,
+                ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
+                'Degreed2 User ID not found for [{name}]'.format(
+                    name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
+                ))))
+            return None
+        except Exception as e:
+            LOGGER.error(generate_formatted_log(
+                self.enterprise_configuration.channel_code(),
+                enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
+                enterprise_enrollment.enterprise_customer_user.user_id,
+                enterprise_enrollment.course_id,
+                'Degreed2 get_learner_data_records failed, possibly due to an invalid customer configuration. '
+                f'Error: {e}'
+            ))


### PR DESCRIPTION
Context: https://2u-internal.atlassian.net/browse/ENT-7725?focusedCommentId=741115

TLDR: An exception was being thrown due to invalid customer configuration which took us days to trace in Splunk. So, adding a try catch block in this PR with a log including customer and LMS user id for enhanced debugging.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
