### PR TITLE
[ENT-7715] fix: filter the response only after a successful response status

### DIFF
--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -227,7 +227,9 @@ class ContentMetadataTransmitter(Transmitter):
                     )
                     transmission.api_response_status_code = response_status_code
                     was_successful = response_status_code < 300
-                    api_content_response = self._filter_api_response(response_body, content_id)
+                    api_content_response = response_body
+                    if was_successful:
+                        api_content_response = self._filter_api_response(api_content_response, content_id)
                     if transmission.api_record:
                         transmission.api_record.body = api_content_response
                         transmission.api_record.status_code = response_status_code

--- a/integrated_channels/sap_success_factors/transmitters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/transmitters/content_metadata.py
@@ -6,6 +6,7 @@ import logging
 
 from integrated_channels.integrated_channel.transmitters.content_metadata import ContentMetadataTransmitter
 from integrated_channels.sap_success_factors.client import SAPSuccessFactorsAPIClient
+from integrated_channels.utils import log_exception
 
 LOGGER = logging.getLogger(__name__)
 
@@ -36,7 +37,10 @@ class SapSuccessFactorsContentMetadataTransmitter(ContentMetadataTransmitter):
             filtered_response = json.dumps(parsed_response)
             return filtered_response
         except Exception as exc:  # pylint: disable=broad-except
-            LOGGER.exception("Error filtering response from SAPSF for Course: %s, %s", content_id, exc)
+            log_exception(
+                self.enterprise_configuration,
+                f'Error filtering API response: {exc}'
+            )
             return response
 
     def transmit(self, create_payload, update_payload, delete_payload):

--- a/integrated_channels/sap_success_factors/transmitters/content_metadata.py
+++ b/integrated_channels/sap_success_factors/transmitters/content_metadata.py
@@ -39,7 +39,9 @@ class SapSuccessFactorsContentMetadataTransmitter(ContentMetadataTransmitter):
         except Exception as exc:  # pylint: disable=broad-except
             log_exception(
                 self.enterprise_configuration,
-                f'Error filtering API response: {exc}'
+                f'Failed to filter the API response: '
+                f'{exc}',
+                content_id
             )
             return response
 

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -316,6 +316,18 @@ def generate_formatted_log(
         f'integrated_channel_plugin_configuration_id={plugin_configuration_id}, {message}'
 
 
+def log_exception(enterprise_configuration, msg, course_or_course_run_key=None):
+    LOGGER.exception(
+        generate_formatted_log(
+            channel_name=enterprise_configuration.channel_code(),
+            enterprise_customer_uuid=enterprise_configuration.enterprise_customer.uuid,
+            course_or_course_run_key=course_or_course_run_key,
+            plugin_configuration_id=enterprise_configuration.id,
+            message=msg
+        )
+    )
+
+
 def refresh_session_if_expired(
     oauth_access_token_function,
     session=None,

--- a/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_content_metadata.py
+++ b/tests/test_integrated_channels/test_sap_success_factors/test_transmitters/test_content_metadata.py
@@ -328,7 +328,7 @@ class TestSapSuccessFactorsContentMetadataTransmitter(unittest.TestCase):
                 integrated_channel_code=self.enterprise_config.channel_code(),
             ).count() == 2
 
-    @mock.patch('integrated_channels.sap_success_factors.transmitters.content_metadata.LOGGER')
+    @mock.patch('integrated_channels.utils.LOGGER')
     def test_filter_api_response_successful(self, logger_mock):
         """
         Test that the api response is successfully filtered
@@ -343,7 +343,7 @@ class TestSapSuccessFactorsContentMetadataTransmitter(unittest.TestCase):
         assert json.loads(filtered_response) == {"ocnCourses": [{"courseID": "course:DemoX"}]}
         assert logger_mock.exception.call_count == 0
 
-    @mock.patch('integrated_channels.sap_success_factors.transmitters.content_metadata.LOGGER')
+    @mock.patch('integrated_channels.utils.LOGGER')
     def test_filter_api_response_exception(self, logger_mock):
         """
         Test that the api response is not filtered if an exception occurs


### PR DESCRIPTION
JIRA Ticket: [ENT-7715](https://2u-internal.atlassian.net/browse/ENT-7715)

Description: 
To reduce unnecessary logs, filter the API response only when a successful response is received from the SAP instance.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
