### PR TITLE
[ENT-7716] feat: Truncate API Response before writing to DB

### DIFF
--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -219,3 +219,6 @@ class FulfillmentTypes:
 
 
 SSO_BRAZE_CAMPAIGN_ID = 'a5f10d46-8093-4ce1-bab7-6df018d03660'
+
+# The maximum length of a text field in the database.
+MAX_ALLOWED_TEXT_LENGTH = 16_000_000

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -42,6 +42,7 @@ from enterprise.constants import (
     PATHWAY_CUSTOMER_ADMIN_ENROLLMENT,
     PROGRAM_TYPE_DESCRIPTION,
     CourseModes,
+    MAX_ALLOWED_TEXT_LENGTH,
 )
 from enterprise.logging import getEnterpriseLogger
 
@@ -2365,3 +2366,13 @@ def camelCase(string):
     """
     output = ''.join(x for x in string.title() if x.isalnum())
     return output[0].lower() + output[1:]
+
+
+def truncate_string(string, max_length=MAX_ALLOWED_TEXT_LENGTH):
+    """
+    Truncate a string to the specified max length.
+    If max length is not specified, it will be set to MAX_ALLOWED_TEXT_LENGTH.
+    """
+    if len(string) > max_length:
+        return string[:max_length]
+    return string

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -39,10 +39,10 @@ from enterprise.constants import (
     DEFAULT_CATALOG_CONTENT_FILTER,
     LMS_API_DATETIME_FORMAT,
     LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE,
+    MAX_ALLOWED_TEXT_LENGTH,
     PATHWAY_CUSTOMER_ADMIN_ENROLLMENT,
     PROGRAM_TYPE_DESCRIPTION,
     CourseModes,
-    MAX_ALLOWED_TEXT_LENGTH,
 )
 from enterprise.logging import getEnterpriseLogger
 
@@ -2372,7 +2372,13 @@ def truncate_string(string, max_length=MAX_ALLOWED_TEXT_LENGTH):
     """
     Truncate a string to the specified max length.
     If max length is not specified, it will be set to MAX_ALLOWED_TEXT_LENGTH.
+
+    Returns:
+        (tuple): (truncated_string, was_truncated)
     """
+    was_truncated = False
     if len(string) > max_length:
-        return string[:max_length]
-    return string
+        truncated_string = string[:max_length]
+        was_truncated = True
+        return (truncated_string, was_truncated)
+    return (string, was_truncated)

--- a/integrated_channels/integrated_channel/transmitters/content_metadata.py
+++ b/integrated_channels/integrated_channel/transmitters/content_metadata.py
@@ -12,7 +12,7 @@ import requests
 from django.apps import apps
 from django.conf import settings
 
-from enterprise.utils import localized_utcnow
+from enterprise.utils import localized_utcnow, truncate_string
 from integrated_channels.exceptions import ClientError
 from integrated_channels.integrated_channel.client import IntegratedChannelApiClient
 from integrated_channels.integrated_channel.transmitters import Transmitter
@@ -228,6 +228,13 @@ class ContentMetadataTransmitter(Transmitter):
                     transmission.api_response_status_code = response_status_code
                     was_successful = response_status_code < 300
                     api_content_response = self._filter_api_response(response_body, content_id)
+                    (api_content_response, was_truncated) = truncate_string(api_content_response)
+                    if was_truncated:
+                        self._log_info(
+                            f'integrated_channel_content_transmission_id={transmission.id}, '
+                            f'api response truncated',
+                            course_or_course_run_key=content_id
+                        )
                     if transmission.api_record:
                         transmission.api_record.body = api_content_response
                         transmission.api_record.status_code = response_status_code

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -22,7 +22,9 @@ from enterprise.utils import (
     localized_utcnow,
     parse_lms_api_datetime,
     serialize_notification_content,
+    truncate_string,
 )
+from enterprise.constants import MAX_ALLOWED_TEXT_LENGTH
 from test_utils import FAKE_UUIDS, TEST_PASSWORD, TEST_USERNAME, factories
 
 LMS_BASE_URL = 'https://lms.base.url'
@@ -516,3 +518,15 @@ class TestUtils(unittest.TestCase):
         expiration_date = get_default_invite_key_expiration_date()
         expected_expiration_date = current_time + timedelta(days=365)
         self.assertEqual(expiration_date.date(), expected_expiration_date.date())
+
+    def test_truncate_string(self):
+        """
+        Test that `truncate_string` returns the expected string.
+        """
+        test_string_1 = 'This is a test string'
+        self.assertEqual('This is a ', truncate_string(test_string_1, 10))
+        self.assertEqual('This is a test string', truncate_string(test_string_1, 100))
+
+        test_string_2 = ''.rjust(MAX_ALLOWED_TEXT_LENGTH + 10, 'x')
+        truncated_string = truncate_string(test_string_2)
+        self.assertEqual(len(truncated_string), MAX_ALLOWED_TEXT_LENGTH)

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -12,6 +12,7 @@ from pytest import mark
 from django.conf import settings
 from django.forms.models import model_to_dict
 
+from enterprise.constants import MAX_ALLOWED_TEXT_LENGTH
 from enterprise.models import EnterpriseCourseEnrollment, LicensedEnterpriseCourseEnrollment
 from enterprise.utils import (
     enroll_subsidy_users_in_courses,
@@ -24,7 +25,6 @@ from enterprise.utils import (
     serialize_notification_content,
     truncate_string,
 )
-from enterprise.constants import MAX_ALLOWED_TEXT_LENGTH
 from test_utils import FAKE_UUIDS, TEST_PASSWORD, TEST_USERNAME, factories
 
 LMS_BASE_URL = 'https://lms.base.url'
@@ -524,9 +524,15 @@ class TestUtils(unittest.TestCase):
         Test that `truncate_string` returns the expected string.
         """
         test_string_1 = 'This is a test string'
-        self.assertEqual('This is a ', truncate_string(test_string_1, 10))
-        self.assertEqual('This is a test string', truncate_string(test_string_1, 100))
+        (truncated_string_1, was_truncated_1) = truncate_string(test_string_1, 10)
+        self.assertTrue(was_truncated_1)
+        self.assertEqual('This is a ', truncated_string_1)
+
+        (truncated_string_2, was_truncated_2) = truncate_string(test_string_1, 100)
+        self.assertFalse(was_truncated_2)
+        self.assertEqual('This is a test string', truncated_string_2)
 
         test_string_2 = ''.rjust(MAX_ALLOWED_TEXT_LENGTH + 10, 'x')
-        truncated_string = truncate_string(test_string_2)
+        (truncated_string, was_truncated) = truncate_string(test_string_2)
+        self.assertTrue(was_truncated)
         self.assertEqual(len(truncated_string), MAX_ALLOWED_TEXT_LENGTH)


### PR DESCRIPTION
JIRA Ticket: [ENT-7716](https://2u-internal.atlassian.net/browse/ENT-7716)

Description:
To prevent errors of maxing out packet sizes for the field of APIResponseRecord.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
