### PR TITLE
feat: Add an api-docs page that lives at `[LMS_ROOT_URL]/enterprise/api-docs/`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,12 @@ Change Log
 
 Unreleased
 ----------
+Nothing unreleased.
+
+[4.7.0]
+--------
+feat: Add an ``api-docs`` page that lives at ``[LMS_ROOT_URL]/enterprise/api-docs/``
+
 [4.6.12]
 --------
 feat: unlink degreed2 inactive user

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.6.12"
+__version__ = "4.7.0"

--- a/enterprise/urls.py
+++ b/enterprise/urls.py
@@ -2,8 +2,10 @@
 URLs for enterprise.
 """
 
+from edx_api_doc_tools import make_api_info, make_docs_urls
+
 from django.conf import settings
-from django.urls import include, re_path
+from django.urls import include, path, re_path
 
 from enterprise.constants import COURSE_KEY_URL_PATTERN
 from enterprise.heartbeat.views import heartbeat
@@ -16,6 +18,12 @@ from enterprise.views import (
 )
 
 ENTERPRISE_ROUTER = RouterView.as_view()
+
+enterprise_rest_api_urls = re_path(
+    r'^enterprise/api/',
+    include('enterprise.api.urls'),
+    name='enterprise_api'
+)
 
 urlpatterns = [
     re_path(r'^enterprise/grant_data_sharing_permissions', GrantDataSharingPermissions.as_view(),
@@ -53,14 +61,10 @@ urlpatterns = [
         name='enterprise_program_enrollment_page'
     ),
     re_path(
-        r'^enterprise/api/',
-        include('enterprise.api.urls'),
-        name='enterprise_api'
-    ),
-    re_path(
         r'^enterprise/heartbeat/', heartbeat,
         name='enterprise_heartbeat',
     ),
+    enterprise_rest_api_urls,
 ]
 
 # Because ROOT_URLCONF points here, we are including the urls from the other apps here for now.
@@ -95,3 +99,16 @@ urlpatterns += [
         include('integrated_channels.api.urls')
     ),
 ]
+
+api_docs_urlpatterns = make_docs_urls(
+    make_api_info(
+        title='Enterprise API',
+        version='v1',
+        description='Docs for the edx-enterprise `/enterprise/api/v1` REST API.',
+    ),
+    api_url_patterns=[enterprise_rest_api_urls],
+)
+
+urlpatterns.append(
+    path('enterprise/', include(api_docs_urlpatterns)),
+)

--- a/requirements/celery53.txt
+++ b/requirements/celery53.txt
@@ -1,9 +1,9 @@
-amqp==5.1.1
-billiard==4.1.0
+amqp==5.2.0
+billiard==4.2.0
 celery==5.3.4
 click==8.1.7
 click-didyoumean==0.3.0
 click-repl==0.3.0
-kombu==5.3.2
+kombu==5.3.3
 prompt-toolkit==3.0.39
-vine==5.0.0
+vine==5.1.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -24,7 +24,7 @@ alabaster==0.7.13
     # via
     #   -r requirements/doc.txt
     #   sphinx
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -77,14 +77,13 @@ backports-zoneinfo[tzdata]==0.2.1
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-    #   backports-zoneinfo
     #   celery
     #   kombu
 beautifulsoup4==4.12.2
     # via
     #   -r requirements/doc.txt
     #   pydata-sphinx-theme
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -171,10 +170,22 @@ code-annotations==1.5.0
     #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
+coreapi==2.3.3
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
+coreschema==0.0.4
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   coreapi
+    #   drf-yasg
 coverage[toml]==7.3.2
     # via
     #   -r requirements/test.txt
-    #   coverage
     #   pytest-cov
 cryptography==38.0.4
     # via
@@ -223,6 +234,8 @@ django==3.2.22
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-i18n-tools
@@ -309,6 +322,8 @@ djangorestframework==3.14.0
     #   -r requirements/test.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
@@ -331,6 +346,17 @@ drf-jwt==1.19.2
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.7.0
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-braze-client==0.1.8
     # via
     #   -r requirements/doc.txt
@@ -361,7 +387,6 @@ edx-opaque-keys[django]==2.5.1
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
     #   edx-drf-extensions
-    #   edx-opaque-keys
 edx-rbac==1.8.0
     # via
     #   -r requirements/doc.txt
@@ -387,7 +412,7 @@ factory-boy==3.3.0
     #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
-faker==19.12.1
+faker==19.13.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
@@ -428,6 +453,12 @@ importlib-metadata==6.8.0
     #   -r requirements/doc.txt
     #   build
     #   sphinx
+inflection==0.5.1
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via
     #   -r requirements/doc.txt
@@ -437,12 +468,19 @@ isort==5.12.0
     # via
     #   -r requirements/dev.in
     #   pylint
+itypes==1.2.0
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
     #   code-annotations
+    #   coreschema
     #   diff-cover
     #   sphinx
 jsondiff==2.0.0
@@ -461,7 +499,7 @@ jwcrypto==1.5.0
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
     #   django-oauth-toolkit
-kombu==5.3.2
+kombu==5.3.3
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -521,6 +559,7 @@ packaging==23.2
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
     #   build
+    #   drf-yasg
     #   pydata-sphinx-theme
     #   pytest
     #   snowflake-connector-python
@@ -637,7 +676,6 @@ pyjwt[crypto]==2.8.0
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwt
     #   snowflake-connector-python
 pylint==3.0.2
     # via
@@ -706,6 +744,7 @@ pytz==2022.7.1
     #   babel
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.1
@@ -722,6 +761,7 @@ requests==2.31.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
+    #   coreapi
     #   django-oauth-toolkit
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -742,6 +782,18 @@ restructuredtext-lint==1.4.0
     # via
     #   -r requirements/doc.txt
     #   doc8
+ruamel-yaml==0.17.35
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.8
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -r requirements/doc.txt
@@ -913,6 +965,13 @@ unicodecsv==0.14.1
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
+uritemplate==4.1.1
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.17
     # via
     #   -r requirements/doc.txt
@@ -920,7 +979,7 @@ urllib3==1.26.17
     #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -16,7 +16,7 @@ aiosignal==1.3.1
     #   aiohttp
 alabaster==0.7.13
     # via sphinx
-amqp==5.1.1
+amqp==5.2.0
     # via
     #   -r requirements/test-master.txt
     #   kombu
@@ -50,12 +50,11 @@ babel==2.13.1
 backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/test-master.txt
-    #   backports-zoneinfo
     #   celery
     #   kombu
 beautifulsoup4==4.12.2
     # via pydata-sphinx-theme
-billiard==4.1.0
+billiard==4.2.0
     # via
     #   -r requirements/test-master.txt
     #   celery
@@ -107,6 +106,15 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test-master.txt
     #   edx-toggles
+coreapi==2.3.3
+    # via
+    #   -r requirements/test-master.txt
+    #   drf-yasg
+coreschema==0.0.4
+    # via
+    #   -r requirements/test-master.txt
+    #   coreapi
+    #   drf-yasg
 cryptography==38.0.4
     # via
     #   -r requirements/test-master.txt
@@ -138,6 +146,8 @@ django==3.2.22
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
@@ -186,6 +196,8 @@ djangorestframework==3.14.0
     #   -r requirements/test-master.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/test-master.txt
@@ -203,6 +215,12 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test-master.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via
+    #   -r requirements/test-master.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.7.0
+    # via -r requirements/test-master.txt
 edx-braze-client==0.1.8
     # via -r requirements/test-master.txt
 edx-django-utils==5.7.0
@@ -220,7 +238,6 @@ edx-opaque-keys[django]==2.5.1
     # via
     #   -r requirements/test-master.txt
     #   edx-drf-extensions
-    #   edx-opaque-keys
 edx-rbac==1.8.0
     # via -r requirements/test-master.txt
 edx-rest-api-client==5.6.0
@@ -233,7 +250,7 @@ factory-boy==3.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-faker==19.12.1
+faker==19.13.0
     # via factory-boy
 filelock==3.12.4
     # via
@@ -254,12 +271,21 @@ imagesize==1.4.1
     # via sphinx
 importlib-metadata==6.8.0
     # via sphinx
+inflection==0.5.1
+    # via
+    #   -r requirements/test-master.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via pytest
+itypes==1.2.0
+    # via
+    #   -r requirements/test-master.txt
+    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/test-master.txt
     #   code-annotations
+    #   coreschema
     #   sphinx
 jsondiff==2.0.0
     # via -r requirements/test-master.txt
@@ -269,7 +295,7 @@ jwcrypto==1.5.0
     # via
     #   -r requirements/test-master.txt
     #   django-oauth-toolkit
-kombu==5.3.2
+kombu==5.3.3
     # via
     #   -r requirements/test-master.txt
     #   celery
@@ -301,6 +327,7 @@ oscrypto==1.3.0
 packaging==23.2
     # via
     #   -r requirements/test-master.txt
+    #   drf-yasg
     #   pydata-sphinx-theme
     #   pytest
     #   snowflake-connector-python
@@ -362,7 +389,6 @@ pyjwt[crypto]==2.8.0
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwt
     #   snowflake-connector-python
 pymongo==3.13.0
     # via
@@ -395,6 +421,7 @@ pytz==2022.7.1
     #   babel
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.1
@@ -406,6 +433,7 @@ readme-renderer==42.0
 requests==2.31.0
     # via
     #   -r requirements/test-master.txt
+    #   coreapi
     #   django-oauth-toolkit
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -415,6 +443,14 @@ requests==2.31.0
     #   sphinx
 restructuredtext-lint==1.4.0
     # via doc8
+ruamel-yaml==0.17.35
+    # via
+    #   -r requirements/test-master.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.8
+    # via
+    #   -r requirements/test-master.txt
+    #   ruamel-yaml
 rules==3.3
     # via -r requirements/test-master.txt
 semantic-version==2.10.0
@@ -506,12 +542,17 @@ tzdata==2023.3
     #   celery
 unicodecsv==0.14.1
     # via -r requirements/test-master.txt
+uritemplate==4.1.1
+    # via
+    #   -r requirements/test-master.txt
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.17
     # via
     #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
-vine==5.0.0
+vine==5.1.0
     # via
     #   -r requirements/test-master.txt
     #   amqp

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -470,7 +470,7 @@ edx-drf-extensions==8.12.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.6.9
+edx-enterprise==4.6.12
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -759,7 +759,7 @@ openedx-django-require==2.1.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==2.0.3
     # via -r requirements/edx/kernel.in
-openedx-events==9.0.0
+openedx-events==9.0.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-event-bus-kafka
@@ -768,7 +768,7 @@ openedx-filters==1.6.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
-openedx-learning==0.3.0
+openedx-learning==0.3.2
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -776,7 +776,7 @@ openedx-mongodbproxy==0.2.0
     # via -r requirements/edx/kernel.in
 optimizely-sdk==4.1.1
     # via -r requirements/edx/bundled.in
-ora2==5.5.5
+ora2==6.0.0
     # via -r requirements/edx/bundled.in
 oscrypto==1.3.0
     # via snowflake-connector-python

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -28,7 +28,7 @@ h11==0.14.0
     # via wsproto
 idna==3.4
     # via trio
-importlib-resources==6.1.0
+importlib-resources==6.1.1
     # via jaraco-text
 inflect==7.0.0
     # via jaraco-text
@@ -40,7 +40,7 @@ jaraco-collections==4.3.0
     #   cherrypy
 jaraco-context==4.3.0
     # via jaraco-text
-jaraco-functools==3.9.0
+jaraco-functools==4.0.0
     # via
     #   -r requirements/js_test.in
     #   cheroot
@@ -79,7 +79,7 @@ pytz==2023.3.post1
     # via tempora
 pyyaml==6.0.1
     # via jasmine
-selenium==4.14.0
+selenium==4.15.2
     # via jasmine
 sniffio==1.3.0
     # via trio
@@ -89,7 +89,7 @@ tempora==5.5.0
     # via
     #   -r requirements/js_test.in
     #   portend
-trio==0.22.2
+trio==0.23.1
     # via
     #   selenium
     #   trio-websocket
@@ -99,13 +99,10 @@ typing-extensions==4.8.0
     # via
     #   annotated-types
     #   inflect
-    #   jaraco-functools
     #   pydantic
     #   pydantic-core
 urllib3[socks]==2.0.7
-    # via
-    #   selenium
-    #   urllib3
+    # via selenium
 wsproto==1.2.0
     # via trio-websocket
 zc-lockfile==3.0.post1

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -5,3 +5,5 @@
 -c edx-platform-constraints.txt
 -c constraints.txt
 -r base.in
+
+edx-api-doc-tools  # for installing an api-docs page for enterprise

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -12,7 +12,7 @@ aiosignal==1.3.1
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
-amqp==5.1.1
+amqp==5.2.0
     # via kombu
 aniso8601==9.0.1
     # via
@@ -41,7 +41,7 @@ backports-zoneinfo[tzdata]==0.2.1
     #   -c requirements/edx-platform-constraints.txt
     #   celery
     #   kombu
-billiard==4.1.0
+billiard==4.2.0
     # via celery
 bleach==6.1.0
     # via
@@ -89,6 +89,15 @@ code-annotations==1.5.0
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
     #   edx-toggles
+coreapi==2.3.3
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   drf-yasg
+coreschema==0.0.4
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   coreapi
+    #   drf-yasg
 cryptography==38.0.4
     # via
     #   -c requirements/edx-platform-constraints.txt
@@ -122,6 +131,8 @@ django==3.2.22
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
@@ -192,6 +203,8 @@ djangorestframework==3.14.0
     #   -r requirements/base.in
     #   django-config-models
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
@@ -201,6 +214,14 @@ drf-jwt==1.19.2
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.7.0
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/test-master.in
 edx-braze-client==0.1.8
     # via
     #   -c requirements/edx-platform-constraints.txt
@@ -254,10 +275,19 @@ idna==3.4
     #   requests
     #   snowflake-connector-python
     #   yarl
+inflection==0.5.1
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   drf-yasg
+itypes==1.2.0
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   coreapi
 jinja2==3.1.2
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
+    #   coreschema
 jsondiff==2.0.0
     # via
     #   -c requirements/edx-platform-constraints.txt
@@ -270,7 +300,7 @@ jwcrypto==1.5.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   django-oauth-toolkit
-kombu==5.3.2
+kombu==5.3.3
     # via celery
 markupsafe==2.1.3
     # via
@@ -300,6 +330,7 @@ oscrypto==1.3.0
 packaging==23.2
     # via
     #   -c requirements/edx-platform-constraints.txt
+    #   drf-yasg
     #   snowflake-connector-python
 path==16.7.1
     # via
@@ -349,7 +380,6 @@ pyjwt[crypto]==2.8.0
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwt
     #   snowflake-connector-python
 pymongo==3.13.0
     # via
@@ -378,6 +408,7 @@ pytz==2022.7.1
     #   -r requirements/base.in
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.1
@@ -388,12 +419,21 @@ requests==2.31.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
+    #   coreapi
     #   django-oauth-toolkit
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openai
     #   slumber
     #   snowflake-connector-python
+ruamel-yaml==0.17.35
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.8
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   ruamel-yaml
 rules==3.3
     # via
     #   -c requirements/edx-platform-constraints.txt
@@ -465,12 +505,17 @@ unicodecsv==0.14.1
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
+uritemplate==4.1.1
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.17
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   requests
     #   snowflake-connector-python
-vine==5.0.0
+vine==5.1.0
     # via
     #   amqp
     #   celery

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -42,7 +42,6 @@ backports-zoneinfo[tzdata]==0.2.1
     # via
     #   -r requirements/test-master.txt
     #   -r requirements/test.in
-    #   backports-zoneinfo
     #   celery
     #   kombu
     # via
@@ -94,10 +93,17 @@ code-annotations==1.5.0
     # via
     #   -r requirements/test-master.txt
     #   edx-toggles
-coverage[toml]==7.3.2
+coreapi==2.3.3
     # via
-    #   coverage
-    #   pytest-cov
+    #   -r requirements/test-master.txt
+    #   drf-yasg
+coreschema==0.0.4
+    # via
+    #   -r requirements/test-master.txt
+    #   coreapi
+    #   drf-yasg
+coverage[toml]==7.3.2
+    # via pytest-cov
 cryptography==38.0.4
     # via
     #   -r requirements/test-master.txt
@@ -132,6 +138,8 @@ diff-cover==8.0.0
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
@@ -181,6 +189,8 @@ djangorestframework==3.14.0
     #   -r requirements/test-master.txt
     #   django-config-models
     #   drf-jwt
+    #   drf-yasg
+    #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via -r requirements/test-master.txt
@@ -188,6 +198,12 @@ drf-jwt==1.19.2
     # via
     #   -r requirements/test-master.txt
     #   edx-drf-extensions
+drf-yasg==1.21.5
+    # via
+    #   -r requirements/test-master.txt
+    #   edx-api-doc-tools
+edx-api-doc-tools==1.7.0
+    # via -r requirements/test-master.txt
 edx-braze-client==0.1.8
     # via -r requirements/test-master.txt
 edx-django-utils==5.7.0
@@ -205,7 +221,6 @@ edx-opaque-keys[django]==2.5.1
     # via
     #   -r requirements/test-master.txt
     #   edx-drf-extensions
-    #   edx-opaque-keys
 edx-rbac==1.8.0
     # via -r requirements/test-master.txt
 edx-rest-api-client==5.6.0
@@ -218,7 +233,7 @@ factory-boy==3.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-faker==19.12.1
+faker==19.13.0
     # via factory-boy
 filelock==3.12.4
     # via
@@ -239,12 +254,21 @@ idna==3.4
     #   requests
     #   snowflake-connector-python
     #   yarl
+inflection==0.5.1
+    # via
+    #   -r requirements/test-master.txt
+    #   drf-yasg
 iniconfig==2.0.0
     # via pytest
+itypes==1.2.0
+    # via
+    #   -r requirements/test-master.txt
+    #   coreapi
 jinja2==3.1.2
     # via
     #   -r requirements/test-master.txt
     #   code-annotations
+    #   coreschema
     #   diff-cover
 jsondiff==2.0.0
     # via -r requirements/test-master.txt
@@ -287,6 +311,7 @@ oscrypto==1.3.0
 packaging==23.2
     # via
     #   -r requirements/test-master.txt
+    #   drf-yasg
     #   pytest
     #   snowflake-connector-python
 path==16.7.1
@@ -340,7 +365,6 @@ pyjwt[crypto]==2.8.0
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
-    #   pyjwt
     #   snowflake-connector-python
 pymongo==3.13.0
     # via
@@ -378,6 +402,7 @@ pytz==2022.7.1
     #   -r requirements/test-master.txt
     #   django
     #   djangorestframework
+    #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.1
@@ -387,6 +412,7 @@ pyyaml==6.0.1
 requests==2.31.0
     # via
     #   -r requirements/test-master.txt
+    #   coreapi
     #   django-oauth-toolkit
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -398,6 +424,14 @@ responses==0.10.15
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
+ruamel-yaml==0.17.35
+    # via
+    #   -r requirements/test-master.txt
+    #   drf-yasg
+ruamel-yaml-clib==0.2.8
+    # via
+    #   -r requirements/test-master.txt
+    #   ruamel-yaml
 rules==3.3
     # via -r requirements/test-master.txt
 semantic-version==2.10.0
@@ -469,6 +503,11 @@ tzdata==2023.3
     #   celery
 unicodecsv==0.14.1
     # via -r requirements/test-master.txt
+uritemplate==4.1.1
+    # via
+    #   -r requirements/test-master.txt
+    #   coreapi
+    #   drf-yasg
 urllib3==1.26.17
     # via
     #   -r requirements/test-master.txt


### PR DESCRIPTION
We somehow haven't had api-docs available for edx-enterprise for a while.  This adds them such that they exist at http://localhost:18000/enterprise/api-docs/

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
