### PR TITLE
[ENT-7925] feat: stop learner data transmissions for course runs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 Nothing unreleased.
 
+[4.7.2]
+--------
+feat: stop learner data transmissions for course runs
+
 [4.7.1]
 --------
 chore: retire Degreed v1 code from the set of channels

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.7.1"
+__version__ = "4.7.2"

--- a/integrated_channels/degreed/exporters/learner_data.py
+++ b/integrated_channels/degreed/exporters/learner_data.py
@@ -54,17 +54,6 @@ class DegreedLearnerExporter(LearnerExporter):
                     enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id,
                 ),
-                DegreedLearnerDataTransmissionAudit(
-                    enterprise_course_enrollment_id=enterprise_enrollment.id,
-                    degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=enterprise_enrollment.course_id,
-                    course_completed=course_completed,
-                    completed_timestamp=completed_date,
-                    degreed_completed_timestamp=degreed_completed_timestamp,
-                    enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-                    plugin_configuration_id=self.enterprise_configuration.id,
-                )
             ]
         LOGGER.info(generate_formatted_log(
             self.enterprise_configuration.channel_code(),

--- a/integrated_channels/degreed2/exporters/learner_data.py
+++ b/integrated_channels/degreed2/exporters/learner_data.py
@@ -81,18 +81,6 @@ class Degreed2LearnerExporter(LearnerExporter):
                     enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id,
                 ),
-                Degreed2LearnerDataTransmissionAudit(
-                    enterprise_course_enrollment_id=enterprise_enrollment.id,
-                    degreed_user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=enterprise_enrollment.course_id,
-                    completed_timestamp=completed_date,
-                    degreed_completed_timestamp=degreed_completed_timestamp,
-                    course_completed=course_completed,
-                    grade=percent_grade,
-                    enterprise_customer_uuid=enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-                    plugin_configuration_id=self.enterprise_configuration.id,
-                )
             ]
         LOGGER.info(generate_formatted_log(
             self.enterprise_configuration.channel_code(),

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -627,18 +627,6 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 content_title=content_title,
                 progress_status=progress_status,
             ),
-            TransmissionAudit(
-                plugin_configuration_id=self.enterprise_configuration.id,
-                enterprise_customer_uuid=self.enterprise_configuration.enterprise_customer.uuid,
-                enterprise_course_enrollment_id=enterprise_enrollment.id,
-                course_id=enterprise_enrollment.course_id,
-                course_completed=course_completed,
-                completed_timestamp=completed_timestamp,
-                grade=grade,
-                user_email=user_email,
-                content_title=content_title,
-                progress_status=progress_status,
-            )
         ]
 
     def collect_certificate_data(self, enterprise_enrollment, channel_name):

--- a/integrated_channels/moodle/exporters/learner_data.py
+++ b/integrated_channels/moodle/exporters/learner_data.py
@@ -68,16 +68,4 @@ class MoodleLearnerExporter(LearnerExporter):
                 enterprise_customer_uuid=enterprise_customer_user.enterprise_customer.uuid,
                 plugin_configuration_id=self.enterprise_configuration.id,
             ),
-            MoodleLearnerDataTransmissionAudit(
-                enterprise_course_enrollment_id=enterprise_enrollment.id,
-                moodle_user_email=enterprise_customer_user.user_email,
-                user_email=enterprise_customer_user.user_email,
-                course_id=enterprise_enrollment.course_id,
-                course_completed=course_completed,
-                grade=percent_grade,
-                completed_timestamp=completed_date,
-                moodle_completed_timestamp=moodle_completed_timestamp,
-                enterprise_customer_uuid=enterprise_customer_user.enterprise_customer.uuid,
-                plugin_configuration_id=self.enterprise_configuration.id,
-            )
         ]

--- a/integrated_channels/sap_success_factors/exporters/learner_data.py
+++ b/integrated_channels/sap_success_factors/exporters/learner_data.py
@@ -73,20 +73,6 @@ class SapSuccessFactorsLearnerExporter(LearnerExporter):
                     enterprise_customer_uuid=self.enterprise_configuration.enterprise_customer.uuid,
                     plugin_configuration_id=self.enterprise_configuration.id
                 ),
-                SapSuccessFactorsLearnerDataTransmissionAudit(
-                    enterprise_course_enrollment_id=enterprise_enrollment.id,
-                    sapsf_user_id=sapsf_user_id,
-                    user_email=enterprise_enrollment.enterprise_customer_user.user_email,
-                    course_id=enterprise_enrollment.course_id,
-                    course_completed=course_completed,
-                    completed_timestamp=completed_date,
-                    sap_completed_timestamp=sap_completed_timestamp,
-                    grade=grade,
-                    total_hours=total_hours,
-                    credit_hours=total_hours,
-                    enterprise_customer_uuid=self.enterprise_configuration.enterprise_customer.uuid,
-                    plugin_configuration_id=self.enterprise_configuration.id
-                ),
             ]
         LOGGER.info(
             generate_formatted_log(

--- a/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_degreed/test_exporters/test_learner_data.py
@@ -81,9 +81,8 @@ class TestDegreedLearnerExporter(unittest.TestCase):
             completed_date=completed_date,
             course_completed=course_completed,
         )
-        assert len(learner_data_records) == 2
+        assert len(learner_data_records) == 1
         assert learner_data_records[0].course_id == self.course_key
-        assert learner_data_records[1].course_id == self.course_id
 
         for learner_data_record in learner_data_records:
             assert learner_data_record.enterprise_course_enrollment_id == enterprise_course_enrollment.id

--- a/tests/test_integrated_channels/test_degreed2/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_degreed2/test_exporters/test_learner_data.py
@@ -80,9 +80,8 @@ class TestDegreed2LearnerExporter(unittest.TestCase):
             completed_date=completed_date,
             grade_percent=grade_percent,
         )
-        assert len(learner_data_records) == 2
+        assert len(learner_data_records) == 1
         assert learner_data_records[0].course_id == self.course_key
-        assert learner_data_records[1].course_id == self.course_id
 
         for learner_data_record in learner_data_records:
             assert learner_data_record.enterprise_course_enrollment_id == enterprise_course_enrollment.id

--- a/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_integrated_channel/test_exporters/test_learner_data.py
@@ -124,9 +124,9 @@ class TestLearnerExporter(unittest.TestCase):
             course_completed=expected_course_completed,
         )
 
-        learner_data_record = learner_data_records[1]
+        learner_data_record = learner_data_records[0]
         assert learner_data_record.enterprise_course_enrollment_id == enterprise_course_enrollment.id
-        assert learner_data_record.course_id == enterprise_course_enrollment.course_id
+        assert learner_data_record.course_id == self.course_key
         assert learner_data_record.course_completed == expected_course_completed
         assert learner_data_record.completed_timestamp == (self.NOW_TIMESTAMP if completed_date is not None else None)
         assert learner_data_record.grade == 'A+'
@@ -247,16 +247,14 @@ class TestLearnerExporter(unittest.TestCase):
         }
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 2
+        assert len(learner_data) == 1
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
 
-        for report in learner_data:
-            assert report.user_email == self.user.email
-            assert report.enterprise_course_enrollment_id == enrollment.id
-            assert not report.course_completed
-            assert report.completed_timestamp is None
-            assert report.grade == LearnerExporter.GRADE_INCOMPLETE
+        assert learner_data[0].user_email == self.user.email
+        assert learner_data[0].enterprise_course_enrollment_id == enrollment.id
+        assert not learner_data[0].course_completed
+        assert learner_data[0].completed_timestamp is None
+        assert learner_data[0].grade == LearnerExporter.GRADE_INCOMPLETE
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_single_user_grade')
@@ -359,17 +357,14 @@ class TestLearnerExporter(unittest.TestCase):
         }
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 2
+        assert len(learner_data) == 1
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
-
-        for report in learner_data:
-            assert report.enterprise_course_enrollment_id == enrollment.id
-            assert report.course_completed
-            assert report.completed_timestamp == self.NOW_TIMESTAMP
-            assert report.grade == LearnerExporter.GRADE_PASSING
-            assert report.progress_status == 'Passed'
-            assert report.content_title == 'Dogs and Cats: Star Crossed Lovers or Fated Foes'
+        assert learner_data[0].enterprise_course_enrollment_id == enrollment.id
+        assert learner_data[0].course_completed
+        assert learner_data[0].completed_timestamp == self.NOW_TIMESTAMP
+        assert learner_data[0].grade == LearnerExporter.GRADE_PASSING
+        assert learner_data[0].progress_status == 'Passed'
+        assert learner_data[0].content_title == 'Dogs and Cats: Star Crossed Lovers or Fated Foes'
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_details')
@@ -423,15 +418,12 @@ class TestLearnerExporter(unittest.TestCase):
         }
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 2
+        assert len(learner_data) == 1
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
-
-        for report in learner_data:
-            assert report.enterprise_course_enrollment_id == enrollment.id
-            assert report.course_completed
-            assert report.completed_timestamp == self.NOW_TIMESTAMP
-            assert report.grade == LearnerExporter.GRADE_PASSING
+        assert learner_data[0].enterprise_course_enrollment_id == enrollment.id
+        assert learner_data[0].course_completed
+        assert learner_data[0].completed_timestamp == self.NOW_TIMESTAMP
+        assert learner_data[0].grade == LearnerExporter.GRADE_PASSING
 
     @mock.patch('enterprise.models.EnrollmentApiClient')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')
@@ -468,9 +460,8 @@ class TestLearnerExporter(unittest.TestCase):
         }
 
         learner_data = list(self.exporter.export())
-        assert len(learner_data) == 2
+        assert len(learner_data) == 1
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
 
         for report in learner_data:
             assert report.enterprise_course_enrollment_id == enrollment.id
@@ -556,9 +547,8 @@ class TestLearnerExporter(unittest.TestCase):
         with freeze_time(self.NOW):
             learner_data = list(self.exporter.export())
 
-        assert len(learner_data) == 2
+        assert len(learner_data) == 1
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
 
         for report in learner_data:
             assert report.enterprise_course_enrollment_id == enrollment.id
@@ -647,9 +637,8 @@ class TestLearnerExporter(unittest.TestCase):
         with freeze_time(self.NOW):
             learner_data = list(self.exporter.export())
 
-        assert len(learner_data) == 2
+        assert len(learner_data) == 1
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
 
         for report in learner_data:
             assert report.enterprise_course_enrollment_id == enrollment.id
@@ -866,41 +855,36 @@ class TestLearnerExporter(unittest.TestCase):
         with freeze_time(self.NOW):
             learner_data = list(self.exporter.export())
 
-        assert len(learner_data) == 6
+        assert len(learner_data) == 3
 
         assert learner_data[0].course_id == self.course_key
-        assert learner_data[1].course_id == self.course_id
         # note: the course_completed is a function of the mock_is_course_completed mock
-        for report1 in learner_data[0:1]:
-            assert report1.enterprise_course_enrollment_id == enrollment1.id
-            assert report1.course_completed
-            assert report1.completed_timestamp is None
-            assert report1.grade == LearnerExporter.GRADE_INCOMPLETE
+        assert learner_data[0].enterprise_course_enrollment_id == enrollment1.id
+        assert learner_data[0].course_completed
+        assert learner_data[0].completed_timestamp is None
+        assert learner_data[0].grade == LearnerExporter.GRADE_INCOMPLETE
+
+        assert learner_data[1].course_id == self.course_key
+        assert learner_data[1].enterprise_course_enrollment_id == enrollment2.id
+        assert learner_data[1].course_completed
+        assert learner_data[1].completed_timestamp == self.NOW_TIMESTAMP
+        assert learner_data[1].grade == grade
 
         assert learner_data[2].course_id == self.course_key
-        assert learner_data[3].course_id == course_id2
-        for report2 in learner_data[2:3]:
-            assert report2.enterprise_course_enrollment_id == enrollment2.id
-            assert report2.course_completed
-            assert report2.completed_timestamp == self.NOW_TIMESTAMP
-            assert report2.grade == grade
-        assert learner_data[4].course_id == self.course_key
-        assert learner_data[5].course_id == self.course_id
-        for report3 in learner_data[4:5]:
-            assert report3.enterprise_course_enrollment_id == enrollment3.id
-            assert report3.course_completed
-            assert report3.completed_timestamp is None
-            assert report3.grade == LearnerExporter.GRADE_INCOMPLETE
+        assert learner_data[2].enterprise_course_enrollment_id == enrollment3.id
+        assert learner_data[2].course_completed
+        assert learner_data[2].completed_timestamp is None
+        assert learner_data[2].grade == LearnerExporter.GRADE_INCOMPLETE
 
     @ddt.data(
-        (True, True, 'audit', 2),
+        (True, True, 'audit', 1),
         (True, False, 'audit', 0),
         (False, True, 'audit', 0),
         (False, False, 'audit', 0),
-        (True, True, 'verified', 2),
-        (True, False, 'verified', 2),
-        (False, True, 'verified', 2),
-        (False, False, 'verified', 2),
+        (True, True, 'verified', 1),
+        (True, False, 'verified', 1),
+        (False, True, 'verified', 1),
+        (False, False, 'verified', 1),
     )
     @ddt.unpack
     @mock.patch('enterprise.models.CourseEnrollment')
@@ -968,13 +952,11 @@ class TestLearnerExporter(unittest.TestCase):
 
         assert len(learner_data) == expected_data_len
 
-        if expected_data_len == 2:
+        if expected_data_len == 1:
             assert learner_data[0].course_id == self.course_key
-            assert learner_data[1].course_id == self.course_id
-            for report in learner_data:
-                assert report.enterprise_course_enrollment_id == enrollment.id
-                assert report.course_completed
-                assert report.grade == LearnerExporter.GRADE_PASSING
+            assert learner_data[0].enterprise_course_enrollment_id == enrollment.id
+            assert learner_data[0].course_completed
+            assert learner_data[0].grade == LearnerExporter.GRADE_PASSING
 
     @mock.patch('enterprise.models.CourseEnrollment')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_single_user_grade')


### PR DESCRIPTION
JIRA Ticket: [ENT-7925](https://2u-internal.atlassian.net/browse/ENT-7925)

Description:
Stop sending course run metadata on integrated channels

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
