### PR TITLE
feat: add modified to output of catalog list endpoint

### DIFF
--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -446,7 +446,7 @@ class EnterpriseCustomerCatalogSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseCustomerCatalog
         fields = (
-            'uuid', 'title', 'enterprise_customer', 'enterprise_catalog_query',
+            'uuid', 'title', 'enterprise_customer', 'enterprise_catalog_query', 'created', 'modified',
         )
 
 

--- a/enterprise/api/v1/views/enterprise_customer_catalog.py
+++ b/enterprise/api/v1/views/enterprise_customer_catalog.py
@@ -122,7 +122,7 @@ class EnterpriseCustomerCatalogViewSet(EnterpriseReadOnlyModelViewSet):
 
     USER_ID_FILTER = 'enterprise_customer__enterprise_customer_users__user_id'
     FIELDS = (
-        'uuid', 'title', 'enterprise_customer', 'enterprise_catalog_query',
+        'uuid', 'title', 'enterprise_customer', 'enterprise_catalog_query', 'created', 'modified',
     )
     filterset_fields = FIELDS
     ordering_fields = FIELDS

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2054,55 +2054,60 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
 
         response = self.client.get(ENTERPRISE_CATALOGS_LIST_ENDPOINT)
         response = self.load_json(response.content)
+        # Assert they exist, but don't test `created` and `modified` response keys because their values are
+        # non-deterministic.
+        if response['results']:
+            del response['results'][0]['created']
+            del response['results'][0]['modified']
 
         assert response == expected_results
 
     @ddt.data(
-        (
-            False,
-            False,
-            {'detail': 'Not found.'},
-        ),
-        (
-            False,
-            True,
-            fake_enterprise_api.build_fake_enterprise_catalog_detail(
+        {
+            'is_staff': False,
+            'is_linked_to_enterprise': False,
+            'expected_result': {'detail': 'Not found.'},
+        },
+        {
+            'is_staff': False,
+            'is_linked_to_enterprise': True,
+            'expected_result': fake_enterprise_api.build_fake_enterprise_catalog_detail(
                 paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS,
                 include_enterprise_context=True,
                 add_utm_info=False,
                 count=3,
             ),
-        ),
-        (
-            True,
-            False,
-            fake_enterprise_api.build_fake_enterprise_catalog_detail(
+        },
+        {
+            'is_staff': True,
+            'is_linked_to_enterprise': False,
+            'expected_result': fake_enterprise_api.build_fake_enterprise_catalog_detail(
                 paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS,
                 include_enterprise_context=True,
                 add_utm_info=False,
                 count=3,
             ),
-        ),
-        (
-            True,
-            True,
-            fake_enterprise_api.build_fake_enterprise_catalog_detail(
+        },
+        {
+            'is_staff': True,
+            'is_linked_to_enterprise': True,
+            'expected_result': fake_enterprise_api.build_fake_enterprise_catalog_detail(
                 paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS,
                 include_enterprise_context=True,
                 add_utm_info=False,
                 count=3,
             ),
-        ),
+        },
     )
     @ddt.unpack
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     @mock.patch("enterprise.utils.update_query_parameters", mock.MagicMock(side_effect=side_effect))
     def test_enterprise_customer_catalogs_detail(
             self,
+            mock_catalog_api_client,
             is_staff,
             is_linked_to_enterprise,
             expected_result,
-            mock_catalog_api_client,
     ):
         """
         Make sure the Enterprise Customer's Catalog view correctly returns details about specific catalogs based on
@@ -2137,6 +2142,12 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
         )
         response = self.client.get(ENTERPRISE_CATALOGS_DETAIL_ENDPOINT)
         response = self.load_json(response.content)
+        # Assert they exist, but don't test `created` and `modified` response keys because their values are
+        # non-deterministic.
+        if is_staff or is_linked_to_enterprise:
+            del response['created']
+            del response['modified']
+
         self.assertDictEqual(response, expected_result)
 
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
@@ -2167,6 +2178,10 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
 
         response = self.client.get(ENTERPRISE_CATALOGS_DETAIL_ENDPOINT + '?page=2')
         response = self.load_json(response.content)
+        # Assert they exist, but don't test `created` and `modified` response keys because their values are
+        # non-deterministic.
+        del response['created']
+        del response['modified']
 
         expected_result = fake_enterprise_api.build_fake_enterprise_catalog_detail(
             paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS_2,
@@ -2205,6 +2220,10 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
         )
         response = self.client.get(ENTERPRISE_CATALOGS_DETAIL_ENDPOINT + '?page=2')
         response = self.load_json(response.content)
+        # Assert they exist, but don't test `created` and `modified` response keys because their values are
+        # non-deterministic.
+        del response['created']
+        del response['modified']
 
         expected_result = fake_enterprise_api.build_fake_enterprise_catalog_detail(
             paginated_content=fake_catalog_api.FAKE_SEARCH_ALL_RESULTS_3,


### PR DESCRIPTION
This is needed to support sorting of catalog options during provisioning and editing of Learner Credit Plans.

ENT-7922

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
