### PR TITLE
fix: fixed the domain issue to point to "courses.edx.org" for the resumeCourseRunUrl

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.8.4]
+--------
+fix: changed relative resumeCourseRunUrl to an absolute URL
+
 [4.8.3]
 --------
 refactor: adding log for learner data transmission

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.8.3"
+__version__ = "4.8.4"

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -78,7 +78,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
         representation['is_revoked'] = instance.license.is_revoked if instance.license else False
         representation['is_enrollment_active'] = instance.is_active
         representation['mode'] = instance.mode
-        representation['resume_course_run_url'] = self.context['course_enrollments_resume_urls'].get(course_run_id)
+        representation['resume_course_run_url'] = self._get_resume_course_run_url(course_run_id, request)
 
         if CourseDetails:
             course_details = CourseDetails.objects.filter(id=course_run_id).first()
@@ -122,3 +122,12 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
                 course_run_url = '{}?{}'.format(exec_ed_base_url, urlencode(params))
 
         return course_run_url
+
+    def _get_resume_course_run_url(self, course_run_id, request):
+        """
+        Converts a relative resume course run URL to an absolute URL.
+        """
+        resume_course_run_url = self.context['course_enrollments_resume_urls'].get(course_run_id)
+        if resume_course_run_url:
+            return request.build_absolute_uri(resume_course_run_url)
+        return None

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -53,6 +53,7 @@ class EnterpriseCourseEnrollmentView(APIView):
                 "org_name": "edX",
                 "is_revoked": false,
                 "is_enrollment_active": true
+                "resume_course_run_url": "http://localhost:18000/courses/course-v1:MITx+6.86x+2T2024"
             }
         ]
 

--- a/tests/test_enterprise_learner_portal/api/test_serializers.py
+++ b/tests/test_enterprise_learner_portal/api/test_serializers.py
@@ -4,12 +4,14 @@ Tests for the EnterpriseCourseEnrollmentview of the enterprise_learner_portal ap
 
 from collections import OrderedDict
 from unittest import mock
+from unittest.mock import patch
 from urllib.parse import urlencode
 
 import ddt
 from pytest import mark
 
 from django.conf import settings
+from django.http import HttpRequest
 from django.test import RequestFactory, TestCase
 
 from enterprise.utils import NotConnectedToOpenEdX
@@ -36,6 +38,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
         (settings.EXEC_ED_LANDING_PAGE, True),
     )
     @ddt.unpack
+    @patch.object(HttpRequest, 'get_host', return_value='courses.edx.org')
     @mock.patch('enterprise.models.CourseEnrollment')
     @mock.patch('enterprise_learner_portal.api.v1.serializers.get_course_run_status')
     @mock.patch('enterprise_learner_portal.api.v1.serializers.get_emails_enabled')
@@ -50,6 +53,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             mock_get_emails_enabled,
             mock_get_course_run_status,
             mock_course_enrollment_class,
+            _,
     ):
         """
         EnterpriseCourseEnrollmentSerializer should create proper representation
@@ -65,7 +69,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             'display_org_with_default': 'my university',
         }]
         course_enrollments_resume_urls = {
-            course_run_id: "http://example.com/resume_url",
+            course_run_id: '/courses/course-v1:MITx+6.86x+2T2024'
         }
 
         mock_get_cert.return_value = {
@@ -90,7 +94,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
         mock_course_enrollment_class.objects.get.return_value.is_active = True
         mock_course_enrollment_class.objects.get.return_value.mode = 'verified'
 
-        request = self.factory.get('/')
+        request = HttpRequest()
         request.user = self.user
 
         serializer = EnterpriseCourseEnrollmentSerializer(
@@ -119,7 +123,7 @@ class TestEnterpriseCourseEnrollmentSerializer(TestCase):
             ('is_revoked', False),
             ('is_enrollment_active', True),
             ('mode', 'verified'),
-            ('resume_course_run_url', 'http://example.com/resume_url'),
+            ('resume_course_run_url', 'http://courses.edx.org/courses/course-v1:MITx+6.86x+2T2024'),
         ])
         actual = serializer.data[0]
         self.assertDictEqual(actual, expected)

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -80,7 +80,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
         mock_serializer.return_value = self.MockSerializer()
         mock_course_resume_urls.return_value = {
-            'course-v1:edX+DemoX+Demo_Course': 'http://example.com/resume_url'
+            'course-v1:edX+DemoX+Demo_Course': '/courses/course-v1:MITx+6.86x+2T2024'
         }
 
         resp = self.client.get(
@@ -114,7 +114,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
         mock_serializer.return_value = self.MockSerializer()
         mock_course_resume_urls.return_value = {
-            'course-v1:edX+DemoX+Demo_Course': 'http://example.com/resume_url'
+            'course-v1:edX+DemoX+Demo_Course': '/courses/course-v1:MITx+6.86x+2T2024'
         }
 
         resp = self.client.get(
@@ -147,7 +147,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
         mock_serializer.return_value = self.MockSerializer()
         mock_course_resume_urls.return_value = {
-            'course-v1:edX+DemoX+Demo_Course': 'http://example.com/resume_url'
+            'course-v1:edX+DemoX+Demo_Course': '/courses/course-v1:MITx+6.86x+2T2024'
         }
 
         resp = self.client.get(
@@ -174,7 +174,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
         mock_get_overviews.return_value = {'overview_info': 'this would be a larger dict'}
         mock_serializer.return_value = self.MockSerializer()
         mock_course_resume_urls.return_value = {
-            'course-v1:edX+DemoX+Demo_Course': 'http://example.com/resume_url'
+            'course-v1:edX+DemoX+Demo_Course': '/courses/course-v1:MITx+6.86x+2T2024'
         }
 
         resp = self.client.get(


### PR DESCRIPTION
**Jira Ticket**: https://2u-internal.atlassian.net/browse/ENT-8069
**Description**: Fixed the domain issue to point to [courses.edx.org](http://courses.edx.org/) for the `resumeCourseRunUrl`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
