### PR TITLE
[ENT-7950] - Post skills metadata for Degreed2 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[4.8.14]
+--------
+
+feat: Modified existing content transmission job to post skills metadata to Degreed2
+
 [4.8.13]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.8.13"
+__version__ = "4.8.14"

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -318,7 +318,7 @@ class EnterpriseCatalogApiClient(UserAPIClient):
     @UserAPIClient.refresh_token
     def get_content_metadata_content_identifier(self, enterprise_uuid, content_id):  # pylint: disable=inconsistent-return-statements
         """
-        Return all content metadata contained in the catalogs associated with the the
+        Return all content metadata contained in the catalogs associated with the
         given EnterpriseCustomer and content_id.
         """
         try:
@@ -341,6 +341,7 @@ class EnterpriseCatalogApiClient(UserAPIClient):
                 "Exception raised in EnterpriseCatalogApiClient::get_content_metadata_content_identifier: [%s]",
                 str(exc),
             )
+            return {}
 
 
 class NoAuthEnterpriseCatalogClient(NoAuthAPIClient):

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -28,9 +28,9 @@ class EnterpriseCatalogApiClient(UserAPIClient):
     REFRESH_CATALOG_ENDPOINT = ENTERPRISE_CATALOG_ENDPOINT + '/{}/refresh_metadata'
     CATALOG_DIFF_ENDPOINT = ENTERPRISE_CATALOG_ENDPOINT + '/{}/generate_diff'
     ENTERPRISE_CUSTOMER_ENDPOINT = 'enterprise-customer'
-    CONTENT_METADATA_IDENTIFIER_ENDPOINT = (
-        ENTERPRISE_CUSTOMER_ENDPOINT + "/{}/content-metadata/" + "{}"
-    )
+    CONTENT_METADATA_IDENTIFIER_ENDPOINT = ENTERPRISE_CUSTOMER_ENDPOINT + \
+        "/{}/content-metadata/" + "{}"
+    
     APPEND_SLASH = True
     GET_CONTENT_METADATA_PAGE_SIZE = getattr(settings, 'ENTERPRISE_CATALOG_GET_CONTENT_METADATA_PAGE_SIZE', 50)
 

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -8,6 +8,7 @@ from logging import getLogger
 from urllib.parse import urljoin
 
 from requests.exceptions import ConnectionError, RequestException, Timeout  # pylint: disable=redefined-builtin
+from rest_framework.exceptions import NotFound
 
 from django.conf import settings
 
@@ -30,7 +31,6 @@ class EnterpriseCatalogApiClient(UserAPIClient):
     ENTERPRISE_CUSTOMER_ENDPOINT = 'enterprise-customer'
     CONTENT_METADATA_IDENTIFIER_ENDPOINT = ENTERPRISE_CUSTOMER_ENDPOINT + \
         "/{}/content-metadata/" + "{}"
-    
     APPEND_SLASH = True
     GET_CONTENT_METADATA_PAGE_SIZE = getattr(settings, 'ENTERPRISE_CATALOG_GET_CONTENT_METADATA_PAGE_SIZE', 50)
 
@@ -316,16 +316,31 @@ class EnterpriseCatalogApiClient(UserAPIClient):
         return response.json()['contains_content_items']
 
     @UserAPIClient.refresh_token
-    def get_content_metadata_content_identifier(self, enterprise_uuid, content_id):
+    def get_content_metadata_content_identifier(self, enterprise_uuid, content_id):  # pylint: disable=inconsistent-return-statements
         """
         Return all content metadata contained in the catalogs associated with the the
         given EnterpriseCustomer and content_id.
         """
-        api_url = self.get_api_url(
-            f"{self.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(enterprise_uuid, content_id)}")
-        response = self.client.get(api_url)
-        response.raise_for_status()
-        return response.json()
+        try:
+            api_url = self.get_api_url(
+                f"{self.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(enterprise_uuid, content_id)}"
+            )
+            response = self.client.get(api_url)
+            response.raise_for_status()
+            return response.json()
+        except NotFound as exc:
+            LOGGER.exception(
+                "No matching content found in catalog for customer: [%s] or content_id: [%s], Error: %s",
+                enterprise_uuid,
+                content_id,
+                str(exc),
+            )
+            return {}
+        except (RequestException, ConnectionError, Timeout) as exc:
+            LOGGER.exception(
+                "Exception raised in EnterpriseCatalogApiClient::get_content_metadata_content_identifier: [%s]",
+                str(exc),
+            )
 
 
 class NoAuthEnterpriseCatalogClient(NoAuthAPIClient):

--- a/enterprise/api_client/enterprise_catalog.py
+++ b/enterprise/api_client/enterprise_catalog.py
@@ -28,6 +28,8 @@ class EnterpriseCatalogApiClient(UserAPIClient):
     REFRESH_CATALOG_ENDPOINT = ENTERPRISE_CATALOG_ENDPOINT + '/{}/refresh_metadata'
     CATALOG_DIFF_ENDPOINT = ENTERPRISE_CATALOG_ENDPOINT + '/{}/generate_diff'
     ENTERPRISE_CUSTOMER_ENDPOINT = 'enterprise-customer'
+    CONTENT_METADATA_IDENTIFIER_ENDPOINT = ENTERPRISE_CUSTOMER_ENDPOINT + \
+        '/{}/content-metadata/'+'{}'
     APPEND_SLASH = True
     GET_CONTENT_METADATA_PAGE_SIZE = getattr(settings, 'ENTERPRISE_CATALOG_GET_CONTENT_METADATA_PAGE_SIZE', 50)
 
@@ -311,6 +313,18 @@ class EnterpriseCatalogApiClient(UserAPIClient):
         response = self.client.get(api_url, params=query_params)
         response.raise_for_status()
         return response.json()['contains_content_items']
+    
+    @UserAPIClient.refresh_token
+    def get_content_metadata_content_identifier(self, enterprise_uuid, content_id):
+        """
+        Return all content metadata contained in the catalogs associated with the the
+        given EnterpriseCustomer and content_id.
+        """
+        api_url = self.get_api_url(
+            f"{self.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(enterprise_uuid, content_id)}")
+        response = self.client.get(api_url)
+        response.raise_for_status()
+        return response.json()
 
 
 class NoAuthEnterpriseCatalogClient(NoAuthAPIClient):

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -296,8 +296,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         # 2. Transmit to degreed
         skills = metadata['skill_names']
         if skills:
-            course_id = a_course.get("external-id")
-            self.assign_course_skills(course_id, skills)
+            self.assign_course_skills(external_id, skills)
             LOGGER.info(
                 generate_formatted_log(
                     self.enterprise_configuration.channel_code(),
@@ -305,7 +304,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
                     None,
                     None,
                     f'[Degreed2Client] transmitted skills: {metadata["skill_names"]},'
-                    f'for course: {course_id}'
+                    f'for course: {external_id}'
                 )
             )
         return status_code, response_body


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
