### PR TITLE
Removed course completion check from is_already_transmitted utility

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[4.8.16]
+--------
+
+fix: removed course completion check from is_already_transmitted utility (ENT 7837)
+
 [4.8.15]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.8.15"
+__version__ = "4.8.16"

--- a/integrated_channels/moodle/client.py
+++ b/integrated_channels/moodle/client.py
@@ -74,14 +74,6 @@ def moodle_request_wrapper(method):
             # but we have nothing else to go on
             if body == 0:
                 if method.__name__ == "_wrapped_create_course_completion" and response.status_code == 200:
-                    LOGGER.info(
-                        'Integer Response for Moodle Course Completion'
-                        f'with data kwargs={kwargs} and args={args} '
-                        f' response: {response} '
-                        f'Status Code: {response.status_code}, '
-                        f'Text: {response.text}, '
-                        f'Headers: {response.headers}, '
-                    )
                     return MoodleResponse(status_code=200, text='')
                 return 200, ''
             raise ClientError('Moodle API Grade Update failed with int code: {code}'.format(code=body), 500)

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -218,7 +218,6 @@ def is_already_transmitted(
             plugin_configuration_id=enterprise_configuration_id,
             error_message='',
             status__lt=400,
-            course_completed=True
         )
         if subsection_id:
             already_transmitted = already_transmitted.filter(subsection_id=subsection_id)


### PR DESCRIPTION
Description:
Removed course completion check from is_already_transmitted utility is it does not seems to be the desired flow.

JIRA:
https://2u-internal.atlassian.net/jira/software/c/projects/ENT/issues/ENT-7837