### PR TITLE
ENT-8130: add logs to debug ENT-8130

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,11 @@ Change Log
 Unreleased
 ----------
 
+[4.8.18]
+--------
+
+feat: added logs to debug ENT-8130
+
 [4.8.17]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.8.17"
+__version__ = "4.8.18"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -397,6 +397,11 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         )
         enrollment_ids_to_export = [enrollment.id for enrollment in enrollments_permitted]
 
+        LOGGER.info(
+            f"[Debug-SAP]: course_run_id:{course_run_id}, channel_name: {channel_name}"
+            f"lms_user_for_filter:{lms_user_for_filter}, grade:{grade} "
+            f"enrollment_ids_to_export: {enrollment_ids_to_export}"
+        )
         for enterprise_enrollment in enrollments_permitted:
             lms_user_id = enterprise_enrollment.enterprise_customer_user.user_id
             user_email = enterprise_enrollment.enterprise_customer_user.user_email
@@ -439,6 +444,12 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             # Apply the Source of Truth for Grades
             # Note: Only completed records are transmitted by the completion transmitter
             #       therefore even non complete grading/cert records are exported here.
+            _is_course_completed = is_course_completed(
+                enterprise_enrollment,
+                is_passing_from_api,
+                incomplete_count,
+                passed_timestamp,
+            )
             records = self.get_learner_data_records(
                 enterprise_enrollment=enterprise_enrollment,
                 user_email=user_email,
@@ -446,15 +457,21 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 grade=grade_from_api,
                 content_title=course_details.display_name,
                 progress_status=progress_status,
-                course_completed=is_course_completed(
-                    enterprise_enrollment,
-                    is_passing_from_api,
-                    incomplete_count,
-                    passed_timestamp,
-                ),
+                course_completed=_is_course_completed,
                 grade_percent=grade_percent,
             )
-
+            LOGGER.info(
+                generate_formatted_log(
+                    channel_name,
+                    enterprise_customer_uuid,
+                    lms_user_id,
+                    course_id,
+                    f", [Debug-SAP]: _is_course_completed: {_is_course_completed}, progress_status:{progress_status}"
+                    f",completed_date_from_api: {completed_date_from_api}, grade_from_api:{grade_from_api}"
+                    f"is_passing_from_api: {is_passing_from_api}, grade_percent:{grade_percent}"
+                    f"passed_timestamp:{passed_timestamp}, records: {records}",
+                )
+            )
             if records:
                 # There are some cases where we won't receive a record from the above
                 # method; right now, that should only happen if we have an Enterprise-linked
@@ -474,7 +491,7 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
 
         LOGGER.info(generate_formatted_log(
             channel_name, None, lms_user_for_filter, course_run_id,
-            f'export finished. Did not export records for EnterpriseCourseEnrollment objects: '
+            f'[Debug-SAP]: export finished. Did not export records for EnterpriseCourseEnrollment objects: '
             f' {enrollment_ids_to_export}.'
         ))
 
@@ -529,15 +546,42 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             enterprise_customer_user__active=True,
         )
         if lms_user_for_filter and course_run_id:
+            LOGGER.info(
+                generate_formatted_log(
+                    channel_name,
+                    self.enterprise_customer.uuid,
+                    lms_user_for_filter,
+                    course_run_id,
+                    f"[Debug-SAP]: enrollments to process before filtering: {list(enrollment_queryset)}",
+                )
+            )
             enrollment_queryset = enrollment_queryset.filter(
                 course_id=course_run_id,
                 enterprise_customer_user__user_id=lms_user_for_filter.id,
+            )
+            LOGGER.info(
+                generate_formatted_log(
+                    channel_name,
+                    self.enterprise_customer.uuid,
+                    lms_user_for_filter,
+                    course_run_id,
+                    f"[Debug-SAP]: enrollments to process after filtering: {list(enrollment_queryset)}",
+                )
             )
             LOGGER.info(generate_formatted_log(
                 channel_name, self.enterprise_customer.uuid, lms_user_for_filter, course_run_id,
                 'get_enrollments_to_process run for single learner and course.'))
         enrollment_queryset = enrollment_queryset.order_by('course_id')
         # return resolved list instead of queryset
+        LOGGER.info(
+            generate_formatted_log(
+                channel_name,
+                self.enterprise_customer.uuid,
+                lms_user_for_filter,
+                course_run_id,
+                f"[Debug-SAP]: enrollments to process: {list(enrollment_queryset)}",
+            )
+        )
         return list(enrollment_queryset)
 
     def get_learner_assessment_data_records(


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
