### PR TITLE
fix: guard against null content_filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Change Log
 Unreleased
 ----------
 
+[4.10.8]
+--------
+
+fix: guard against null content_filters
+
+
 [4.10.7]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.10.7"
+__version__ = "4.10.8"

--- a/enterprise/management/commands/add_exec_ed_exclusion_to_catalogs.py
+++ b/enterprise/management/commands/add_exec_ed_exclusion_to_catalogs.py
@@ -57,9 +57,16 @@ class Command(BaseCommand):
                     f'updated query {catalog_query.id}'
                 )
 
-        for cusrtomer_catalog_batch in batch_by_pk(EnterpriseCustomerCatalog):
-            for customer_catalog in cusrtomer_catalog_batch:
+        for customer_catalog_batch in batch_by_pk(EnterpriseCustomerCatalog):
+            for customer_catalog in customer_catalog_batch:
                 logger.info(f'{customer_catalog.uuid}')
+
+                if customer_catalog.content_filter is None:
+                    logger.info(
+                        'add_exec_ed_exclusion_to_catalogs '
+                        f'catalog {customer_catalog.uuid} has no content_filter'
+                    )
+                    continue
 
                 if customer_catalog.content_filter.get('course_type__exclude'):
                     logger.info(


### PR DESCRIPTION
```
20:38:43 2024-01-23 20:39:12,091 INFO 11552 [enterprise.management.commands.add_exec_ed_exclusion_to_catalogs] [user None] [ip None] add_exec_ed_exclusion_to_catalogs.py:62 - 3973a547-72c4-4cda-bd20-2fb66425a760
20:38:43 Traceback (most recent call last):
20:38:43   File "/edx/app/edxapp/edx-platform/manage.py", line 106, in <module>
20:38:43     execute_from_command_line([sys.argv[0]] + django_args)
20:38:43   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
20:38:43     utility.execute()
20:38:43   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/__init__.py", line 413, in execute
20:38:43     self.fetch_command(subcommand).run_from_argv(self.argv)
20:38:43   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/base.py", line 354, in run_from_argv
20:38:43     self.execute(*args, **cmd_options)
20:38:43   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/django/core/management/base.py", line 398, in execute
20:38:43     output = self.handle(*args, **options)
20:38:43   File "/edx/app/edxapp/venvs/edxapp/lib/python3.8/site-packages/enterprise/management/commands/add_exec_ed_exclusion_to_catalogs.py", line 64, in handle
20:38:43     if customer_catalog.content_filter.get('course_type__exclude'):
20:38:43 AttributeError: 'NoneType' object has no attribute 'get'non-zero return code
```