### PR TITLE
feat: remove ability to edit catalog include_exec_ed_2u_courses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,12 @@ Change Log
 Unreleased
 ----------
 
+[4.10.10]
+---------
+
+feat: remove ability to edit catalog `include_exec_ed_2u_courses`
+
+
 [4.10.9]
 --------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.10.9"
+__version__ = "4.10.10"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -810,6 +810,13 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
     class Meta:
         model = models.EnterpriseCatalogQuery
 
+    fields = (
+        'uuid'
+        'title',
+        'discovery_query_url',
+        'content_filter',
+    )
+
     def get_urls(self):
         """
         Returns the additional urls used by the custom object tools.
@@ -826,7 +833,6 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
     list_display = (
         'title',
         'discovery_query_url',
-        'include_exec_ed_2u_courses',
     )
 
     @admin.display(


### PR DESCRIPTION
## Description
- https://2u-internal.atlassian.net/browse/ENT-7893
- this is in prep for removing of the field entirely
- removing it from the UI first, leaving it in the DB in case we need to rollback
- we will be removing this field from the indexing logic shortly