### PR TITLE
fix: add missing comma to catalog query fields list.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.10.11]
+---------
+* fix: add missing comma to catalog query fields list.
+
 [4.10.10]
 ---------
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.10.10"
+__version__ = "4.10.11"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -811,7 +811,7 @@ class EnterpriseCatalogQueryAdmin(admin.ModelAdmin):
         model = models.EnterpriseCatalogQuery
 
     fields = (
-        'uuid'
+        'uuid',
         'title',
         'discovery_query_url',
         'content_filter',


### PR DESCRIPTION
**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
