### PR TITLE
fix: Added logs and removed cornerstone from loop

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.11.5]
+---------
+* fix: Added logs and remove cornerstone from management command
+
 [4.11.4]
 ---------
 * feat: update blackboard client to store API calls in DB

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.11.4"
+__version__ = "4.11.5"

--- a/integrated_channels/integrated_channel/management/commands/remove_duplicate_learner_transmission_audit_records.py
+++ b/integrated_channels/integrated_channel/management/commands/remove_duplicate_learner_transmission_audit_records.py
@@ -32,8 +32,7 @@ class Command(BaseCommand):
         channel_learner_audit_models = [
             ('moodle', 'MoodleLearnerDataTransmissionAudit'),
             ('blackboard', 'BlackboardLearnerDataTransmissionAudit'),
-            ('cornerstone', 'CornerstoneLearnerDataTransmissionAudit'),
-            ('canvas', 'CanvasLearnerAssessmentDataTransmissionAudit'),
+            ('canvas', 'CanvasLearnerDataTransmissionAudit'),
             ('degreed2', 'Degreed2LearnerDataTransmissionAudit'),
             ('sap_success_factors', 'SapSuccessFactorsLearnerDataTransmissionAudit'),
         ]
@@ -62,6 +61,7 @@ class Command(BaseCommand):
                         .exclude(id=most_recent_transmission_id)
                     )
                     LOGGER.info(
-                        f'{app_label} channel - {duplicate_records_to_delete.count()} duplicate records are deleted'
+                        f'{app_label} channel - {duplicate_records_to_delete.count()} duplicate records are deleted '
+                        f' for enrollment id {enterprise_course_enrollment_id}'
                     )
                     duplicate_records_to_delete.delete()


### PR DESCRIPTION
`CornerstoneLearnerDataTransmissionAudit` table is removed from the management command since it already has constraints applied on user_id and course_id which will not allow any duplication of records.


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
