### PR TITLE
feat: adds waffle flag for prequery search

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.11.6]
+---------
+* feat: Added a flag for prequery search suggestions
+
 [4.11.5]
 ---------
 * fix: Added logs and remove cornerstone from management command

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.11.5"
+__version__ = "4.11.6"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -19,6 +19,11 @@ TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+FEATURE_PREQUERY_SEARCH_SUGGESTIONS = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.feature_prequery_search_suggestions',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
 
 def top_down_assignment_real_time_lcm():
     """
@@ -26,6 +31,11 @@ def top_down_assignment_real_time_lcm():
     """
     return TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM.is_enabled()
 
+def feature_prequery_search_suggestions():
+    """
+    Returns whether the prequery search suggestion feature flag is enabled.
+    """
+    return FEATURE_PREQUERY_SEARCH_SUGGESTIONS.is_enabled()
 
 def enterprise_features():
     """

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -19,11 +19,18 @@ TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.feature_prequery_search_suggestions
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables prequery search suggestions
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-01-31
 FEATURE_PREQUERY_SEARCH_SUGGESTIONS = WaffleFlag(
     f'{ENTERPRISE_NAMESPACE}.feature_prequery_search_suggestions',
     __name__,
     ENTERPRISE_LOG_PREFIX,
 )
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -31,11 +38,13 @@ def top_down_assignment_real_time_lcm():
     """
     return TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM.is_enabled()
 
+
 def feature_prequery_search_suggestions():
     """
     Returns whether the prequery search suggestion feature flag is enabled.
     """
     return FEATURE_PREQUERY_SEARCH_SUGGESTIONS.is_enabled()
+
 
 def enterprise_features():
     """
@@ -43,4 +52,5 @@ def enterprise_features():
     """
     return {
         'top_down_assignment_real_time_lcm': top_down_assignment_real_time_lcm(),
+        'feature_prequery_search_suggestions': feature_prequery_search_suggestions(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -300,7 +300,8 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                 'start': 0,
                 'results': [],
                 'enterprise_features': {
-                    'top_down_assignment_real_time_lcm': False
+                    'top_down_assignment_real_time_lcm': False,
+                    'feature_prequery_search_suggestions': False
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1610,7 +1610,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
             active=is_top_down_assignment_real_time_lcm_enabled
         ):
-            
+
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
@@ -1618,7 +1618,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
             active=feature_prequery_search_suggestions_enabled
         ):
-            
+
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -58,7 +58,7 @@ from enterprise.models import (
     PendingEnrollment,
     PendingEnterpriseCustomerUser,
 )
-from enterprise.toggles import TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM, FEATURE_PREQUERY_SEARCH_SUGGESTIONS
+from enterprise.toggles import FEATURE_PREQUERY_SEARCH_SUGGESTIONS, TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_sso_orchestrator_api_base_url,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -58,7 +58,7 @@ from enterprise.models import (
     PendingEnrollment,
     PendingEnterpriseCustomerUser,
 )
-from enterprise.toggles import TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM
+from enterprise.toggles import TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM, FEATURE_PREQUERY_SEARCH_SUGGESTIONS
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_sso_orchestrator_api_base_url,
@@ -1495,58 +1495,59 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
 
     @ddt.data(
         # Request missing required permissions query param.
-        (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'}, False),
+        (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'}, False, False),
         # Staff user that does not have the specified group permission.
         (True, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False),
         # Staff user that does have the specified group permission.
         (True, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False),
+         True, None, False, False),
         # Non staff user that is not linked to the enterprise, nor do they have the group permission.
         (False, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False),
         # Non staff user that is not linked to the enterprise, but does have the group permission.
         (False, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         False, None, False),
+         False, None, False, False),
         # Non staff user that is linked to the enterprise, but does not have the group permission.
         (False, True, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False),
         # Non staff user that is linked to the enterprise and does have the group permission
         (False, True, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False),
+         True, None, False, False),
         # Non staff user that is linked to the enterprise and has group permission and the request has passed
         # multiple groups to check.
         (False, True, ['enterprise_enrollment_api_access'],
-         {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None, False),
+         {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None, False, False),
         # Staff user with group permission filtering on non existent enterprise id.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[1]}, False,
-         None, False),
+         None, False, False),
         # Staff user with group permission filtering on enterprise id successfully.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[0]}, True,
-         None, False),
+         None, False, False),
         # Staff user with group permission filtering on search param with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'blah'}, False,
-         None, False),
+         None, False, False),
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True,
-         None, False),
+         None, False, False),
         # Staff user with group permission filtering on slug with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, False),
+         None, False, False),
         # Staff user with group permissions filtering on slug with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
-         None, False),
+         None, False, False),
         # Staff user with group permission filtering on slug with results, with
-        # top down assignment & real-time LCM feature enabled
+        # top down assignment & real-time LCM feature enabled and
+        # prequery search results enabled
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, True),
+         None, True, True),
     )
     @ddt.unpack
     @mock.patch('enterprise.utils.get_logo_url')
@@ -1559,6 +1560,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             has_access_to_enterprise,
             expected_error,
             is_top_down_assignment_real_time_lcm_enabled,
+            feature_prequery_search_suggestions_enabled,
             mock_get_logo_url,
     ):
         """
@@ -1608,6 +1610,15 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
             active=is_top_down_assignment_real_time_lcm_enabled
         ):
+            
+            response = client.get(
+                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
+            )
+        with override_waffle_flag(
+            FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
+            active=feature_prequery_search_suggestions_enabled
+        ):
+            
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
@@ -1670,6 +1681,8 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'results': [],
                 'enterprise_features': {
                     'top_down_assignment_real_time_lcm': is_top_down_assignment_real_time_lcm_enabled,
+                    'feature_prequery_search_suggestions': feature_prequery_search_suggestions_enabled,
+
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)


### PR DESCRIPTION
Adding waffle flag for prequery search suggestions in learner portal.
[Ticket](https://2u-internal.atlassian.net/browse/ENT-8337)

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
