### PR TITLE
feat: CRUD api endpoints for the enterprise group table

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.11.15]
+---------
+* feat: CRUD api endpoints for the enterprise group table 
+
 [4.11.14]
 ---------
 * feat: added channel_name for api call logs records

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.11.14"
+__version__ = "4.11.15"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -802,6 +802,15 @@ class CourseDetailSerializer(ImmutableStateSerializer):
         return updated_course
 
 
+class EnterpriseGroupSerializer(serializers.ModelSerializer):
+    """
+    Serializer for EnterpriseGroup model.
+    """
+    class Meta:
+        model = models.EnterpriseGroup
+        fields = ('enterprise_customer', 'name', 'uuid')
+
+
 class CourseRunDetailSerializer(ImmutableStateSerializer):
     """
     Serializer for course run data retrieved from the discovery service course_run detail API endpoint.

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -19,6 +19,7 @@ from enterprise.api.v1.views import (
     enterprise_customer_reporting,
     enterprise_customer_sso_configuration,
     enterprise_customer_user,
+    enterprise_group,
     enterprise_subsidy_fulfillment,
     notifications,
     pending_enterprise_customer_user,
@@ -70,6 +71,9 @@ router.register(
 )
 router.register(
     "enterprise_catalogs", enterprise_customer_catalog.EnterpriseCustomerCatalogViewSet, 'enterprise-catalogs'
+)
+router.register(
+    "enterprise_group", enterprise_group.EnterpriseGroupViewSet, 'enterprise-group'
 )
 
 

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -1,0 +1,49 @@
+"""
+Views for the ``enterprise-group`` API endpoint.
+"""
+
+from django_filters.rest_framework import DjangoFilterBackend
+from rest_framework import filters, permissions
+
+from django.db.models import Q
+
+from enterprise import models
+from enterprise.api.v1 import serializers
+from enterprise.api.v1.views.base_views import EnterpriseReadWriteModelViewSet
+
+
+class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
+    """
+    API views for the ``enterprise-group`` API endpoint.
+    """
+    queryset = models.EnterpriseGroup.objects.all()
+    permission_classes = (permissions.IsAuthenticated,)
+    filter_backends = (filters.OrderingFilter, DjangoFilterBackend,)
+    serializer_class = serializers.EnterpriseGroupSerializer
+
+    def get_queryset(self, **kwargs):
+        """
+        - Filter down the queryset of groups available to the requesting user.
+        - Account for requested filtering query params
+        """
+        queryset = self.queryset
+        if not self.request.user.is_staff:
+            enterprise_user_objects = models.EnterpriseCustomerUser.objects.filter(
+                user_id=self.request.user.id,
+                active=True,
+            )
+            associated_customers = []
+            for user_object in enterprise_user_objects:
+                associated_customers.append(user_object.enterprise_customer)
+            queryset = queryset.filter(enterprise_customer__in=associated_customers)
+
+        if self.request.method in ('GET',):
+            if learner_uuids := self.request.query_params.getlist('learner_uuids'):
+                # groups can apply to both existing and pending users
+                queryset = queryset.filter(
+                    Q(members__enterprise_customer_user__in=learner_uuids) |
+                    Q(members__pending_enterprise_customer_user__in=learner_uuids),
+                )
+            if enterprise_uuids := self.request.query_params.getlist('enterprise_uuids'):
+                queryset = queryset.filter(enterprise_customer__in=enterprise_uuids)
+        return queryset


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8413

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
