### PR TITLE
feat: adding assign_learners and remove_learners api endpoints for enterprise groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.12.4]
+---------
+* feat: adding assign_learners and remove_learners api endpoints for enterprise groups
+
 [4.12.3]
 ---------
 * feat: management command to clear out excessive records for API log table
@@ -34,7 +38,7 @@ Unreleased
 
 [4.11.15]
 ---------
-* feat: CRUD api endpoints for the enterprise group table 
+* feat: CRUD api endpoints for the enterprise group table
 
 [4.11.14]
 ---------
@@ -86,7 +90,7 @@ Unreleased
 
 [4.11.2]
 ---------
-* feat: added caching for fetching degreed course id 
+* feat: added caching for fetching degreed course id
 
 [4.11.1]
 ---------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.12.3"
+__version__ = "4.12.4"

--- a/enterprise/api/utils.py
+++ b/enterprise/api/utils.py
@@ -19,6 +19,7 @@ from enterprise.models import (
     EnterpriseCustomerUser,
     EnterpriseFeatureRole,
     EnterpriseFeatureUserRoleAssignment,
+    EnterpriseGroup,
 )
 
 User = auth.get_user_model()
@@ -36,6 +37,16 @@ def get_service_usernames():
         return set(settings.ENTERPRISE_ALL_SERVICE_USERNAMES)
 
     return {getattr(settings, username, None) for username in SERVICE_USERNAMES}
+
+
+def get_enterprise_customer_from_enterprise_group_id(group_id):
+    """
+    Get the enterprise customer id given an enterprise customer group id.
+    """
+    try:
+        return str(EnterpriseGroup.objects.get(pk=group_id).enterprise_customer.uuid)
+    except EnterpriseGroup.DoesNotExist:
+        return None
 
 
 def get_enterprise_customer_from_catalog_id(catalog_id):

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -181,6 +181,16 @@ urlpatterns = [
         ),
         name='enterprise-group-learners'
     ),
+    re_path(
+        r'^enterprise_group/(?P<group_uuid>[A-Za-z0-9-]+)/assign_learners/?$',
+        enterprise_group.EnterpriseGroupViewSet.as_view({'post': 'assign_learners'}),
+        name='enterprise-group-assign-learners'
+    ),
+    re_path(
+        r'^enterprise_group/(?P<group_uuid>[A-Za-z0-9-]+)/remove_learners/?$',
+        enterprise_group.EnterpriseGroupViewSet.as_view({'post': 'remove_learners'}),
+        name='enterprise-group-remove-learners'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -3,18 +3,24 @@ Views for the ``enterprise-group`` API endpoint.
 """
 
 from django_filters.rest_framework import DjangoFilterBackend
+from edx_rbac.decorators import permission_required
 from rest_framework import filters, permissions
 from rest_framework.decorators import action
+from rest_framework.response import Response
 
+from django.contrib import auth
 from django.db.models import Q
 from django.http import Http404
 
-from enterprise import models
+from enterprise import models, rules, utils
+from enterprise.api.utils import get_enterprise_customer_from_enterprise_group_id
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseReadWriteModelViewSet
 from enterprise.logging import getEnterpriseLogger
 
 LOGGER = getEnterpriseLogger(__name__)
+
+User = auth.get_user_model()
 
 
 class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
@@ -42,16 +48,43 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
                 associated_customers.append(user_object.enterprise_customer)
             queryset = queryset.filter(enterprise_customer__in=associated_customers)
 
-        if self.request.method in ('GET',):
-            if learner_uuids := self.request.query_params.getlist('learner_uuids'):
+        if self.request.method == 'GET':
+            if learner_ids := self.request.query_params.getlist('learner_ids'):
                 # groups can apply to both existing and pending users
                 queryset = queryset.filter(
-                    Q(members__enterprise_customer_user__in=learner_uuids) |
-                    Q(members__pending_enterprise_customer_user__in=learner_uuids),
+                    Q(members__enterprise_customer_user__in=learner_ids) |
+                    Q(members__pending_enterprise_customer_user__in=learner_ids),
                 )
             if enterprise_uuids := self.request.query_params.getlist('enterprise_uuids'):
                 queryset = queryset.filter(enterprise_customer__in=enterprise_uuids)
         return queryset
+
+    @permission_required(
+        'enterprise.can_access_admin_dashboard',
+        fn=lambda request, *args, **kwargs: get_enterprise_customer_from_enterprise_group_id(kwargs['pk'])
+    )
+    def update(self, request, *args, **kwargs):
+        """
+        PATCH /enterprise/api/v1/enterprise-group/<group uuid>
+        """
+        if requested_customer := self.request.data.get('enterprise_customer'):
+            # Essentially checking ``enterprise.can_access_admin_dashboard`` but for the customer the requester is
+            # attempting to update the group record to.
+            implicit_access = rules.has_implicit_access_to_dashboard(self.request.user, requested_customer)
+            explicit_access = rules.has_explicit_access_to_dashboard(self.request.user, requested_customer)
+            if not implicit_access and not explicit_access:
+                return Response('Unauthorized', status=401)
+        return super().update(request, *args, **kwargs)
+
+    @permission_required(
+        'enterprise.can_access_admin_dashboard',
+        fn=lambda request, *args, **kwargs: request.POST.dict().get('enterprise_customer')
+    )
+    def create(self, request, *args, **kwargs):
+        """
+        POST /enterprise/api/v1/enterprise-group/
+        """
+        return super().create(request, *args, **kwargs)
 
     @action(detail=True, methods=['get'])
     def get_learners(self, *args, **kwargs):
@@ -89,3 +122,152 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
         except models.EnterpriseGroup.DoesNotExist as exc:
             LOGGER.warning(f"group_uuid {group_uuid} does not exist")
             raise Http404 from exc
+
+    @action(methods=['post'], detail=False, permission_classes=[permissions.IsAuthenticated])
+    @permission_required(
+        'enterprise.can_access_admin_dashboard',
+        fn=lambda request, group_uuid: get_enterprise_customer_from_enterprise_group_id(group_uuid)
+    )
+    def assign_learners(self, request, group_uuid):
+        """
+        POST /enterprise/api/v1/enterprise-group/<group uuid>/assign_learners
+
+        Required Arguments:
+        - ``learner_emails``: List of learner emails to associate with the group. Note: only processes the first
+        1000 records provided.
+
+        Returns:
+        - ``records_processed``: Total number of group membership records processed.
+        - ``new_learners``: Total number of group membership records associated with new pending enterprise learners
+        that were processed.
+        - ``existing_learners``: Total number of group membership records associated with existing enterprise learners
+        that were processed.
+
+        """
+        try:
+            group = self.get_queryset().get(uuid=group_uuid)
+            customer = group.enterprise_customer
+        except models.EnterpriseGroup.DoesNotExist as exc:
+            raise Http404 from exc
+        if requested_emails := request.POST.dict().get('learner_emails'):
+            total_records_processed = 0
+            total_existing_users_processed = 0
+            total_new_users_processed = 0
+            for user_email_batch in utils.batch(requested_emails.rstrip(',').split(',')[: 1000], batch_size=200):
+                user_emails_to_create = []
+                memberships_to_create = []
+                # ecus: enterprise customer users
+                ecus = []
+                # Gather all existing User objects associated with the email batch
+                existing_users = User.objects.filter(email__in=user_email_batch)
+
+                # Build and create a list of EnterpriseCustomerUser objects for the emails of existing Users
+                # Ignore conflicts in case any of the ent customer user objects already exist
+                ecu_by_email = {
+                    user.email: models.EnterpriseCustomerUser(
+                        enterprise_customer=customer, user_id=user.id, active=True
+                    ) for user in existing_users
+                }
+                models.EnterpriseCustomerUser.objects.bulk_create(
+                    ecu_by_email.values(),
+                    ignore_conflicts=True,
+                )
+
+                # Fetch all ent customer users related to existing users provided by requester
+                # whether they were created above or already existed
+                ecus.extend(
+                    models.EnterpriseCustomerUser.objects.filter(
+                        user_id__in=existing_users.values_list('id', flat=True)
+                    )
+                )
+
+                # Extend the list of emails that don't have User objects associated and need to be turned into
+                # new PendingEnterpriseCustomerUser objects
+                user_emails_to_create.extend(set(user_email_batch).difference(set(ecu_by_email.keys())))
+
+                # Extend the list of memberships that need to be created associated with existing Users
+                ent_customer_users = [
+                    models.EnterpriseGroupMembership(
+                        enterprise_customer_user=ecu,
+                        group=group
+                    )
+                    for ecu in ecus
+                ]
+                total_existing_users_processed += len(ent_customer_users)
+                memberships_to_create.extend(ent_customer_users)
+
+            # Go over (in batches) all emails that don't have User objects
+            for emails_to_create_batch in utils.batch(user_emails_to_create, batch_size=200):
+                # Create the PendingEnterpriseCustomerUser objects
+                pecu_records = [
+                    models.PendingEnterpriseCustomerUser(
+                        enterprise_customer=customer, user_email=user_email
+                    ) for user_email in emails_to_create_batch
+                ]
+                # According to Django docs, bulk created objects can't be used in future bulk creates as the in memory
+                # objects returned by bulk_create won't have PK's assigned.
+                models.PendingEnterpriseCustomerUser.objects.bulk_create(pecu_records)
+                pecus = models.PendingEnterpriseCustomerUser.objects.filter(
+                    user_email__in=emails_to_create_batch,
+                    enterprise_customer=customer,
+                )
+                total_new_users_processed += len(pecus)
+                # Extend the list of memberships that need to be created associated with the new pending users
+                memberships_to_create.extend([
+                    models.EnterpriseGroupMembership(
+                        pending_enterprise_customer_user=pecu,
+                        group=group
+                    ) for pecu in pecus
+                ])
+
+            # Create all our memberships, bulk_create will batch for us.
+            memberships = models.EnterpriseGroupMembership.objects.bulk_create(
+                memberships_to_create, ignore_conflicts=True
+            )
+            total_records_processed += len(memberships)
+            data = {
+                'records_processed': total_records_processed,
+                'new_learners': total_new_users_processed,
+                'existing_learners': total_existing_users_processed,
+            }
+            return Response(data, status=201)
+        return Response(data="Error: missing request data: `learner_emails`.", status=400)
+
+    @action(methods=['post'], detail=False, permission_classes=[permissions.IsAuthenticated])
+    @permission_required(
+        'enterprise.can_access_admin_dashboard',
+        fn=lambda request, group_uuid: get_enterprise_customer_from_enterprise_group_id(group_uuid)
+    )
+    def remove_learners(self, request, group_uuid):
+        """
+        POST /enterprise/api/v1/enterprise-group/<group uuid>/remove_learners
+
+        Required Arguments:
+            - ``learner_emails``:
+                List of learner emails to associate with the group.
+
+        Returns:
+            - ``records_deleted``:
+                Number of membership records removed
+        """
+        try:
+            group = self.get_queryset().get(uuid=group_uuid)
+        except models.EnterpriseGroup.DoesNotExist as exc:
+            raise Http404 from exc
+        if requested_emails := request.POST.dict().get('learner_emails'):
+            records_deleted = 0
+            for user_email_batch in utils.batch(requested_emails.split(','), batch_size=200):
+                existing_users = User.objects.filter(email__in=user_email_batch).values_list("id", flat=True)
+                group_q = Q(group=group)
+                ecu_in_q = Q(enterprise_customer_user__user_id__in=existing_users)
+                pecu_in_q = Q(pending_enterprise_customer_user__user_email__in=user_email_batch)
+                records_to_delete = models.EnterpriseGroupMembership.objects.filter(
+                    group_q & (ecu_in_q | pecu_in_q),
+                )
+                records_deleted += len(records_to_delete)
+                records_to_delete.delete()
+            data = {
+                'records_deleted': records_deleted,
+            }
+            return Response(data, status=200)
+        return Response(data="Error: missing request data: `learner_emails`.", status=400)

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1476,6 +1476,18 @@ class PendingEnterpriseCustomerUser(TimeStampedModel):
         )
         return enterprise_customer_user
 
+    def fulfill_pending_group_memberships(self, enterprise_customer_user):
+        """
+        Updates any membership records associated with a new created enterprise customer user object.
+
+        Arguments:
+            enterprise_customer_user: a EnterpriseCustomerUser instance
+        """
+        self.memberships.update(
+            pending_enterprise_customer_user=None,
+            enterprise_customer_user=enterprise_customer_user
+        )
+
     def fulfill_pending_course_enrollments(self, enterprise_customer_user):
         """
         Enrolls a newly created EnterpriseCustomerUser in any courses attached to their

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -85,6 +85,7 @@ def handle_user_post_save(sender, **kwargs):  # pylint: disable=unused-argument
             is_user_created=created,
         )
         pending_ecu.fulfill_pending_course_enrollments(enterprise_customer_user)
+        pending_ecu.fulfill_pending_group_memberships(enterprise_customer_user)
         pending_ecu.delete()
 
     enterprise_customer_users = models.EnterpriseCustomerUser.objects.filter(user_id=user_instance.id)

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -330,6 +330,22 @@ class APITest(APITestCase):
         request.COOKIES[jwt_cookie_name()] = jwt_token
         return request
 
+    def set_multiple_enterprise_roles_to_jwt(self, context_and_roles):
+        """
+        Sets multiple roles to the jwt token cookies
+        """
+        jwt_roles = []
+        for pairs in context_and_roles:
+            context, role = pairs
+            jwt_roles.append(f"{context}:{role}")
+        payload = generate_unversioned_payload(self.user)
+        payload.update({
+            'roles': jwt_roles
+        })
+        jwt_token = generate_jwt_token(payload)
+
+        self.client.cookies[jwt_cookie_name()] = jwt_token
+
     def set_jwt_cookie(self, system_wide_role='enterprise_admin', context='some_context'):
         """
         Set jwt token in cookies.

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -511,7 +511,6 @@ class TestEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         )
 
         expected_groups = ['enterprise_enrollment_api_access']
-
         response = self.client.get(
             '{host}{path}?username={username}'.format(
                 host=settings.TEST_SERVER,
@@ -7270,7 +7269,12 @@ class TestEnterpriseGroupViewSet(APITest):
         self.client.login(username=self.user.username, password=TEST_PASSWORD)
 
         self.group_1 = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
-        self.group_2 = EnterpriseGroupFactory()
+        self.group_2 = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+        self.set_multiple_enterprise_roles_to_jwt([
+            (ENTERPRISE_ADMIN_ROLE, self.enterprise_customer.pk),
+            (ENTERPRISE_ADMIN_ROLE, self.group_2.enterprise_customer.pk)
+        ])
+
         self.enterprise_group_memberships = []
         for _ in range(11):
             self.enterprise_group_memberships.append(EnterpriseGroupMembershipFactory(
@@ -7299,8 +7303,7 @@ class TestEnterpriseGroupViewSet(APITest):
             'enterprise-group-list',
         )
         response = self.client.get(url)
-        assert response.json().get('count') == 1
-        assert response.json().get('results')[0].get('uuid') == str(self.group_1.uuid)
+        assert response.json().get('count') == 2
 
     def test_successful_retrieve_group(self):
         """
@@ -7411,6 +7414,10 @@ class TestEnterpriseGroupViewSet(APITest):
             'enterprise_customer': str(new_customer.uuid),
             'name': 'foobar',
         }
+        unauthorized_response = self.client.post(url, data=request_data)
+        assert unauthorized_response.status_code == 403
+
+        self.set_jwt_cookie(ENTERPRISE_ADMIN_ROLE, new_customer.pk)
         response = self.client.post(url, data=request_data)
         assert response.json().get('name') == 'foobar'
         assert len(EnterpriseGroup.objects.filter(name='foobar')) == 1
@@ -7424,11 +7431,19 @@ class TestEnterpriseGroupViewSet(APITest):
             'enterprise-group-detail',
             kwargs={'pk': self.group_1.uuid},
         )
-        request_data = {'name': 'ayylmao'}
+        new_uuid = uuid.uuid4()
+        new_customer = EnterpriseCustomerFactory(uuid=new_uuid)
+        self.set_multiple_enterprise_roles_to_jwt([
+            (ENTERPRISE_ADMIN_ROLE, self.enterprise_customer.pk),
+            (ENTERPRISE_ADMIN_ROLE, self.group_2.enterprise_customer.pk),
+            (ENTERPRISE_ADMIN_ROLE, new_customer.pk),
+        ])
+
+        request_data = {'enterprise_customer': new_uuid}
         response = self.client.patch(url, data=request_data)
         assert response.json().get('uuid') == str(self.group_1.uuid)
-        assert response.json().get('name') == 'ayylmao'
-        assert len(EnterpriseGroup.objects.filter(name='ayylmao')) == 1
+        assert response.json().get('enterprise_customer') == str(new_uuid)
+        assert len(EnterpriseGroup.objects.filter(enterprise_customer=str(new_uuid))) == 1
 
     def test_successful_delete_group(self):
         """
@@ -7444,6 +7459,162 @@ class TestEnterpriseGroupViewSet(APITest):
         assert response.status_code == 204
         assert not EnterpriseGroup.objects.filter(uuid=group_to_delete_uuid)
         assert not EnterpriseGroupMembership.objects.filter(group=group_to_delete_uuid)
+
+    def test_assign_learners_404(self):
+        """
+        Test that the assign learners endpoint properly handles no finding the provided group
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': uuid.uuid4()},
+        )
+        assert self.client.post(url).status_code == 404
+
+    def test_assign_learners_requires_learner_emails(self):
+        """
+        Test that the assign learners endpoint requires a POST body param: `learner_emails`
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+        response = self.client.post(url)
+        assert response.status_code == 400
+        assert response.data == "Error: missing request data: `learner_emails`."
+
+    def test_successful_assign_learners_to_group(self):
+        """
+        Test that both existing and new learners assigned to groups properly creates membership records
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+
+        existing_emails = ",".join([(UserFactory().email) for _ in range(10)])
+        new_emails = ",".join([(f"email_{x}@example.com") for x in range(10)])
+
+        request_data = {'learner_emails': f"{new_emails},{existing_emails}"}
+        response = self.client.post(url, data=request_data)
+
+        assert response.status_code == 201
+        assert response.data == {'records_processed': 20, 'new_learners': 10, 'existing_learners': 10}
+        assert len(
+            EnterpriseGroupMembership.objects.filter(
+                group=self.group_2,
+                pending_enterprise_customer_user__isnull=True
+            )
+        ) == 10
+        assert len(
+            EnterpriseGroupMembership.objects.filter(
+                group=self.group_2,
+                enterprise_customer_user__isnull=True
+            )
+        ) == 10
+
+    def test_remove_learners_404(self):
+        """
+        Test that the remove learners endpoint properly handles no finding the provided group
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-remove-learners',
+            kwargs={'group_uuid': uuid.uuid4()},
+        )
+        assert self.client.post(url).status_code == 404
+
+    def test_remove_learners_requires_learner_emails(self):
+        """
+        Test that the remove learners endpoint requires a POST body param: `learner_emails`
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-remove-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+        response = self.client.post(url)
+        assert response.status_code == 400
+        assert response.data == "Error: missing request data: `learner_emails`."
+
+    def test_patch_with_bad_request_customer_to_change_to(self):
+        """
+        Test that the PATCH endpoint will not allow the user to update a group to a customer that the requester
+        doesn't have access to
+        """
+        # url: 'http://testserver/enterprise/api/v1/enterprise_group/<group uuid>'
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-detail',
+            kwargs={'pk': self.group_1.uuid},
+        )
+        new_uuid = uuid.uuid4()
+        new_customer = EnterpriseCustomerFactory(uuid=new_uuid)
+
+        request_data = {'enterprise_customer': new_uuid}
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 401
+
+        self.set_multiple_enterprise_roles_to_jwt([
+            (ENTERPRISE_ADMIN_ROLE, self.enterprise_customer.pk),
+            (ENTERPRISE_ADMIN_ROLE, self.group_2.enterprise_customer.pk),
+            (ENTERPRISE_ADMIN_ROLE, new_customer.pk),
+        ])
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 200
+
+        request_data = {'enterprise_customer': uuid.uuid4()}
+        response = self.client.patch(url, data=request_data)
+        assert response.status_code == 401
+
+    def test_successful_remove_learners_from_group(self):
+        """
+        Test that both existing and new learners in groups are properly removed by the remove_learners endpoint
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-remove-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+        existing_emails = ""
+        memberships_to_delete = []
+        for _ in range(10):
+            membership = EnterpriseGroupMembershipFactory(group=self.group_2)
+            memberships_to_delete.append(membership)
+            existing_emails += membership.enterprise_customer_user.user.email + ','
+
+        request_data = {'learner_emails': existing_emails}
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 200
+        assert response.data == {'records_deleted': 10}
+        for membership in memberships_to_delete:
+            with self.assertRaises(EnterpriseGroupMembership.DoesNotExist):
+                EnterpriseGroupMembership.objects.get(pk=membership.pk)
+
+    def test_remove_learners_from_group_only_removes_from_specified_group(self):
+        """
+        Test that removing a learner's membership from a group will only effect the specified group
+        """
+        existing_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+        group_to_remove_from = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+        pending_user = PendingEnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        existing_membership = EnterpriseGroupMembershipFactory(
+            group=existing_group,
+            pending_enterprise_customer_user=pending_user,
+            enterprise_customer_user=None
+        )
+        membership_to_remove = EnterpriseGroupMembershipFactory(
+            group=group_to_remove_from,
+            pending_enterprise_customer_user=pending_user,
+            enterprise_customer_user=None
+        )
+
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-remove-learners',
+            kwargs={'group_uuid': group_to_remove_from.uuid},
+        )
+
+        request_data = {'learner_emails': pending_user.user_email}
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 200
+        with self.assertRaises(EnterpriseGroupMembership.DoesNotExist):
+            EnterpriseGroupMembership.objects.get(pk=membership_to_remove.pk)
+        assert EnterpriseGroupMembership.objects.get(pk=existing_membership.pk)
 
 
 @mark.django_db


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8415

ADR: https://github.com/openedx/edx-enterprise/blob/master/docs/decisions/0013-custom-groups-for-enterprise-learners.rst

in this PR:

- updates to enterprise group API:
    - added extra protections to PATCH requests (checking for membership to the requested to change org)
    - added `can_access_admin_dashboard` permission validation to both PATCH and CREATE requests
    - New `assign_learners` endpoint
    - New `remove_learners` endpoint
- Additional process on the User table post save signal to update membership records with newly created EnterpriseCustomerUser objects
- Unit tests

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
