### PR TITLE
feat: add api /learners/ endpoint to the enterprise group viewset

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.12.2]
+---------
+* feat: add api /learners/ endpoint to the enterprise group viewset
+
 [4.12.1]
 ---------
 * feat: unlink canvas user if not decommissioned on canvas side

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.12.1"
+__version__ = "4.12.2"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -811,6 +811,19 @@ class EnterpriseGroupSerializer(serializers.ModelSerializer):
         fields = ('enterprise_customer', 'name', 'uuid')
 
 
+class EnterpriseGroupMembershipSerializer(serializers.ModelSerializer):
+    """
+    Serializer for EnterpriseGroupMembership model.
+    """
+    learner_id = serializers.IntegerField(source='enterprise_customer_user.id', allow_null=True)
+    pending_learner_id = serializers.IntegerField(source='pending_enterprise_customer_user.id', allow_null=True)
+    enterprise_group_membership_uuid = serializers.UUIDField(source='uuid', allow_null=True, read_only=True)
+
+    class Meta:
+        model = models.EnterpriseGroupMembership
+        fields = ('learner_id', 'pending_learner_id', 'enterprise_group_membership_uuid')
+
+
 class CourseRunDetailSerializer(ImmutableStateSerializer):
     """
     Serializer for course run data retrieved from the discovery service course_run detail API endpoint.

--- a/enterprise/api/v1/urls.py
+++ b/enterprise/api/v1/urls.py
@@ -174,6 +174,13 @@ urlpatterns = [
         ),
         name='enterprise-customer-sso-configuration-base'
     ),
+    re_path(
+        r'^enterprise-group/(?P<group_uuid>[A-Za-z0-9-]+)/learners/?$',
+        enterprise_group.EnterpriseGroupViewSet.as_view(
+            {'get': 'get_learners'}
+        ),
+        name='enterprise-group-learners'
+    ),
 ]
 
 urlpatterns += router.urls

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -4,12 +4,17 @@ Views for the ``enterprise-group`` API endpoint.
 
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import filters, permissions
+from rest_framework.decorators import action
 
 from django.db.models import Q
+from django.http import Http404
 
 from enterprise import models
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseReadWriteModelViewSet
+from enterprise.logging import getEnterpriseLogger
+
+LOGGER = getEnterpriseLogger(__name__)
 
 
 class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
@@ -47,3 +52,40 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
             if enterprise_uuids := self.request.query_params.getlist('enterprise_uuids'):
                 queryset = queryset.filter(enterprise_customer__in=enterprise_uuids)
         return queryset
+
+    @action(detail=True, methods=['get'])
+    def get_learners(self, *args, **kwargs):
+        """
+        Endpoint Location: GET api/v1/enterprise-group/<group_uuid>/learners/
+
+        Request Arguments:
+        - ``group_uuid`` (URL location, required): The uuid of the group from which learners should be listed.
+
+        Returns: Paginated list of learners that are associated with the enterprise group uuid::
+
+            {
+                'count': 1,
+                'next': null,
+                'previous': null,
+                'results': [
+                    {
+                        'learner_uuid': 'enterprise_customer_user_id',
+                        'pending_learner_id': 'pending_enterprise_customer_user_id',
+                        'enterprise_group_membership_uuid': 'enterprise_group_membership_uuid',
+                    },
+                ],
+            }
+
+        """
+
+        group_uuid = kwargs.get('group_uuid')
+        try:
+            learner_list = self.get_queryset().get(uuid=group_uuid).members.all()
+            page = self.paginate_queryset(learner_list)
+            serializer = serializers.EnterpriseGroupMembershipSerializer(page, many=True)
+            response = self.get_paginated_response(serializer.data)
+            return response
+
+        except models.EnterpriseGroup.DoesNotExist as exc:
+            LOGGER.warning(f"group_uuid {group_uuid} does not exist")
+            raise Http404 from exc

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -7271,12 +7271,13 @@ class TestEnterpriseGroupViewSet(APITest):
 
         self.group_1 = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
         self.group_2 = EnterpriseGroupFactory()
-        for _ in range(5):
-            EnterpriseGroupMembershipFactory(
+        self.enterprise_group_memberships = []
+        for _ in range(11):
+            self.enterprise_group_memberships.append(EnterpriseGroupMembershipFactory(
                 group=self.group_1,
                 pending_enterprise_customer_user=None,
                 enterprise_customer_user__enterprise_customer=self.enterprise_customer,
-            )
+            ))
 
     def test_group_permissions(self):
         """
@@ -7312,6 +7313,66 @@ class TestEnterpriseGroupViewSet(APITest):
         )
         response = self.client.get(url)
         assert response.json().get('uuid') == str(self.group_1.uuid)
+
+    def test_successful_list_learners(self):
+        """
+        Test a successful GET request to the list endpoint.
+        """
+        # url: 'http://testserver/enterprise/api/v1/enterprise_group/<group uuid>/learners/'
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-learners',
+            kwargs={'group_uuid': self.group_1.uuid},
+        )
+        results_list = []
+        for i in reversed(range(1, 11)):
+            results_list.append(
+                {
+                    'learner_id': self.enterprise_group_memberships[i].enterprise_customer_user.id,
+                    'pending_learner_id': None,
+                    'enterprise_group_membership_uuid': str(self.enterprise_group_memberships[i].uuid),
+                },
+            )
+        expected_response = {
+            'count': 11,
+            'next': f'http://testserver/enterprise/api/v1/enterprise-group/{self.group_1.uuid}/learners?page=2',
+            'previous': None,
+            'results': results_list,
+        }
+        response = self.client.get(url)
+        assert response.json() == expected_response
+        # verify page 2 of paginated response
+        url_page_2 = settings.TEST_SERVER + reverse(
+            'enterprise-group-learners',
+            kwargs={'group_uuid': self.group_1.uuid},
+        ) + '?page=2'
+        page_2_response = self.client.get(url_page_2)
+        expected_response_page_2 = {
+            'count': 11,
+            'next': None,
+            'previous': f'http://testserver/enterprise/api/v1/enterprise-group/{self.group_1.uuid}/learners',
+            'results': [
+                {
+                    'learner_id': self.enterprise_group_memberships[0].enterprise_customer_user.id,
+                    'pending_learner_id': None,
+                    'enterprise_group_membership_uuid': str(self.enterprise_group_memberships[0].uuid),
+                }
+            ],
+        }
+        assert page_2_response.json() == expected_response_page_2
+
+    def test_group_uuid_not_found(self):
+        """
+        Verify that the endpoint api/v1/enterprise_group/<group uuid>/learners/
+        returns 404 when the group_uuid is not found.
+        """
+        # url: 'http://testserver/enterprise/api/v1/enterprise_group/<group uuid>/learners/'
+        group_uuid = fake.uuid4()
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-learners',
+            kwargs={'group_uuid': group_uuid},
+        )
+        response = self.client.get(url)
+        assert response.status_code == 404
 
     def test_successful_list_with_filters(self):
         """


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8414

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
