### PR TITLE
fix: proximus learner transmission issue

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.12.6]
+---------
+* fix: Proximus learner transmission failures
+
 [4.12.5]
 ---------
 * feat: adding a group membership to the EnterpriseCustomerUserReadOnlySerializer

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.12.5"
+__version__ = "4.12.6"

--- a/integrated_channels/cornerstone/exporters/learner_data.py
+++ b/integrated_channels/cornerstone/exporters/learner_data.py
@@ -36,41 +36,47 @@ class CornerstoneLearnerExporter(LearnerExporter):
             'cornerstone',
             'CornerstoneLearnerDataTransmissionAudit'
         )
+        enterprise_customer_user = enterprise_enrollment.enterprise_customer_user
+        # get the proper internal representation of the course key
+        course_id = get_course_id_for_enrollment(enterprise_enrollment)
+        # because CornerstoneLearnerDataTransmissionAudit records are created with a click-through
+        # the internal edX course_id is always used on the CornerstoneLearnerDataTransmissionAudit records
+        # rather than the external_course_id mapped via CornerstoneCourseKey
+        transmission_exists = CornerstoneLearnerDataTransmissionAudit.objects.filter(
+            user_id=enterprise_enrollment.enterprise_customer_user.user.id,
+            course_id=course_id,
+            plugin_configuration_id=self.enterprise_configuration.id,
+            enterprise_customer_uuid=self.enterprise_configuration.enterprise_customer.uuid,
+        ).exists()
 
-        try:
-            # get the proper internal representation of the course key
-            course_id = get_course_id_for_enrollment(enterprise_enrollment)
-            # because CornerstoneLearnerDataTransmissionAudit records are created with a click-through
-            # the internal edX course_id is always used on the CornerstoneLearnerDataTransmissionAudit records
-            # rather than the external_course_id mapped via CornerstoneCourseKey
-            csod_learner_data_transmission = CornerstoneLearnerDataTransmissionAudit.objects.get(
-                user_id=enterprise_enrollment.enterprise_customer_user.user.id,
+        if transmission_exists or enterprise_customer_user.user_email is not None:
+            csod_transmission_record, __ = CornerstoneLearnerDataTransmissionAudit.objects.update_or_create(
+                user_id=enterprise_customer_user.user.id,
                 course_id=course_id,
                 plugin_configuration_id=self.enterprise_configuration.id,
                 enterprise_customer_uuid=self.enterprise_configuration.enterprise_customer.uuid,
+                defaults={
+                    "enterprise_course_enrollment_id": enterprise_enrollment.id,
+                    "grade": grade,
+                    "course_completed": course_completed,
+                    "completed_timestamp": completed_date,
+                    "user_email": enterprise_customer_user.user_email,
+                },
             )
-            csod_learner_data_transmission.enterprise_course_enrollment_id = enterprise_enrollment.id
-            csod_learner_data_transmission.grade = grade
-            csod_learner_data_transmission.course_completed = course_completed
-            csod_learner_data_transmission.completed_timestamp = completed_date
-
-            # Used for api error reporting
-            csod_learner_data_transmission.user_email = enterprise_enrollment.enterprise_customer_user.user_email
-
-            enterprise_customer = enterprise_enrollment.enterprise_customer_user.enterprise_customer
-            csod_learner_data_transmission.enterprise_customer_uuid = enterprise_customer.uuid
-            csod_learner_data_transmission.plugin_configuration_id = self.enterprise_configuration.id
-            return [
-                csod_learner_data_transmission
-            ]
-        except CornerstoneLearnerDataTransmissionAudit.DoesNotExist:
-            LOGGER.info(generate_formatted_log(
-                self.enterprise_configuration.channel_code(),
-                enterprise_enrollment.enterprise_customer_user.enterprise_customer.uuid,
-                enterprise_enrollment.enterprise_customer_user.user_id,
-                enterprise_enrollment.course_id,
-                ('get_learner_data_records finished. No learner data was sent for this LMS User Id because '
-                 'Cornerstone User ID not found for [{name}]'.format(
-                     name=enterprise_enrollment.enterprise_customer_user.enterprise_customer.name
-                 ))))
+            return [csod_transmission_record]
+        else:
+            LOGGER.info(
+                generate_formatted_log(
+                    self.enterprise_configuration.channel_code(),
+                    enterprise_customer_user.enterprise_customer.uuid,
+                    enterprise_customer_user.user_id,
+                    enterprise_enrollment.course_id,
+                    (
+                        'get_learner_data_records finished. No learner data was sent for this LMS User Id because '
+                        'Cornerstone User ID not found for [{name}]'.format(
+                            name=enterprise_customer_user.enterprise_customer.name
+                        )
+                    )
+                )
+            )
             return None

--- a/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_exporters/test_learner_data.py
@@ -131,20 +131,6 @@ class TestCornerstoneLearnerExporter(unittest.TestCase):
 
         assert learner_data_records_1.id == learner_data_records_2.id
 
-    def test_get_learner_data_record_not_exist(self):
-        """
-        If learner data is not already exist, nothing is returned.
-        """
-        exporter = CornerstoneLearnerExporter('fake-user', self.config)
-        enterprise_course_enrollment = factories.EnterpriseCourseEnrollmentFactory(
-            enterprise_customer_user=factories.EnterpriseCustomerUserFactory(
-                user_id=self.other_user.id,
-                enterprise_customer=self.enterprise_customer,
-            ),
-            course_id=self.course_id,
-        )
-        assert exporter.get_learner_data_records(enterprise_course_enrollment) is None
-
     @responses.activate
     @mock.patch('integrated_channels.cornerstone.client.requests.post')
     @mock.patch('integrated_channels.integrated_channel.exporters.learner_data.get_course_certificate')


### PR DESCRIPTION
**Merge checklist:**

JIRA: https://2u-internal.atlassian.net/browse/ENT-8198

- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
