### PR TITLE
feat: add Waffle-based enterprise_features to EnterpriseCustomerUserViewSet

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,10 @@ Change Log
 Unreleased
 ----------
 
+[4.13.0]
+---------
+* feat: add Waffle-based `enterprise_features` to the `EnterpriseCustomerUserViewSet`.
+
 [4.12.6]
 ---------
 * fix: Proximus learner transmission failures

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.12.6"
+__version__ = "4.13.0"

--- a/enterprise/api/v1/views/enterprise_customer_user.py
+++ b/enterprise/api/v1/views/enterprise_customer_user.py
@@ -6,6 +6,7 @@ from rest_framework import filters
 
 from enterprise import models
 from enterprise.api.filters import EnterpriseCustomerUserFilterBackend
+from enterprise.api.pagination import PaginationWithFeatureFlags
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseReadWriteModelViewSet
 
@@ -17,6 +18,7 @@ class EnterpriseCustomerUserViewSet(EnterpriseReadWriteModelViewSet):
 
     queryset = models.EnterpriseCustomerUser.objects.all()
     filter_backends = (filters.OrderingFilter, DjangoFilterBackend, EnterpriseCustomerUserFilterBackend)
+    pagination_class = PaginationWithFeatureFlags
 
     FIELDS = (
         'enterprise_customer', 'user_id', 'active',

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -467,8 +467,7 @@ class TestEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
 
     def test_get_enterprise_customer_user_contains_features(self):
         """
-        Assert whether the paginated response contains `enterprise_features` with the
-        appropriate feature flags.
+        Assert whether the paginated response contains `enterprise_features`.
         """
         user = factories.UserFactory()
         enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -465,6 +465,27 @@ class TestEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
     Test enterprise learner list endpoint
     """
 
+    def test_get_enterprise_customer_user_contains_features(self):
+        """
+        Assert whether the paginated response contains `enterprise_features` with the
+        appropriate feature flags.
+        """
+        user = factories.UserFactory()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        factories.EnterpriseCustomerUserFactory(
+            user_id=user.id,
+            enterprise_customer=enterprise_customer
+        )
+        response = self.client.get(
+            '{host}{path}?username={username}'.format(
+                host=settings.TEST_SERVER,
+                path=ENTERPRISE_LEARNER_LIST_ENDPOINT,
+                username=user.username
+            )
+        )
+        response = self.load_json(response.content)
+        assert response['enterprise_features'] is not None
+
     def test_get_enterprise_customer_user_contains_consent_records(self):
         user = factories.UserFactory()
         enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])


### PR DESCRIPTION
Ensures the Waffle-based feature flags are serialized in the `EnterpriseCustomerUserViewSet` GET response such that we can stop relying on the `enterprise-customer` API endpoint in `frontend-app-learner-portal-enterprise`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
