### PR TITLE
feat: add waffle flag for enterprise groups feature

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,9 @@ Change Log
 
 Unreleased
 ----------
+[4.13.2]
+---------
+* feat: add a waffle flag for enterprise groups feature
 
 [4.13.1]
 ---------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.13.1"
+__version__ = "4.13.2"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -31,6 +31,18 @@ FEATURE_PREQUERY_SEARCH_SUGGESTIONS = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.enterprise_groups_v1
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables enterprise groups feature
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-02-29
+ENTERPRISE_GROUPS_V1 = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.enterprise_groups_v1',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -46,6 +58,13 @@ def feature_prequery_search_suggestions():
     return FEATURE_PREQUERY_SEARCH_SUGGESTIONS.is_enabled()
 
 
+def enterprise_groups_v1():
+    """
+    Returns whether the enterprise groups feature flag is enabled.
+    """
+    return ENTERPRISE_GROUPS_V1.is_enabled()
+
+
 def enterprise_features():
     """
     Returns a dict of enterprise Waffle-based feature flags.
@@ -53,4 +72,5 @@ def enterprise_features():
     return {
         'top_down_assignment_real_time_lcm': top_down_assignment_real_time_lcm(),
         'feature_prequery_search_suggestions': feature_prequery_search_suggestions(),
+        'enterprise_groups_v1': enterprise_groups_v1(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -301,7 +301,8 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                 'results': [],
                 'enterprise_features': {
                     'top_down_assignment_real_time_lcm': False,
-                    'feature_prequery_search_suggestions': False
+                    'feature_prequery_search_suggestions': False,
+                    'enterprise_groups_v1': False
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -60,7 +60,11 @@ from enterprise.models import (
     PendingEnrollment,
     PendingEnterpriseCustomerUser,
 )
-from enterprise.toggles import FEATURE_PREQUERY_SEARCH_SUGGESTIONS, TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM
+from enterprise.toggles import (
+    ENTERPRISE_GROUPS_V1,
+    FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
+    TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
+)
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_sso_orchestrator_api_base_url,
@@ -1519,59 +1523,61 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
 
     @ddt.data(
         # Request missing required permissions query param.
-        (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'}, False, False),
+        (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'}, False, False, False),
         # Staff user that does not have the specified group permission.
         (True, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False),
         # Staff user that does have the specified group permission.
         (True, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False),
+         True, None, False, False, False),
         # Non staff user that is not linked to the enterprise, nor do they have the group permission.
         (False, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False),
         # Non staff user that is not linked to the enterprise, but does have the group permission.
         (False, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         False, None, False, False),
+         False, None, False, False, False),
         # Non staff user that is linked to the enterprise, but does not have the group permission.
         (False, True, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False),
         # Non staff user that is linked to the enterprise and does have the group permission
         (False, True, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False),
+         True, None, False, False, False),
         # Non staff user that is linked to the enterprise and has group permission and the request has passed
         # multiple groups to check.
         (False, True, ['enterprise_enrollment_api_access'],
-         {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None, False, False),
+         {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None, False,
+         False, False),
         # Staff user with group permission filtering on non existent enterprise id.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[1]}, False,
-         None, False, False),
+         None, False, False, False),
         # Staff user with group permission filtering on enterprise id successfully.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[0]}, True,
-         None, False, False),
+         None, False, False, False),
         # Staff user with group permission filtering on search param with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'blah'}, False,
-         None, False, False),
+         None, False, False, False),
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True,
-         None, False, False),
+         None, False, False, False),
         # Staff user with group permission filtering on slug with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, False, False),
+         None, False, False, False),
         # Staff user with group permissions filtering on slug with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
-         None, False, False),
+         None, False, False, False),
         # Staff user with group permission filtering on slug with results, with
-        # top down assignment & real-time LCM feature enabled and
-        # prequery search results enabled
+        # top down assignment & real-time LCM feature enabled,
+        # prequery search results enabled and
+        # enterprise groups v1 feature enabled
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, True, True),
+         None, True, True, True),
     )
     @ddt.unpack
     @mock.patch('enterprise.utils.get_logo_url')
@@ -1585,6 +1591,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             expected_error,
             is_top_down_assignment_real_time_lcm_enabled,
             feature_prequery_search_suggestions_enabled,
+            enterprise_groups_v1_enabled,
             mock_get_logo_url,
     ):
         """
@@ -1641,6 +1648,14 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
         with override_waffle_flag(
             FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
             active=feature_prequery_search_suggestions_enabled
+        ):
+
+            response = client.get(
+                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
+            )
+        with override_waffle_flag(
+            ENTERPRISE_GROUPS_V1,
+            active=enterprise_groups_v1_enabled
         ):
 
             response = client.get(
@@ -1706,7 +1721,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enterprise_features': {
                     'top_down_assignment_real_time_lcm': is_top_down_assignment_real_time_lcm_enabled,
                     'feature_prequery_search_suggestions': feature_prequery_search_suggestions_enabled,
-
+                    'enterprise_groups_v1': enterprise_groups_v1_enabled,
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8531

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
