### PR TITLE
feat: pass force_enrollment when bulk enrolling learners

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.13.11]
+---------
+* feat: pass force_enrollment when bulk enrolling learners
+
 [4.13.10]
 ---------
 * fix: remove filter to debug failing transmissions

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.13.10"
+__version__ = "4.13.11"

--- a/enterprise/api/v1/views/enterprise_customer.py
+++ b/enterprise/api/v1/views/enterprise_customer.py
@@ -171,9 +171,15 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
         Parameters:
             enrollments_info (list of dicts): an array of dictionaries, each containing the necessary information to
                 create an enrollment based on a subsidy for a user in a specified course. Each dictionary must contain
-                a user email (or user_id), a course run key, and either a UUID of the license that the learner is using
-                to enroll with or a transaction ID related to Executive Education the enrollment. `licenses_info` is
-                also accepted as a body param name.
+                the following keys:
+
+                * 'user_id' OR 'email': Either unique identifier describing the user to enroll.
+                * 'course_run_key': The course to enroll into.
+                * 'license_uuid' OR 'transaction_id': ID of either accepted form of subsidy. `license_uuid` refers to
+                  subscription licenses, and `transaction_id` refers to Learner Credit transactions.
+                * 'force_enrollment' (bool, optional): Enroll even if enrollment deadline is expired (default False).
+
+                `licenses_info` is also accepted as a body param name.
 
                 Example::
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1807,6 +1807,7 @@ def customer_admin_enroll_user_with_status(
         enrollment_source=None,
         license_uuid=None,
         transaction_id=None,
+        force_enrollment=False,
 ):
     """
     For use with bulk enrollment, or any use case of admin enrolling a user
@@ -1848,6 +1849,7 @@ def customer_admin_enroll_user_with_status(
             course_mode,
             is_active=True,
             enterprise_uuid=enterprise_customer.uuid,
+            force_enrollment=force_enrollment,
         )
         succeeded = True
         LOGGER.info("Successfully enrolled user %s in course %s", user.id, course_id)
@@ -1987,6 +1989,7 @@ def enroll_subsidy_users_in_courses(enterprise_customer, subsidy_users_info, dis
             * 'course_run_key': The course to enroll into.
             * 'course_mode': The course mode.
             * 'license_uuid' OR 'transaction_id': ID of either accepted form of subsidy.
+            * 'force_enrollment' (bool, optional): Enroll user even enrollment deadline is expired (default False).
 
             Example::
 
@@ -2037,6 +2040,7 @@ def enroll_subsidy_users_in_courses(enterprise_customer, subsidy_users_info, dis
         license_uuid = subsidy_user_info.get('license_uuid')
         transaction_id = subsidy_user_info.get('transaction_id')
         activation_link = subsidy_user_info.get('activation_link')
+        force_enrollment = subsidy_user_info.get('force_enrollment', False)
 
         if user_id and user_email:
             user = User.objects.filter(id=subsidy_user_info['user_id']).first()
@@ -2066,7 +2070,8 @@ def enroll_subsidy_users_in_courses(enterprise_customer, subsidy_users_info, dis
                     course_run_key,
                     enrollment_source,
                     license_uuid,
-                    transaction_id
+                    transaction_id,
+                    force_enrollment=force_enrollment,
                 )
                 if succeeded:
                     success_dict = {


### PR DESCRIPTION
A `force_enrollment` boolean flag has been added to the "enrollment info" dict fed into the bulk enrollment endpoint.  This enables consumers of the enterprise bulk enrollment endpoint to force specific enrollments even after the enrollment deadline has passed for the course.

ENT-8525

This is one of three PRs which percolate this single boolean through multiple layers of code, all the way down to the core LMS enrollment API:

1. https://github.com/openedx/enterprise-subsidy/pull/219
2. [YOU ARE HERE] https://github.com/openedx/edx-enterprise/pull/2048
3. https://github.com/openedx/edx-platform/pull/34376