### PR TITLE
feat: adding additional info to the enterprise group membership serializer

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.13.12]
+---------
+* feat: adding additional info to the enterprise group membership serializer
+
 [4.13.11]
 ---------
 * feat: pass force_enrollment when bulk enrolling learners

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.13.11"
+__version__ = "4.13.12"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -600,9 +600,48 @@ class EnterpriseGroupMembershipSerializer(serializers.ModelSerializer):
     pending_learner_id = serializers.IntegerField(source='pending_enterprise_customer_user.id', allow_null=True)
     enterprise_group_membership_uuid = serializers.UUIDField(source='uuid', allow_null=True, read_only=True)
 
+    member_details = serializers.SerializerMethodField()
+    recent_action = serializers.SerializerMethodField()
+    member_status = serializers.SerializerMethodField()
+
     class Meta:
         model = models.EnterpriseGroupMembership
-        fields = ('learner_id', 'pending_learner_id', 'enterprise_group_membership_uuid')
+        fields = (
+            'learner_id',
+            'pending_learner_id',
+            'enterprise_group_membership_uuid',
+            'member_details',
+            'recent_action',
+            'member_status',
+        )
+
+    def get_member_details(self, obj):
+        """
+        Return either the member's name and email if it's the case that the member is realized, otherwise just email
+        """
+        if user := obj.enterprise_customer_user:
+            return {"user_email": user.user_email, "user_name": user.name}
+        return {"user_email": obj.pending_enterprise_customer_user.user_email}
+
+    def get_recent_action(self, obj):
+        """
+        Return the timestamp and name of the most recent action associated with the membership.
+        """
+        if obj.is_removed:
+            return f"Removed: {obj.modified.strftime('%B %d, %Y')}"
+        if obj.enterprise_customer_user and obj.activated_at:
+            return f"Accepted: {obj.activated_at.strftime('%B %d, %Y')}"
+        return f"Invited: {obj.created.strftime('%B %d, %Y')}"
+
+    def get_member_status(self, obj):
+        """
+        Return the status related to the membership.
+        """
+        if obj.is_removed:
+            return "removed"
+        if obj.enterprise_customer_user:
+            return "accepted"
+        return "pending"
 
 
 class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1139,6 +1139,15 @@ class EnterpriseCustomerUser(TimeStampedModel):
         return None
 
     @property
+    def name(self):
+        """
+        Return linked user's name.
+        """
+        if self.user is not None:
+            return f"{self.user.first_name} {self.user.last_name}"
+        return None
+
+    @property
     def data_sharing_consent_records(self):
         """
         Return the DataSharingConsent records associated with this EnterpriseCustomerUser.


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8503

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
