### PR TITLE
fix: allowing for existing pecus to be added to enterprise groups

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,9 +15,13 @@ Change Log
 
 Unreleased
 ----------
+[4.15.4]
+--------
+* fix: allowing for existing pecus to be added to enterprise groups
+
 [4.15.3]
 --------
-* feat: replacing non encrypted fields of degreed config model with encrypted ones 
+* feat: replacing non encrypted fields of degreed config model with encrypted ones
 
 [4.15.2]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.15.3"
+__version__ = "4.15.4"

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -235,7 +235,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
                 ]
                 # According to Django docs, bulk created objects can't be used in future bulk creates as the in memory
                 # objects returned by bulk_create won't have PK's assigned.
-                models.PendingEnterpriseCustomerUser.objects.bulk_create(pecu_records)
+                models.PendingEnterpriseCustomerUser.objects.bulk_create(pecu_records, ignore_conflicts=True)
                 pecus = models.PendingEnterpriseCustomerUser.objects.filter(
                     user_email__in=emails_to_create_batch,
                     enterprise_customer=customer,

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -7740,6 +7740,21 @@ class TestEnterpriseGroupViewSet(APITest):
         assert response.status_code == 400
         assert response.data == "Error: missing request data: `learner_emails`."
 
+    def test_assign_learners_to_group_with_existing_pecu(self):
+        """
+        Test that we can add existing pending ecus to groups
+        """
+        url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+        pcu = PendingEnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer)
+        existing_email = pcu.user_email
+        request_data = {'learner_emails': existing_email}
+        response = self.client.post(url, data=request_data)
+        assert response.status_code == 201
+        assert response.json() == {'records_processed': 1, 'new_learners': 1, 'existing_learners': 0}
+
     def test_successful_assign_learners_to_group(self):
         """
         Test that both existing and new learners assigned to groups properly creates membership records


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
