### PR TITLE
fix: support `force_enrollment` in serializers used by bulk enrollment

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.15.11]
+---------
+* fix: support `force_enrollment` in serializers used by bulk enrollment (ENT-8788)
+
 [4.15.10]
 ---------
 * fix: set default langauge for all learners linked with an enteprise customer

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.15.10"
+__version__ = "4.15.11"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1426,6 +1426,10 @@ class EnrollmentsInfoSerializer(serializers.Serializer):
     course_run_key = serializers.CharField(required=True)
     license_uuid = serializers.CharField(required=False)
     transaction_id = serializers.CharField(required=False)
+    force_enrollment = serializers.BooleanField(
+        required=False,
+        help_text='Enroll even if enrollment deadline is expired.',
+    )
 
     def create(self, validated_data):
         return validated_data

--- a/requirements/celery53.txt
+++ b/requirements/celery53.txt
@@ -1,6 +1,6 @@
 amqp==5.2.0
 billiard==4.2.0
-celery==5.3.6
+celery==5.4.0
 click==8.1.7
 click-didyoumean==0.3.1
 click-repl==0.3.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -26,5 +26,5 @@ tox==3.28.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/ci.in
-virtualenv==20.25.1
+virtualenv==20.25.3
     # via tox

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -96,7 +96,7 @@ bleach==6.1.0
     #   -r requirements/test.txt
 build==1.2.1
     # via pip-tools
-celery==5.3.6
+celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
@@ -405,7 +405,7 @@ factory-boy==3.3.0
     #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
-faker==24.9.0
+faker==24.11.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test.txt
@@ -976,7 +976,7 @@ vine==5.1.0
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.25.1
+virtualenv==20.25.3
     # via tox
 wcwidth==0.2.13
     # via

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -60,7 +60,7 @@ billiard==4.2.0
     #   celery
 bleach==6.1.0
     # via -r requirements/test-master.txt
-celery==5.3.6
+celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test-master.txt
@@ -245,7 +245,7 @@ factory-boy==3.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-faker==24.9.0
+faker==24.11.0
     # via factory-boy
 filelock==3.13.1
     # via

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -401,7 +401,7 @@ drf-yasg==1.21.5
     #   -c requirements/edx/../constraints.txt
     #   django-user-tasks
     #   edx-api-doc-tools
-edx-ace==1.7.0
+edx-ace==1.8.0
     # via -r requirements/edx/kernel.in
 edx-api-doc-tools==1.8.0
     # via
@@ -420,7 +420,7 @@ edx-bulk-grades==1.0.2
     # via
     #   -r requirements/edx/kernel.in
     #   staff-graded-xblock
-edx-ccx-keys==1.2.1
+edx-ccx-keys==1.3.0
     # via
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
@@ -431,7 +431,7 @@ edx-celeryutils==1.3.0
     #   super-csv
 edx-codejail==3.3.3
     # via -r requirements/edx/kernel.in
-edx-completion==4.5.0
+edx-completion==4.6.0
     # via -r requirements/edx/kernel.in
 edx-django-release-util==1.4.0
     # via
@@ -469,7 +469,7 @@ edx-drf-extensions==10.2.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==4.15.2
+edx-enterprise==4.15.3
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -766,7 +766,7 @@ openedx-django-pyfs==3.6.0
     #   xblock
 openedx-django-require==2.1.0
     # via -r requirements/edx/kernel.in
-openedx-django-wiki==2.0.3
+openedx-django-wiki==2.1.0
     # via -r requirements/edx/kernel.in
 openedx-events==9.5.2
     # via
@@ -1201,7 +1201,7 @@ webob==1.8.7
     #   xblock
 wrapt==1.16.0
     # via -r requirements/edx/paver.txt
-xblock[django]==2.0.0
+xblock[django]==3.1.0
     # via
     #   -r requirements/edx/kernel.in
     #   acid-xblock

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -10,7 +10,7 @@ attrs==23.2.0
     #   trio
 autocommand==2.2.2
     # via jaraco-text
-backports-tarfile==1.0.0
+backports-tarfile==1.1.0
     # via jaraco-context
 certifi==2024.2.2
     # via selenium

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -47,7 +47,7 @@ bleach==6.1.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-celery==5.3.6
+celery==5.4.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -228,7 +228,7 @@ factory-boy==3.3.0
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/test.in
-faker==24.9.0
+faker==24.11.0
     # via factory-boy
 filelock==3.13.1
     # via

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4646,6 +4646,57 @@ class TestBulkEnrollment(BaseTestEnterpriseAPIViews):
         assert mock_update_or_create_enrollment.call_count == 2
 
     @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
+    @mock.patch('enterprise.utils.lms_update_or_create_enrollment')
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment', mock.MagicMock())
+    def test_bulk_enrollment_force_enrollment(
+        self,
+        mock_update_or_create_enrollment,
+        mock_get_course_mode,
+    ):
+        """
+        Ensure bulk enrollment passes force_enrollment hints into lower level functions.
+        """
+        mock_update_or_create_enrollment.return_value = True
+
+        user_one = factories.UserFactory(is_active=True)
+        user_two = factories.UserFactory(is_active=True)
+
+        factories.EnterpriseCustomerFactory(
+            uuid=FAKE_UUIDS[0],
+            name="test_enterprise"
+        )
+
+        permission = Permission.objects.get(name='Can add Enterprise Customer')
+        self.user.user_permissions.add(permission)
+        mock_get_course_mode.return_value = VERIFIED_SUBSCRIPTION_COURSE_MODE
+
+        self.assertEqual(len(PendingEnrollment.objects.all()), 0)
+        body = {
+            'enrollments_info': [
+                {
+                    'user_id': user_one.id,
+                    'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                    'license_uuid': '5a88bdcade7c4ecb838f8111b68e18ac',
+                    # For this enrollment, force_enrollment should fallback to False.
+                },
+                {
+                    'email': user_two.email,
+                    'course_run_key': 'course-v1:edX+DemoX+Demo_Course',
+                    'license_uuid': '2c58acdade7c4ede838f7111b42e18ac',
+                    'force_enrollment': True,
+                },
+            ]
+        }
+        response = self.client.post(
+            settings.TEST_SERVER + ENTERPRISE_CUSTOMER_BULK_ENROLL_LEARNERS_IN_COURSES_ENDPOINT,
+            data=json.dumps(body),
+            content_type='application/json',
+        )
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        assert mock_update_or_create_enrollment.mock_calls[0].kwargs['force_enrollment'] is False
+        assert mock_update_or_create_enrollment.mock_calls[1].kwargs['force_enrollment'] is True
+
+    @mock.patch('enterprise.api.v1.views.enterprise_customer.get_best_mode_from_course_key')
     @mock.patch('enterprise.api.v1.views.enterprise_customer.track_enrollment')
     @mock.patch('enterprise.models.EnterpriseCustomer.notify_enrolled_learners')
     def test_bulk_enrollment_in_bulk_courses_nonexisting_user_id(


### PR DESCRIPTION
ENT-8788

Testing
===

Before this PR (`force_enrollment` key was ignored from input):

```
$ python manage.py shell
>>> from enterprise.api.v1.serializers import EnterpriseCustomerBulkSubscriptionEnrollmentsSerializer
>>> serializer = EnterpriseCustomerBulkSubscriptionEnrollmentsSerializer(data={'enrollments_info': [{'email': 'newuser@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'license_uuid': '5b77bdbade7b4fcb838f8111b68e18ae', 'force_enrollment': True}]})
>>> serializer.is_valid()
True
>>> serializer.validated_data.get('enrollments_info')[0].get('force_enrollment', False)
False
```

After this PR:

```
$ python manage.py shell
>>> from enterprise.api.v1.serializers import EnterpriseCustomerBulkSubscriptionEnrollmentsSerializer
>>> serializer = EnterpriseCustomerBulkSubscriptionEnrollmentsSerializer(data={'enrollments_info': [{'email': 'newuser@test.com', 'course_run_key': 'course-v1:edX+DemoX+Demo_Course', 'license_uuid': '5b77bdbade7b4fcb838f8111b68e18ae', 'force_enrollment': True}]})
>>> serializer.is_valid()
True
>>> serializer.validated_data.get('enrollments_info')[0].get('force_enrollment', False)
True
```
