### PR TITLE
perf: make user pref update non-blocking

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.15.6]
+--------
+* perf: update user preferences inside an async task to void request timeout
+
 [4.15.5]
 --------
 * fix: Improved the query to only fetch active configs for CSOD customers.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.15.5"
+__version__ = "4.15.6"

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -14,7 +14,11 @@ from django.db import IntegrityError
 
 from enterprise.api_client.braze import BrazeAPIClient
 from enterprise.constants import SSO_BRAZE_CAMPAIGN_ID
-from enterprise.utils import get_enterprise_customer, send_email_notification_message
+from enterprise.utils import (
+    get_enterprise_customer,
+    send_email_notification_message,
+    unset_language_of_all_enterprise_learners,
+)
 
 LOGGER = getLogger(__name__)
 
@@ -182,3 +186,15 @@ def send_sso_configured_email(
         )
         LOGGER.exception(message)
         raise exc
+
+
+@shared_task
+@set_code_owner_attribute
+def update_enterprise_learners_user_preference(enterprise_customer_uuid):
+    """
+    Update the user preference `pref-lang` attribute for all enterprise learners linked with an enterprise.
+
+    Arguments:
+        * enterprise_customer_uuid (UUID): uuid of an enterprise customer
+    """
+    unset_language_of_all_enterprise_learners(enterprise_customer_uuid)


### PR DESCRIPTION
**Description:** Move the update of user preferences inside an async task to avoid request timeout. Timeout can happen if the number of user preferences to update is too large.

**JIRA:** https://2u-internal.atlassian.net/browse/ENT-8614

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
