### PR TITLE
fix: return 404 for inactive csod configs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 ----------
+[4.15.9]
+--------
+* fix: return a 404 response for inactive CSOD customers while fetching courses
+
+
 [4.15.8]
 --------
 * fix: SSO self-serve tool invalid entityId parsing

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.15.8"
+__version__ = "4.15.9"

--- a/integrated_channels/cornerstone/views.py
+++ b/integrated_channels/cornerstone/views.py
@@ -14,6 +14,7 @@ from rest_framework.authentication import SessionAuthentication
 from rest_framework.response import Response
 
 from django.apps import apps
+from django.core.exceptions import ObjectDoesNotExist
 from django.utils.http import parse_http_date_safe
 
 from enterprise.api.throttles import ServiceUserThrottle
@@ -126,10 +127,20 @@ class CornerstoneCoursesListView(BaseViewSet):
                 })
 
         worker_user = get_enterprise_worker_user()
-        enterprise_config = CornerstoneEnterpriseCustomerConfiguration.objects.get(
-            enterprise_customer=enterprise_customer,
-            active=True
-        )
+        try:
+            enterprise_config = CornerstoneEnterpriseCustomerConfiguration.objects.get(
+                enterprise_customer=enterprise_customer,
+                active=True
+            )
+        except ObjectDoesNotExist:
+            return Response(
+                status=status.HTTP_404_NOT_FOUND,
+                data={
+                    "message": (
+                        "No active Cornerstone configuration found for given ciid."
+                    )
+                })
+
         exporter = enterprise_config.get_content_metadata_exporter(worker_user)
         transmitter = enterprise_config.get_content_metadata_transmitter()
 

--- a/tests/test_integrated_channels/test_cornerstone/test_views.py
+++ b/tests/test_integrated_channels/test_cornerstone/test_views.py
@@ -69,6 +69,20 @@ class TestCornerstoneCoursesListView(APITest, EnterpriseMockMixin):
         response = self.client.get(url)
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
+        @responses.activate
+        def test_course_list_invalid_ciid(self):
+            """
+            Test courses list with ciid of existing customer but with a non-active config
+            """
+            self.config.active = False
+            self.config.save()
+            url = '{path}?ciid={customer_uuid}'.format(
+                path=self.course_list_url,
+                customer_uuid=self.enterprise_customer_catalog.enterprise_customer.uuid
+            )
+            response = self.client.get(url)
+            self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
     def test_course_list_with_skip_key_if_none_false(self):
         """
         Test courses list view produces desired json when SKIP_KEY_IF_NONE is set to False


### PR DESCRIPTION
Description: We should not be returning courses for any inactive Cornerstone customers and gracefully handle the 500 server error.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
