### PR TITLE
fix: fix the PATCH method of ``EnterpriseCourseEnrollmentView``.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,11 @@ Change Log
 
 Unreleased
 ----------
+* Nothing
+
+[4.16.2]
+---------
+* fix: fix the PATCH method of ``EnterpriseCourseEnrollmentView``.
 
 [4.16.1]
 ---------
@@ -39,7 +44,6 @@ Unreleased
 [4.15.9]
 --------
 * fix: return a 404 response for inactive CSOD customers while fetching courses
-
 
 [4.15.8]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.16.1"
+__version__ = "4.16.2"

--- a/enterprise_learner_portal/api/v1/views.py
+++ b/enterprise_learner_portal/api/v1/views.py
@@ -96,6 +96,8 @@ class EnterpriseCourseEnrollmentView(APIView):
                 user,
                 list(filtered_enterprise_enrollments)
             )
+        else:
+            course_enrollments_resume_urls = {}
 
         data = EnterpriseCourseEnrollmentSerializer(
             filtered_enterprise_enrollments,
@@ -103,9 +105,7 @@ class EnterpriseCourseEnrollmentView(APIView):
             context={
                 'request': request,
                 'course_overviews': course_overviews,
-                'course_enrollments_resume_urls': (
-                    course_enrollments_resume_urls if course_enrollments_resume_urls else None
-                )
+                'course_enrollments_resume_urls': course_enrollments_resume_urls,
             },
         ).data
 
@@ -158,13 +158,22 @@ class EnterpriseCourseEnrollmentView(APIView):
 
         # TODO: For now, this makes the change backward compatible, we will change this to true boolean support
         enterprise_enrollment.saved_for_later = saved_for_later.lower() == 'true'
-
         enterprise_enrollment.save()
 
         course_overviews = get_course_overviews([course_id])
+
+        if get_resume_urls_for_course_enrollments and enterprise_enrollment.course_enrollment:
+            course_enrollments_resume_urls = get_resume_urls_for_course_enrollments(user, [enterprise_enrollment])
+        else:
+            course_enrollments_resume_urls = {}
+
         data = EnterpriseCourseEnrollmentSerializer(
             enterprise_enrollment,
-            context={'request': request, 'course_overviews': course_overviews},
+            context={
+                'request': request,
+                'course_overviews': course_overviews,
+                'course_enrollments_resume_urls': course_enrollments_resume_urls,
+            },
         ).data
 
         return Response(data)

--- a/pytest.local.ini
+++ b/pytest.local.ini
@@ -4,4 +4,4 @@
 [pytest]
 DJANGO_SETTINGS_MODULE = enterprise.settings.test
 addopts = --cov-report term-missing -W ignore
-norecursedirs = .* docs requirements node_modules
+testpaths = tests

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,3 +4,6 @@
 # W503,W504: warnings added since pep8/pycodestyle 1.5.7 that we haven't cleaned up yet
 ignore=E501,W503,W504
 exclude=.git,.tox,enterprise/settings,enterprise/migrations,enterprise/static
+
+[flake8]
+max-line-length = 120


### PR DESCRIPTION
Passes in a dictionary used for computation of course run resume URLs in the `patch()` method of the `EnterpriseCourseEnrollmentView`.

ENT-8608

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
