### PR TITLE
feat: splitting out group membership serializer learner id into lms user ID and ecu ID

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -15,6 +15,10 @@ Change Log
 
 Unreleased
 ----------
+[4.16.5]
+--------
+* feat: splitting out group membership serializer learner id into lms user ID and ecu ID
+
 [4.16.4]
 --------
 * revert: fix: set default langauge for all learners linked with an enteprise customer

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.16.4"
+__version__ = "4.16.5"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -602,9 +602,13 @@ class EnterpriseGroupMembershipSerializer(serializers.ModelSerializer):
     """
     Serializer for EnterpriseGroupMembership model.
     """
-    learner_id = serializers.IntegerField(source='enterprise_customer_user.id', allow_null=True)
-    pending_learner_id = serializers.IntegerField(source='pending_enterprise_customer_user.id', allow_null=True)
+    enterprise_customer_user_id = serializers.IntegerField(source='enterprise_customer_user.id', allow_null=True)
+    lms_user_id = serializers.IntegerField(source='enterprise_customer_user.user_id', allow_null=True)
+    pending_enterprise_customer_user_id = serializers.IntegerField(
+        source='pending_enterprise_customer_user.id', allow_null=True
+    )
     enterprise_group_membership_uuid = serializers.UUIDField(source='uuid', allow_null=True, read_only=True)
+    activated_at = serializers.DateTimeField(required=False)
 
     member_details = serializers.SerializerMethodField()
     recent_action = serializers.SerializerMethodField()
@@ -613,12 +617,14 @@ class EnterpriseGroupMembershipSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.EnterpriseGroupMembership
         fields = (
-            'learner_id',
-            'pending_learner_id',
+            'enterprise_customer_user_id',
+            'lms_user_id',
+            'pending_enterprise_customer_user_id',
             'enterprise_group_membership_uuid',
             'member_details',
             'recent_action',
             'status',
+            'activated_at',
         )
 
     def get_member_details(self, obj):

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -123,7 +123,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
                 'results': [
                     {
                         'learner_id': integer or None,
-                        'pending_learner_id': integer or None,
+                        'pending_enterprise_customer_user_id': integer or None,
                         'enterprise_group_membership_uuid': UUID,
                         'member_details': {
                             'user_email': string,
@@ -204,7 +204,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
         # act_by_date and catalog_uuid values are needed for Braze email trigger properties
         act_by_date = param_serializer.validated_data.get('act_by_date')
         catalog_uuid = param_serializer.validated_data.get('catalog_uuid')
-        learner_emails = param_serializer.validated_data.get('learner_emails')
+        learner_emails = param_serializer.validated_data.get('learner_emails', [])
         total_records_processed = 0
         total_existing_users_processed = 0
         total_new_users_processed = 0

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -7587,7 +7587,7 @@ class TestEnterpriseGroupViewSet(APITest):
         response = self.client.get(url)
 
         assert response.json().get('count') == 1
-        assert response.json().get('results')[0].get('pending_learner_id') == pending_user.id
+        assert response.json().get('results')[0].get('pending_enterprise_customer_user_id') == pending_user.id
 
         group.applies_to_all_contexts = False
         group.save()
@@ -7614,7 +7614,7 @@ class TestEnterpriseGroupViewSet(APITest):
 
         assert response.json().get('count') == 1
         assert response.json().get('results')[0].get(
-            'learner_id'
+            'enterprise_customer_user_id'
         ) == existing_membership.enterprise_customer_user.id
 
         url = settings.TEST_SERVER + reverse(
@@ -7626,7 +7626,7 @@ class TestEnterpriseGroupViewSet(APITest):
 
         assert response.json().get('count') == 1
         assert response.json().get('results')[0].get(
-            'pending_learner_id'
+            'pending_enterprise_customer_user_id'
         ) == pending_membership.pending_enterprise_customer_user.id
 
     def test_list_removed_learners(self):
@@ -7720,8 +7720,9 @@ class TestEnterpriseGroupViewSet(APITest):
             member_user = self.enterprise_group_memberships[i].enterprise_customer_user
             results_list.append(
                 {
-                    'learner_id': member_user.id,
-                    'pending_learner_id': None,
+                    'enterprise_customer_user_id': member_user.id,
+                    'lms_user_id': member_user.user_id,
+                    'pending_enterprise_customer_user_id': None,
                     'enterprise_group_membership_uuid': str(self.enterprise_group_memberships[i].uuid),
                     'member_details': {
                         'user_email': member_user.user_email,
@@ -7739,9 +7740,11 @@ class TestEnterpriseGroupViewSet(APITest):
         }
         response = self.client.get(url)
         for i in range(10):
-            assert response.json()['results'][i]['learner_id'] == expected_response['results'][i]['learner_id']
-            assert response.json()['results'][i]['pending_learner_id'] == (
-                expected_response['results'][i]['pending_learner_id'])
+            assert response.json()['results'][i]['enterprise_customer_user_id'] == expected_response['results'][i][
+                'enterprise_customer_user_id'
+            ]
+            assert response.json()['results'][i]['pending_enterprise_customer_user_id'] == (
+                expected_response['results'][i]['pending_enterprise_customer_user_id'])
             assert (response.json()['results'][i]['enterprise_group_membership_uuid']
                     == expected_response['results'][i]['enterprise_group_membership_uuid'])
 
@@ -7758,8 +7761,9 @@ class TestEnterpriseGroupViewSet(APITest):
             'previous': f'http://testserver/enterprise/api/v1/enterprise-group/{self.group_1.uuid}/learners',
             'results': [
                 {
-                    'learner_id': user.id,
-                    'pending_learner_id': None,
+                    'enterprise_customer_user_id': user.id,
+                    'lms_user_id': user.user_id,
+                    'pending_enterprise_customer_user_id': None,
                     'enterprise_group_membership_uuid': str(self.enterprise_group_memberships[0].uuid),
                     'member_details': {
                         'user_email': user.user_email,
@@ -7772,10 +7776,10 @@ class TestEnterpriseGroupViewSet(APITest):
         }
         assert page_2_response.json()['count'] == expected_response_page_2['count']
         assert page_2_response.json()['previous'] == expected_response_page_2['previous']
-        assert page_2_response.json()['results'][0]['learner_id'] == (
-            expected_response_page_2['results'][0]['learner_id'])
-        assert page_2_response.json()['results'][0]['pending_learner_id'] == (
-            expected_response_page_2['results'][0]['pending_learner_id'])
+        assert page_2_response.json()['results'][0]['enterprise_customer_user_id'] == (
+            expected_response_page_2['results'][0]['enterprise_customer_user_id'])
+        assert page_2_response.json()['results'][0]['pending_enterprise_customer_user_id'] == (
+            expected_response_page_2['results'][0]['pending_enterprise_customer_user_id'])
         assert (page_2_response.json()['results'][0]['enterprise_group_membership_uuid']
                 == expected_response_page_2['results'][0]['enterprise_group_membership_uuid'])
         self.enterprise_group_memberships[0].delete()
@@ -7801,7 +7805,7 @@ class TestEnterpriseGroupViewSet(APITest):
             'results': [
                 {
                     'learner_id': self.enterprise_group_memberships[0].enterprise_customer_user.id,
-                    'pending_learner_id': self.pending_enterprise_customer_user,
+                    'pending_enterprise_customer_user_id': self.pending_enterprise_customer_user,
                     'enterprise_group_membership_uuid': str(self.enterprise_group_memberships[0].uuid),
                     'enterprise_customer': {
                         'name': self.enterprise_customer.name,
@@ -8142,7 +8146,11 @@ class TestEnterpriseGroupViewSet(APITest):
         response = self.client.get(url)
         results = response.json().get('results')
         for result in results:
-            assert (result.get('pending_learner_id') == pending_user.id) or (result.get('learner_id') == new_user.id)
+            assert (
+                result.get('pending_enterprise_customer_user_id') == pending_user.id
+            ) or (
+                result.get('enterprise_customer_user_id') == new_user.id
+            )
 
     def test_group_assign_realized_learner_adds_activated_at(self):
         """


### PR DESCRIPTION
Additionally adding activation date to the membership serializer

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
