### PR TITLE
fix: hard deleting expired group memberships

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.17.5]
+--------
+* fix: hard deleting expired group memberships
+
 [4.17.4]
 --------
 * fix: update language cookie if langauge cookie is not same as user's language preference

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.17.4"
+__version__ = "4.17.5"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1732,3 +1732,10 @@ class EnterpriseGroupLearnersRequestQuerySerializer(serializers.Serializer):
         required=False,
     )
     pending_users_only = serializers.BooleanField(required=False, default=False)
+    show_removed = serializers.BooleanField(required=False, default=False)
+    is_reversed = serializers.BooleanField(required=False, default=False)
+    page = serializers.IntegerField(required=False)
+    lms_users = serializers.ListField(
+        child=serializers.IntegerField(required=True),
+        required=False,
+    )

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -107,12 +107,14 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
 
         Optional query params:
         - ``pending_users_only`` (string, optional): Specify that results should only contain pending learners
-        - ``q`` (string, optional): Filter the returned members by user email and name with a provided sub-string
+        - ``user_query`` (string, optional): Filter the returned members by user email and name with a provided
+        sub-string
         - ``sort_by`` (string, optional): Specify how the returned members should be ordered. Supported sorting values
         are `memberDetails`, `memberStatus`, and `recentAction`. Ordering can be reversed by supplying a `-` at the
         beginning of the sorting value ie `-memberStatus`.
         - ``page`` (int, optional): Which page of paginated data to return.
         - ``show_removed`` (bool, optional): Include removed learners in the response.
+        - ``is_reversed`` (bool, optional): Include to reverse the order of returned records.
 
         Returns: Paginated list of learners that are associated with the enterprise group uuid::
 
@@ -136,10 +138,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
             }
 
         """
-        query_params = self.request.query_params.copy()
-        is_reversed = bool(query_params.get('is_reversed', False))
-        show_removed = bool(query_params.get('show_removed', False))
-
+        query_params = self.request.query_params
         param_serializers = serializers.EnterpriseGroupLearnersRequestQuerySerializer(
             data=query_params
         )
@@ -148,8 +147,11 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
             return Response(param_serializers.errors, status=400)
 
         user_query = param_serializers.validated_data.get('user_query')
+        show_removed = param_serializers.validated_data.get('show_removed', False)
+        is_reversed = param_serializers.validated_data.get('is_reversed', False)
+
         sort_by = param_serializers.validated_data.get('sort_by')
-        pending_users_only = param_serializers.validated_data.get('pending_users_only')
+        pending_users_only = param_serializers.validated_data.get('pending_users_only', False)
 
         group_uuid = kwargs.get('group_uuid')
         try:

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -4402,14 +4402,14 @@ class EnterpriseGroupMembership(TimeStampedModel, SoftDeletableModel):
         blank=True,
         null=True,
         related_name='memberships',
-        on_delete=models.deletion.CASCADE,
+        on_delete=models.deletion.SET_NULL,
     )
     pending_enterprise_customer_user = models.ForeignKey(
         PendingEnterpriseCustomerUser,
         blank=True,
         null=True,
         related_name='memberships',
-        on_delete=models.deletion.CASCADE,
+        on_delete=models.deletion.SET_NULL,
     )
     activated_at = models.DateTimeField(
         default=None,

--- a/tests/test_enterprise/management/test_remove_expired_pending_group_memberships.py
+++ b/tests/test_enterprise/management/test_remove_expired_pending_group_memberships.py
@@ -93,7 +93,7 @@ class RemoveExpiredPendingGroupMembershipsCommandTests(TestCase):
 
         call_command(self.command)
 
-        # Assert that memberships and pending customers are removed
+        # Assert that pending memberships and pending customers are removed
         assert not models.EnterpriseGroupMembership.all_objects.filter(pk=membership_to_remove.pk)
         assert not models.PendingEnterpriseCustomerUser.objects.filter(
             pk=membership_to_remove.pending_enterprise_customer_user.pk


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
