### PR TITLE
fix: update enterprise model lookup in removal email task

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.17.9]
+--------
+* fix: update enterprise model lookup in removal email task
+
 [4.17.8]
 --------
 * fix: adding missing migration file

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.17.8"
+__version__ = "4.17.9"

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -300,7 +300,7 @@ def send_group_membership_removal_notification(enterprise_customer_uuid, members
     ] = enterprise_catalog_client.get_catalog_content_count(catalog_uuid)
     pecu_emails = []
     ecus = []
-    membership_records = enterprise_group_membership_model().objects.filter(uuid__in=membership_uuids)
+    membership_records = enterprise_group_membership_model().all_objects.filter(uuid__in=membership_uuids)
     for group_membership in membership_records:
         if group_membership.pending_enterprise_customer_user is not None:
             pecu_emails.append(group_membership.pending_enterprise_customer_user.user_email)

--- a/tests/test_enterprise/test_tasks.py
+++ b/tests/test_enterprise/test_tasks.py
@@ -252,17 +252,19 @@ class TestEnterpriseTasks(unittest.TestCase):
         """
         Verify send_group_membership_removal_notification hits braze client with expected args
         """
-        EnterpriseGroupMembershipFactory(
+        pecu_membership = EnterpriseGroupMembershipFactory(
             group=self.enterprise_group,
             pending_enterprise_customer_user=self.pending_enterprise_customer_user,
             enterprise_customer_user=None,
         )
-        EnterpriseGroupMembershipFactory(
+        ecu_membership = EnterpriseGroupMembershipFactory(
             group=self.enterprise_group,
             pending_enterprise_customer_user=None,
             enterprise_customer_user__enterprise_customer=self.enterprise_customer,
             activated_at=datetime.now()
         )
+        pecu_membership.delete()
+        ecu_membership.delete()
         admin_email = 'edx@example.org'
         mock_recipients = [self.pending_enterprise_customer_user.user_email,
                            mock_braze_api_client().create_recipient.return_value]
@@ -273,7 +275,7 @@ class TestEnterpriseTasks(unittest.TestCase):
         mock_catalog_content_count = 5
         mock_enterprise_catalog_client().get_catalog_content_count.return_value = (
             mock_catalog_content_count)
-        membership_uuids = EnterpriseGroupMembership.objects.values_list('uuid', flat=True)
+        membership_uuids = EnterpriseGroupMembership.all_objects.values_list('uuid', flat=True)
         catalog_uuid = uuid.uuid4()
         send_group_membership_removal_notification(
             self.enterprise_customer.uuid,


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8929

## Description:
We were attempting to look up membership uuid's after they have been deleted. To fix this, we need to update the model lookup from `enterprise_group_membership_model().objects` to `enterprise_group_membership_model().all_objects`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
