### PR TITLE
chore: debugging log lines

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.18.1]
+--------
+* chore: debugging log lines
+
 [4.18.0]
 --------
 * feat: updates tasks usage of create_recipient to create_recipients

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.18.0"
+__version__ = "4.18.1"

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -252,12 +252,31 @@ def _recipients_for_identified_users(
     """
     braze_client_instance = BrazeAPIClient()
     recipients = []
+    LOGGER.info(
+        '_recipients_for_identified_users_1: user_id_by_email: {%s}, '
+        'maximum_aliases_per_batch: {%s}, alias_label: {%s} ',
+        user_id_by_email,
+        maximum_aliases_per_batch,
+        alias_label
+    )
     for user_id_by_email_chunk in batch_dict(user_id_by_email, maximum_aliases_per_batch):
+        LOGGER.info(
+            '_recipients_for_identified_users_2: user_id_by_email_chunk: {%s} ',
+            user_id_by_email_chunk
+        )
         recipients_by_email = braze_client_instance.create_recipients(
             alias_label,
             user_id_by_email=user_id_by_email_chunk
         )
-        recipients.extend(recipients_by_email.values())
+        LOGGER.info(
+            '_recipients_for_identified_users_3: recipients_by_email: {%s} ',
+            recipients_by_email
+        )
+    recipients.extend(recipients_by_email.values())
+    LOGGER.info(
+        '_recipients_for_identified_users_4: recipients: {%s} ',
+        recipients
+    )
     return recipients
 
 
@@ -298,6 +317,11 @@ def send_group_membership_invitation_notification(
         if group_membership.pending_enterprise_customer_user is not None:
             pecu_emails.append(group_membership.pending_enterprise_customer_user.user_email)
         else:
+            LOGGER.info(
+                'send_group_membership_invitation_notification_1: user_email: {%s}, user_id: {%s} ',
+                group_membership.enterprise_customer_user.user_email,
+                group_membership.enterprise_customer_user.user_id
+            )
             user_id_by_email[
                 group_membership.enterprise_customer_user.user_email
             ] = group_membership.enterprise_customer_user.user_id
@@ -310,6 +334,10 @@ def send_group_membership_invitation_notification(
             ENTERPRISE_BRAZE_ALIAS_LABEL,
         )
     recipients.extend(_recipients_for_identified_users(user_id_by_email))
+    LOGGER.info(
+        'send_group_membership_invitation_notification_2: recipients: {%s} ',
+        recipients
+    )
     try:
         braze_client_instance.send_campaign_message(
             settings.BRAZE_GROUPS_INVITATION_EMAIL_CAMPAIGN_ID,
@@ -353,6 +381,11 @@ def send_group_membership_removal_notification(enterprise_customer_uuid, members
         if group_membership.pending_enterprise_customer_user is not None:
             pecu_emails.append(group_membership.pending_enterprise_customer_user.user_email)
         else:
+            LOGGER.info(
+                'send_group_membership_removal_notification_1: user_email: {%s}, user_id: {%s} ',
+                group_membership.enterprise_customer_user.user_email,
+                group_membership.enterprise_customer_user.user_id
+            )
             user_id_by_email[
                 group_membership.enterprise_customer_user.user_email
             ] = group_membership.enterprise_customer_user.user_id
@@ -366,7 +399,12 @@ def send_group_membership_removal_notification(enterprise_customer_uuid, members
             pecu_emails,
             ENTERPRISE_BRAZE_ALIAS_LABEL,
         )
+
     recipients.extend(_recipients_for_identified_users(user_id_by_email))
+    LOGGER.info(
+        'send_group_membership_removal_notification_2: recipients: {%s} ',
+        recipients
+    )
     try:
         braze_client_instance.send_campaign_message(
             settings.BRAZE_GROUPS_REMOVAL_EMAIL_CAMPAIGN_ID,


### PR DESCRIPTION
Adds debugging log lines for using `create_recipients`

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
