### PR TITLE
feat: allowing for group members to be revived by reassigning

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.18.6]
+--------
+* feat: allowing for group members to be revived by reassigning
+
 [4.18.5]
 --------
 * feat: force transmit content metadata if customer configs are modified

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.18.5"
+__version__ = "4.18.6"

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -210,13 +210,23 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
         total_records_processed = 0
         total_existing_users_processed = 0
         total_new_users_processed = 0
+        user_emails_to_create = []
+        memberships_to_create = []
         for user_email_batch in utils.batch(learner_emails[: 1000], batch_size=200):
-            user_emails_to_create = []
-            memberships_to_create = []
-            # ecus: enterprise customer users
-            ecus = []
             # Gather all existing User objects associated with the email batch
             existing_users = User.objects.filter(email__in=user_email_batch)
+
+            # Revive any previously deleted membership records connected to ECUs containing related emails
+            previously_removed_ecu_learners = models.EnterpriseGroupMembership.all_objects.filter(
+                enterprise_customer_user__user_id__in=existing_users.values_list('id', flat=True),
+                is_removed=True,
+                group=group,
+            )
+            previously_removed_ecu_learners.update(
+                status=constants.GROUP_MEMBERSHIP_ACCEPTED_STATUS,
+                removed_at=None,
+                is_removed=False,
+            )
 
             # Build and create a list of EnterpriseCustomerUser objects for the emails of existing Users
             # Ignore conflicts in case any of the ent customer user objects already exist
@@ -232,12 +242,10 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
 
             # Fetch all ent customer users related to existing users provided by requester
             # whether they were created above or already existed
-            ecus.extend(
-                models.EnterpriseCustomerUser.objects.filter(
-                    user_id__in=existing_users.values_list('id', flat=True),
-                    enterprise_customer=customer,
-                )
-            )
+            ecus = models.EnterpriseCustomerUser.objects.filter(
+                user_id__in=existing_users.values_list('id', flat=True),
+                enterprise_customer=customer,
+            ).exclude(pk__in=previously_removed_ecu_learners.values_list('pk', flat=True))
 
             # Extend the list of emails that don't have User objects associated and need to be turned into
             # new PendingEnterpriseCustomerUser objects
@@ -257,6 +265,18 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
 
         # Go over (in batches) all emails that don't have User objects
         for emails_to_create_batch in utils.batch(user_emails_to_create, batch_size=200):
+            # Revive any previously deleted membership records connected to PECUs containing related emails
+            previously_removed_pecu_learners = models.EnterpriseGroupMembership.all_objects.filter(
+                pending_enterprise_customer_user__user_email__in=emails_to_create_batch,
+                is_removed=True,
+                group=group,
+            )
+            previously_removed_pecu_learners.update(
+                status=constants.GROUP_MEMBERSHIP_PENDING_STATUS,
+                removed_at=None,
+                is_removed=False,
+            )
+
             # Create the PendingEnterpriseCustomerUser objects
             pecu_records = [
                 models.PendingEnterpriseCustomerUser(
@@ -269,7 +289,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
             pecus = models.PendingEnterpriseCustomerUser.objects.filter(
                 user_email__in=emails_to_create_batch,
                 enterprise_customer=customer,
-            )
+            ).exclude(pk__in=previously_removed_pecu_learners.values_list("pk", flat=True))
             total_new_users_processed += len(pecus)
             # Extend the list of memberships that need to be created associated with the new pending users
             memberships_to_create.extend([

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -43,6 +43,8 @@ from enterprise.constants import (
     ENTERPRISE_LEARNER_ROLE,
     ENTERPRISE_OPERATOR_ROLE,
     ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+    GROUP_MEMBERSHIP_ACCEPTED_STATUS,
+    GROUP_MEMBERSHIP_PENDING_STATUS,
     PATHWAY_CUSTOMER_ADMIN_ENROLLMENT,
 )
 from enterprise.models import (
@@ -7999,6 +8001,53 @@ class TestEnterpriseGroupViewSet(APITest):
         self.client.post(url, data=request_data)
         assert len(EnterpriseGroupMembership.objects.filter(group=self.group_2)) == 1
 
+    def test_assign_learners_revives_previously_removed_members(self):
+        """
+        Test that assigning learners to a group when the learner has already been removed as a member will revive the
+        membership
+        """
+        pending_membership = EnterpriseGroupMembershipFactory(
+            group=self.group_2,
+            pending_enterprise_customer_user=PendingEnterpriseCustomerUserFactory(),
+            enterprise_customer_user=None,
+        )
+        membership = EnterpriseGroupMembershipFactory(
+            group=self.group_2,
+            enterprise_customer_user=EnterpriseCustomerUserFactory(),
+            pending_enterprise_customer_user=None,
+        )
+
+        # Remove the memberships
+        remove_url = settings.TEST_SERVER + reverse(
+            'enterprise-group-remove-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+        request_data = {'learner_emails': [membership.member_email, pending_membership.member_email]}
+        self.client.post(remove_url, data=request_data)
+
+        membership.refresh_from_db()
+        pending_membership.refresh_from_db()
+        assert membership.is_removed
+        assert pending_membership.is_removed
+
+        # Recreate the memberships for the emails
+        assign_url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': self.group_2.uuid},
+        )
+        request_data = {
+            'learner_emails': [membership.member_email, pending_membership.member_email],
+        }
+        self.client.post(assign_url, data=request_data)
+
+        # Assert the memberships have been revived
+        membership.refresh_from_db()
+        pending_membership.refresh_from_db()
+        assert not pending_membership.is_removed
+        assert not membership.is_removed
+        assert pending_membership.status == GROUP_MEMBERSHIP_PENDING_STATUS
+        assert membership.status == GROUP_MEMBERSHIP_ACCEPTED_STATUS
+
     @mock.patch('enterprise.tasks.send_group_membership_invitation_notification.delay', return_value=mock.MagicMock())
     def test_successful_assign_learners_to_group(self, mock_send_group_membership_invitation_notification):
         """
@@ -8008,8 +8057,8 @@ class TestEnterpriseGroupViewSet(APITest):
             'enterprise-group-assign-learners',
             kwargs={'group_uuid': self.group_2.uuid},
         )
-        existing_emails = [UserFactory().email for _ in range(10)]
-        new_emails = [f"email_{x}@example.com" for x in range(10)]
+        existing_emails = [UserFactory(email=f"ayylmao{x}@example.com").email for x in range(400)]
+        new_emails = [f"email_{x}@example.com" for x in range(400)]
         act_by_date = datetime.now(pytz.UTC)
         catalog_uuid = uuid.uuid4()
         request_data = {
@@ -8019,24 +8068,38 @@ class TestEnterpriseGroupViewSet(APITest):
         }
         response = self.client.post(url, data=request_data)
         assert response.status_code == 201
-        assert response.data == {'records_processed': 20, 'new_learners': 10, 'existing_learners': 10}
+        assert response.data == {'records_processed': 800, 'new_learners': 400, 'existing_learners': 400}
         assert len(
             EnterpriseGroupMembership.objects.filter(
                 group=self.group_2,
                 pending_enterprise_customer_user__isnull=True
             )
-        ) == 10
+        ) == 400
         assert len(
             EnterpriseGroupMembership.objects.filter(
                 group=self.group_2,
                 enterprise_customer_user__isnull=True
             )
-        ) == 10
-        assert mock_send_group_membership_invitation_notification.call_count == 1
-        group_uuids = list(reversed(list(
-            EnterpriseGroupMembership.objects.filter(group=self.group_2).values_list('uuid', flat=True))))
-        mock_send_group_membership_invitation_notification.assert_has_calls([
-            mock.call(self.enterprise_customer.uuid, group_uuids, act_by_date, catalog_uuid)], any_order=True)
+        ) == 400
+
+        # Batch size for sending membership invitation notifications is 200, 800 total records means 4 iterations
+        group_uuids = list(
+            reversed(
+                list(EnterpriseGroupMembership.objects.filter(group=self.group_2).values_list('uuid', flat=True))
+            )
+        )
+        assert mock_send_group_membership_invitation_notification.call_count == len(group_uuids) / 200
+
+        for x in range(int(len(group_uuids) / 200)):
+            mock_send_group_membership_invitation_notification.assert_has_calls(
+                [mock.call(
+                    self.enterprise_customer.uuid,
+                    group_uuids[(x * 200):((x + 1) * 200)],
+                    act_by_date,
+                    catalog_uuid
+                )],
+                any_order=True,
+            )
 
     def test_remove_learners_404(self):
         """


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8953

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
