### PR TITLE
feat: allowing for group members to be specified when fetched

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.19.3]
+--------
+* feat: allowing for group members to be specified when fetched
+
 [4.19.2]
 --------
 * feat: added endpoint for pending_enterprise_customer_admin_user.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.19.2"
+__version__ = "4.19.3"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1781,7 +1781,7 @@ class EnterpriseGroupLearnersRequestQuerySerializer(serializers.Serializer):
     show_removed = serializers.BooleanField(required=False, default=False)
     is_reversed = serializers.BooleanField(required=False, default=False)
     page = serializers.IntegerField(required=False)
-    lms_users = serializers.ListField(
-        child=serializers.IntegerField(required=True),
+    learners = serializers.ListField(
+        child=serializers.EmailField(required=True),
         required=False,
     )

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -115,6 +115,8 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
         - ``page`` (int, optional): Which page of paginated data to return.
         - ``show_removed`` (bool, optional): Include removed learners in the response.
         - ``is_reversed`` (bool, optional): Include to reverse the order of returned records.
+        - ``learners`` (list[ email strings ], optional): Include to only return member records that are associated
+        with provided emails.
 
         Returns: Paginated list of learners that are associated with the enterprise group uuid::
 
@@ -161,6 +163,13 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
                                                     desc_order=is_reversed,
                                                     pending_users_only=pending_users_only,
                                                     fetch_removed=show_removed)
+
+            if learners := param_serializers.validated_data.get('learners'):
+                specified_members = []
+                for member in members:
+                    if member.member_email in learners:
+                        specified_members.append(member)
+                members = specified_members
 
             page = self.paginate_queryset(members)
             serializer = serializers.EnterpriseGroupMembershipSerializer(page, many=True)


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-8974

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
