### PR TITLE
feat: submit ` create_enterprise_enrollment` task on commit

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.19.16]
+---------
+* feat: submit ``create_enterprise_enrollment`` task on commit
+
 [4.19.15]
 ---------
 * feat: added filtering for transmitted records using the is_transmitted column.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.19.15"
+__version__ = "4.19.16"

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -11,7 +11,7 @@ import ddt
 from pytest import mark
 
 from django.db import transaction
-from django.test import override_settings
+from django.test import TestCase, override_settings
 
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE
 from enterprise.models import (
@@ -824,7 +824,7 @@ class TestEnterpriseLearnerRoleSignals(unittest.TestCase):
 
 
 @mark.django_db
-class TestCourseEnrollmentSignals(unittest.TestCase):
+class TestCourseEnrollmentSignals(TestCase):
     """
     Tests signals associated with CourseEnrollments (that are found in edx-platform).
     """
@@ -863,7 +863,8 @@ class TestCourseEnrollmentSignals(unittest.TestCase):
             'created': True,
         }
 
-        create_enterprise_enrollment_receiver(sender, instance, **kwargs)
+        with self.captureOnCommitCallbacks(execute=True):
+            create_enterprise_enrollment_receiver(sender, instance, **kwargs)
         mock_task.assert_called_once_with(str(instance.course_id), self.enterprise_customer_user.id)
 
     @mock.patch('enterprise.tasks.create_enterprise_enrollment.delay')


### PR DESCRIPTION
**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
