### PR TITLE
fix: cancel-fulfillment endpoint is now idempotent

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,12 +17,22 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.20.2]
+--------
+* fix: cancel-fulfillment endpoint is now idempotent
+
+Additionally, this fixes a bug whereby users with the
+``enterprise.can_manage_enterprise_fulfillment`` or
+``enterprise.can_access_admin_dashboard`` permissions in at least
+one enterprise could successfully authenticate against these endpoints
+for *any* enterprise.
+
 [4.20.1]
----------
+--------
 * feat: Updating autocomplete field for Enteprise Group creation form
 
 [4.20.0]
----------
+--------
 * feat: Added a new field show_videos_in_learner_portal_search_results in the EnterpriseCustomer model.
 
 [4.19.17]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.20.1"
+__version__ = "4.20.2"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -1217,3 +1217,36 @@ class EnterpriseGroupMembershipAdmin(admin.ModelAdmin):
         'enterprise_customer_user',
         'pending_enterprise_customer_user',
     )
+
+
+@admin.register(models.LearnerCreditEnterpriseCourseEnrollment)
+class LearnerCreditEnterpriseCourseEnrollmentAdmin(admin.ModelAdmin):
+    """
+    Django admin model for LearnerCreditEnterpriseCourseEnrollmentAdmin.
+    """
+    list_display = (
+        'uuid',
+        'fulfillment_type',
+        'enterprise_course_enrollment',
+        'is_revoked',
+        'modified',
+    )
+
+    readonly_fields = (
+        'uuid',
+        'enterprise_course_enrollment',
+    )
+
+    list_filter = ('is_revoked',)
+
+    search_fields = (
+        'uuid',
+        'enterprise_course_enrollment__id'
+        'enterprise_course_enrollment__user_id',
+    )
+
+    ordering = ('-modified',)
+
+    class Meta:
+        fields = '__all__'
+        model = models.LearnerCreditEnterpriseCourseEnrollment

--- a/enterprise/api/v1/views/enterprise_subsidy_fulfillment.py
+++ b/enterprise/api/v1/views/enterprise_subsidy_fulfillment.py
@@ -3,19 +3,20 @@ Views for the Enterprise Subsidy Fulfillment API.
 """
 
 from edx_rbac.decorators import permission_required
+from edx_rbac.mixins import PermissionRequiredMixin
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.exceptions import ValidationError
 from rest_framework.response import Response
-from rest_framework.status import HTTP_200_OK, HTTP_400_BAD_REQUEST, HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
+from rest_framework.status import HTTP_200_OK, HTTP_204_NO_CONTENT, HTTP_404_NOT_FOUND, HTTP_500_INTERNAL_SERVER_ERROR
 
-from django.db.models import Q
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.utils.dateparse import parse_datetime
+from django.utils.functional import cached_property
 from django.utils.translation import gettext as _
 
 from enterprise import models
-from enterprise.api.utils import get_enterprise_customer_from_user_id
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseWrapperApiViewSet
 from enterprise.logging import getEnterpriseLogger
@@ -45,17 +46,17 @@ class EnrollmentModificationException(Exception):
     """
 
 
-class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
+class EnterpriseSubsidyFulfillmentViewSet(PermissionRequiredMixin, EnterpriseWrapperApiViewSet):
     """
     General API views for subsidized enterprise course enrollments.
 
     Supported operations:
         * Fetch a subsidy fulfillment record by uuid.
-            /enterprise/api/v1/subsidy-fulfillment/{fulfillment_source_uuid}/
+            /enterprise/api/v1/enterprise-subsidy-fulfillment/{fulfillment_source_uuid}/
         * Cancel a subsidy fulfillment enrollment record by uuid.
-            /enterprise/api/v1/subsidy-fulfillment/{fulfillment_source_uuid}/cancel-enrollment/
+            /enterprise/api/v1/enterprise-subsidy-fulfillment/{fulfillment_source_uuid}/cancel-fulfillment/
         * Fetch all unenrolled subsidy fulfillment records.
-            /enterprise/api/v1/operator/subsidy-fulfillment/unenrolled/
+            /enterprise/api/v1/operator/enterprise-subsidy-fulfillment/unenrolled/
 
     Cancel and fetch endpoints require a fulfillment source uuid query parameter. Fetching unenrollments supports
     an optional ``unenrolled_after`` query parameter to filter the returned queryset down to only enterprise
@@ -94,47 +95,62 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
         (Http403): If the requesting user does not have the appropriate permissions.
         (EnrollmentModificationException): If something goes wrong while updating the platform CourseEnrollment object.
     """
+    def get_permission_required(self):
+        """
+        Return specific permission name based on the view being requested
+        """
+        if self.action == 'unenrolled':
+            return ['enterprise.can_manage_enterprise_fulfillments']
+        elif self.action == 'retrieve':
+            return ['enterprise.can_access_admin_dashboard']
+        elif self.action == 'cancel_enrollment':
+            return ['enterprise.can_enroll_learners']
+        return []
 
-    def get_subsidy_fulfillment_queryset(self):
+    def get_permission_object(self):
         """
-        Return the queryset for this view. Queries across subsidy types until it finds a match for the provided uuid.
-        Returns a 404 if no subsidy fulfillment record is found.
+        Depending on the requested view, returns a record identifier to check perms against.
         """
-        enterprise_customer_uuid = get_enterprise_customer_from_user_id(self.request.user.id)
+        if self.request.user.is_staff:
+            return None
+
+        if self.action in ('retrieve', 'cancel_enrollment'):
+            enrollment_record = self.requested_fulfillment_source.enterprise_course_enrollment
+            return str(enrollment_record.enterprise_customer_user.enterprise_customer.uuid)
+        else:
+            return None
+
+    @cached_property
+    def requested_fulfillment_source(self):
+        """
+        Computes and caches the requested fulfillment source record for this request.
+        """
+        return self._get_single_fulfillment_by_uuid()
+
+    def _get_single_fulfillment_by_uuid(self):
+        """
+        Returns a single LearnerCreditCourseEnrollment or LicensedCourseEnrollment associated
+        with the requested ``fulfillment_source_uuid``.
+
+        Raises: a 404 if no such record can be found.
+        """
         fulfillment_source_uuid = self.kwargs.get('fulfillment_source_uuid')
 
-        # Get learner credit enrollments under the supplied fulfillment source uuid.
-        learner_credit_enrollments = models.LearnerCreditEnterpriseCourseEnrollment.objects.filter(
-            uuid=fulfillment_source_uuid
-        )
+        # Get learner credit fulfillments under the supplied fulfillment source uuid.
+        learner_credit_enrollment = models.LearnerCreditEnterpriseCourseEnrollment.objects.filter(
+            uuid=fulfillment_source_uuid,
+        ).first()
+        if learner_credit_enrollment:
+            return learner_credit_enrollment
 
-        # Filters to match fulfillment enrollments' and entitlements' enterprise customer uuid to the requesting
-        # user's enterprise customer uuid.
-        subsidy_fulfillment_filter = Q(
-            enterprise_course_enrollment__enterprise_customer_user__enterprise_customer__uuid=enterprise_customer_uuid
-        )
-        subsidy_fulfillment_filter |= Q(
-            enterprise_course_entitlement__enterprise_customer_user__enterprise_customer__uuid=enterprise_customer_uuid
-        )
+        # If no LC fulfillment records, look for licensed enrollment records.
+        licensed_enrollment = models.LicensedEnterpriseCourseEnrollment.objects.filter(
+            uuid=fulfillment_source_uuid,
+        ).first()
+        if licensed_enrollment:
+            return licensed_enrollment
 
-        # If the requester isn't staff, apply the filters
-        if not self.request.user.is_staff:
-            learner_credit_enrollments = learner_credit_enrollments.filter(subsidy_fulfillment_filter)
-
-        # Return if we get any hits
-        if learner_credit_enrollments:
-            return learner_credit_enrollments
-
-        # Get licensed enrollments under the supplied fulfillment source uuid and repeat the same process.
-        licensed_enrollments = models.LicensedEnterpriseCourseEnrollment.objects.filter(
-            uuid=fulfillment_source_uuid
-        )
-        if not self.request.user.is_staff:
-            licensed_enrollments = licensed_enrollments.filter(subsidy_fulfillment_filter)
-
-        if licensed_enrollments:
-            return licensed_enrollments
-        raise ValidationError('No enrollment found for the given fulfillment source uuid.', code=HTTP_404_NOT_FOUND)
+        raise Http404('No fulfillment record matches the provided UUID.')
 
     def get_subsidy_fulfillment_serializer_class(self):
         """
@@ -155,7 +171,7 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
 
         raise ValidationError('No enrollment found for the given fulfillment source uuid.', code=HTTP_404_NOT_FOUND)
 
-    def get_unenrolled_fulfillment_queryset(self):
+    def _get_unenrolled_fulfillment_queryset(self):
         """
         Return the queryset for unenrolled subsidy fulfillment records. Applies a modified timestamp filter to fetch
         records modified after if provided from query params.
@@ -188,10 +204,7 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
         else:
             return serializers.LearnerCreditEnterpriseCourseEnrollmentReadOnlySerializer
 
-    @permission_required(
-        'enterprise.can_manage_enterprise_fulfillments',
-        fn=lambda request: get_enterprise_customer_from_user_id(request.user.id)
-    )
+    @action(methods=['GET'], detail=False)
     def unenrolled(self, request, *args, **kwargs):
         """
         List all unenrolled subsidy fulfillments.
@@ -202,25 +215,19 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
             retrieve_licensed_enrollments (bool): If true, return data related to licensed enrollments instead of
                 learner credit
         """
-        queryset = self.get_unenrolled_fulfillment_queryset()
+        queryset = self._get_unenrolled_fulfillment_queryset()
         serializer_class = self.get_unenrolled_fulfillment_serializer_class()
         serializer = serializer_class(queryset, many=True)
         return Response(serializer.data)
 
-    @permission_required(
-        'enterprise.can_access_admin_dashboard',
-        fn=lambda request, fulfillment_source_uuid: get_enterprise_customer_from_user_id(request.user.id)
-    )
-    def retrieve(self, request, fulfillment_source_uuid, *args, **kwargs):
+    def retrieve(self, request, fulfillment_source_uuid, *args, **kwargs):  # pylint: disable=unused-argument
         """
         Retrieve a single subsidized enrollment.
             /enterprise/api/v1/subsidy-fulfillment/{fulfillment_source_uuid}/
         """
         try:
-            queryset = self.get_subsidy_fulfillment_queryset()
-            fulfillment = get_object_or_404(queryset, uuid=fulfillment_source_uuid)
             serializer_class = self.get_subsidy_fulfillment_serializer_class()
-            serialized_object = serializer_class(fulfillment)
+            serialized_object = serializer_class(self.requested_fulfillment_source)
         except ValidationError as exc:
             return Response(
                 status=HTTP_404_NOT_FOUND,
@@ -229,22 +236,16 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
         return Response(serialized_object.data)
 
     @action(methods=['post'], detail=True)
-    @permission_required(
-        'enterprise.can_enroll_learners',
-        fn=lambda request, fulfillment_source_uuid: get_enterprise_customer_from_user_id(request.user.id)
-    )
-    def cancel_enrollment(self, request, fulfillment_source_uuid):
+    def cancel_enrollment(self, request, fulfillment_source_uuid):  # pylint: disable=unused-argument
         """
         Cancel a single subsidized enrollment. Assumes fulfillment source has a valid enterprise enrollment.
-            /enterprise/api/v1/subsidy-fulfillment/{fulfillment_source_uuid}/cancel-enrollment/
+        /enterprise/api/v1/enterprise-subsidy-fulfillment/{fulfillment_source_uuid}/cancel-fulfillment/
         """
         try:
-            subsidy_fulfillment = get_object_or_404(
-                self.get_subsidy_fulfillment_queryset(), uuid=fulfillment_source_uuid
-            )
+            subsidy_fulfillment = self.requested_fulfillment_source
             if subsidy_fulfillment.is_revoked:
                 return Response(
-                    status=HTTP_400_BAD_REQUEST,
+                    status=HTTP_200_OK,
                     data={'detail': 'Enrollment is already canceled.'}
                 )
         except ValidationError as exc:
@@ -268,7 +269,7 @@ class EnterpriseSubsidyFulfillmentViewSet(EnterpriseWrapperApiViewSet):
             )
             LOGGER.error(msg)
             return Response(msg, status=HTTP_500_INTERNAL_SERVER_ERROR)
-        return Response(status=HTTP_200_OK)
+        return Response(status=HTTP_204_NO_CONTENT)
 
 
 class LicensedEnterpriseCourseEnrollmentViewSet(EnterpriseWrapperApiViewSet):

--- a/test_utils/__init__.py
+++ b/test_utils/__init__.py
@@ -274,12 +274,19 @@ class APITest(APITestCase):
     Base class for API Tests.
     """
 
+    @classmethod
+    def setUpClass(cls):
+        """
+        Perform operations common to all test classes.
+        """
+        super().setUpClass()
+        cls.user = cls.create_user(username=TEST_USERNAME, email=TEST_EMAIL, password=TEST_PASSWORD)
+
     def setUp(self):
         """
-        Perform operations common to all tests.
+        Perform common operations to all tests.
         """
         super().setUp()
-        self.create_user(username=TEST_USERNAME, email=TEST_EMAIL, password=TEST_PASSWORD)
         self.client = APIClient()
         self.client.login(username=TEST_USERNAME, password=TEST_PASSWORD)
 
@@ -291,13 +298,15 @@ class APITest(APITestCase):
         self.client.logout()
         super().tearDown()
 
-    def create_user(self, username=TEST_USERNAME, password=TEST_PASSWORD, **kwargs):
+    @staticmethod
+    def create_user(username=TEST_USERNAME, password=TEST_PASSWORD, **kwargs):
         """
         Create a test user and set its password.
         """
-        self.user = factories.UserFactory(username=username, is_active=True, **kwargs)
-        self.user.set_password(password)
-        self.user.save()
+        user = factories.UserFactory(username=username, is_active=True, **kwargs)
+        user.set_password(password)
+        user.save()
+        return user
 
     def load_json(self, content):
         """

--- a/tests/test_consent/api/test_views.py
+++ b/tests/test_consent/api/test_views.py
@@ -42,13 +42,14 @@ class TestConsentAPIViews(APITest, ConsentMixin):
         self.addCleanup(discovery_client_class.stop)
         super().setUp()
 
-    def create_user(self, username=TEST_USERNAME, password=TEST_PASSWORD, **kwargs):
+    @staticmethod
+    def create_user(username=TEST_USERNAME, password=TEST_PASSWORD, **kwargs):
         """
         Create a test user and set its password.
         """
-        self.user = factories.UserFactory(username=username, is_active=True, is_staff=True, id=TEST_USER_ID)
-        self.user.set_password(password)
-        self.user.save()
+        kwargs['is_staff'] = True
+        kwargs['id'] = TEST_USER_ID
+        return APITest.create_user(username=username, password=password, **kwargs)
 
     def _assert_expectations(self, response, expected_body, expected_status):
         """


### PR DESCRIPTION
Additionally, this fixes a bug whereby users with the `enterprise.can_manage_enterprise_fulfillment` or
`enterprise.can_access_admin_dashboard` permissions in at least one enterprise could successfully authenticate against these endpoints for *any* enterprise.
ENT-9088

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
