### PR TITLE
fix: submit the create_enterprise_enrollment task with a configurable countdown

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,6 @@ jobs:
       fail-fast: false
       matrix:
         python-version:
-        - '3.8'
         - '3.11'
         toxenv: [quality, docs, django42-celery53, django42-pii-annotations]
     env:
@@ -39,7 +38,7 @@ jobs:
         TOXENV: ${{ matrix.toxenv }}
       run: tox
     - name: Run code coverage
-      if: matrix.python-version == '3.8' && matrix.toxenv == 'django42-celery53'
+      if: matrix.python-version == '3.11' && matrix.toxenv == 'django42-celery53'
       uses: codecov/codecov-action@v4
       with:
         flags: unittests

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,12 +17,16 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.20.5]
+--------
+* fix: submit the ``create_enterprise_enrollment`` task with a configurable countdown
+
 [4.20.4]
----------
+--------
 * feat: Populates ``learner_portal_sidebar_content`` in ``EnterpriseCustomer`` and removes references to old fields.
 
 [4.20.3]
----------
+--------
 * feat: Makes ``career_engagement_network_message`` field nullable in ``EnterpriseCustomer``.
 
 [4.20.2]

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.20.4"
+__version__ = "4.20.5"

--- a/enterprise/admin/forms.py
+++ b/enterprise/admin/forms.py
@@ -770,8 +770,8 @@ class AdminNotificationForm(forms.ModelForm):
             # `start_date` must always come before the `expiration_date`
             raise ValidationError({'expiration_date': ['Expiration date should be after start date.']})
         admin_notification = AdminNotification.objects.filter(
-            Q(start_date__range=(start_date, expiration_date)) |  # pylint: disable=unsupported-binary-operation
-            Q(expiration_date__range=(start_date, expiration_date)) |  # pylint: disable=unsupported-binary-operation
+            Q(start_date__range=(start_date, expiration_date)) |
+            Q(expiration_date__range=(start_date, expiration_date)) |
             Q(start_date__lt=start_date, expiration_date__gt=expiration_date)
         ).exclude(
             pk=self.instance.id

--- a/enterprise/rules.py
+++ b/enterprise/rules.py
@@ -201,7 +201,6 @@ def has_explicit_access_to_reporting_api(user, obj):
     )
 
 
-# pylint: disable=unsupported-binary-operation
 rules.add_perm('enterprise.can_access_admin_dashboard',
                has_implicit_access_to_dashboard | has_explicit_access_to_dashboard)
 

--- a/integrated_channels/integrated_channel/exporters/content_metadata.py
+++ b/integrated_channels/integrated_channel/exporters/content_metadata.py
@@ -205,7 +205,7 @@ class ContentMetadataExporter(Exporter):
                 )
 
                 content_query.add(
-                    Q(remote_errored_at__lt=self.LAST_24_HRS) | Q(remote_errored_at__isnull=True) |  # pylint: disable=unsupported-binary-operation
+                    Q(remote_errored_at__lt=self.LAST_24_HRS) | Q(remote_errored_at__isnull=True) |
                     Q(remote_errored_at__lt=self.enterprise_customer.modified),
                     Q.AND
                 )
@@ -414,7 +414,7 @@ class ContentMetadataExporter(Exporter):
                 )
 
                 past_content_query.add(
-                    Q(remote_errored_at__lt=self.LAST_24_HRS) | Q(remote_errored_at__isnull=True) |  # pylint: disable=unsupported-binary-operation
+                    Q(remote_errored_at__lt=self.LAST_24_HRS) | Q(remote_errored_at__isnull=True) |
                     Q(remote_errored_at__lt=self.enterprise_customer.modified), Q.AND)
                 past_content = ContentMetadataItemTransmission.objects.filter(
                     past_content_query).first()

--- a/integrated_channels/integrated_channel/models.py
+++ b/integrated_channels/integrated_channel/models.py
@@ -269,7 +269,7 @@ class EnterpriseCustomerPluginConfiguration(SoftDeletionModel):
             enterprise_customer=self.enterprise_customer,
             remote_deleted_at__isnull=True,
             remote_created_at__isnull=False,
-        ).filter(~non_existent_catalogs_filter | null_catalogs_filter)  # pylint: disable=unsupported-binary-operation
+        ).filter(~non_existent_catalogs_filter | null_catalogs_filter)
 
     def update_content_synced_at(self, action_happened_at, was_successful):
         """
@@ -723,7 +723,7 @@ class ContentMetadataItemTransmission(TimeStampedModel):
             remote_deleted_at__isnull=False,
         )
         query.add(
-            Q(remote_errored_at__lt=LAST_24_HRS)  # pylint: disable=unsupported-binary-operation
+            Q(remote_errored_at__lt=LAST_24_HRS)
             | Q(remote_errored_at__isnull=True)
             | Q(remote_errored_at__lt=enterprise_customer.modified), Q.AND)
         return ContentMetadataItemTransmission.objects.filter(query)
@@ -760,7 +760,7 @@ class ContentMetadataItemTransmission(TimeStampedModel):
             api_response_status_code__gte=400,
         )
         in_db_but_failed_to_send_query.add(
-            Q(remote_errored_at__lt=LAST_24_HRS) | Q(remote_errored_at__isnull=True) |  # pylint: disable=unsupported-binary-operation
+            Q(remote_errored_at__lt=LAST_24_HRS) | Q(remote_errored_at__isnull=True) |
             Q(remote_errored_at__lt=enterprise_customer.modified), Q.AND)
         in_db_but_unsent_query.add(in_db_but_failed_to_send_query, Q.OR)
         return ContentMetadataItemTransmission.objects.filter(in_db_but_unsent_query)
@@ -787,7 +787,7 @@ class ContentMetadataItemTransmission(TimeStampedModel):
             api_response_status_code__gte=400,
         )
         in_db_but_failed_to_send_query.add(
-            Q(remote_errored_at__lt=LAST_24_HRS) | Q(remote_errored_at__isnull=True) |  # pylint: disable=unsupported-binary-operation
+            Q(remote_errored_at__lt=LAST_24_HRS) | Q(remote_errored_at__isnull=True) |
             Q(remote_errored_at__lt=enterprise_customer.modified), Q.AND)
         return ContentMetadataItemTransmission.objects.filter(in_db_but_failed_to_send_query)
 
@@ -812,7 +812,7 @@ class ContentMetadataItemTransmission(TimeStampedModel):
             api_response_status_code__gte=400,
         )
         in_db_but_failed_to_send_query.add(
-            Q(remote_errored_at__lt=LAST_24_HRS)  # pylint: disable=unsupported-binary-operation
+            Q(remote_errored_at__lt=LAST_24_HRS)
             | Q(remote_errored_at__isnull=True)
             | Q(remote_errored_at__lt=enterprise_customer.modified), Q.AND)
         return ContentMetadataItemTransmission.objects.filter(in_db_but_failed_to_send_query)


### PR DESCRIPTION
Also removes Python 3.8 from the CI matrix.
ENT-9107

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
