### PR TITLE
feat: atomically re-activate ECE when re-activating SCE

### DIFF
--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -2289,6 +2289,7 @@ class EnterpriseFulfillmentSource(TimeStampedModel):
         """
         if self.enterprise_course_enrollment:
             self.enterprise_course_enrollment.saved_for_later = True
+            self.enterprise_course_enrollment.unenrolled = True
             self.enterprise_course_enrollment.unenrolled_at = localized_utcnow()
             self.enterprise_course_enrollment.save()
 
@@ -2301,6 +2302,7 @@ class EnterpriseFulfillmentSource(TimeStampedModel):
         """
         if self.enterprise_course_enrollment:
             self.enterprise_course_enrollment.saved_for_later = False
+            self.enterprise_course_enrollment.unenrolled = False
             self.enterprise_course_enrollment.unenrolled_at = None
             self.enterprise_course_enrollment.save()
 

--- a/tests/test_enterprise/test_signals.py
+++ b/tests/test_enterprise/test_signals.py
@@ -4,7 +4,7 @@ Tests for the `edx-enterprise` models module.
 
 import unittest
 from collections import OrderedDict
-from datetime import datetime
+from datetime import datetime, timedelta
 from unittest import mock
 
 import ddt
@@ -25,12 +25,18 @@ from enterprise.models import (
     SystemWideEnterpriseRole,
     SystemWideEnterpriseUserRoleAssignment,
 )
-from enterprise.signals import create_enterprise_enrollment_receiver, handle_user_post_save
+from enterprise.signals import (
+    course_enrollment_changed_receiver,
+    create_enterprise_enrollment_receiver,
+    enterprise_unenrollment_receiver,
+    handle_user_post_save,
+)
 from integrated_channels.integrated_channel.models import OrphanedContentTransmissions
 from test_utils import EmptyCacheMixin
 from test_utils.factories import (
     ContentMetadataItemTransmissionFactory,
     EnterpriseCatalogQueryFactory,
+    EnterpriseCourseEnrollmentFactory,
     EnterpriseCustomerCatalogFactory,
     EnterpriseCustomerFactory,
     EnterpriseCustomerUserFactory,
@@ -844,7 +850,7 @@ class TestCourseEnrollmentSignals(TestCase):
         super().setUp()
 
     @mock.patch('enterprise.tasks.create_enterprise_enrollment.apply_async')
-    def test_receiver_calls_task_if_ecu_exists(self, mock_task):
+    def test_create_ece_receiver_calls_task_if_ecu_exists(self, mock_task):
         """
         Receiver should call a task
         if user tied to the CourseEnrollment that is handed into the function
@@ -869,7 +875,7 @@ class TestCourseEnrollmentSignals(TestCase):
         mock_task.assert_called_once_with((str(instance.course_id), self.enterprise_customer_user.id), countdown=42)
 
     @mock.patch('enterprise.tasks.create_enterprise_enrollment.apply_async')
-    def test_receiver_does_not_call_task_if_ecu_not_exists(self, mock_task):
+    def test_create_ece_receiver_does_not_call_task_if_ecu_not_exists(self, mock_task):
         """
         Receiver should NOT call a task
         if user tied to the CourseEnrollment that is handed into the function
@@ -890,6 +896,60 @@ class TestCourseEnrollmentSignals(TestCase):
 
         create_enterprise_enrollment_receiver(sender, instance, **kwargs)
         mock_task.assert_not_called()
+
+    def test_course_enrollment_changed_receiver(self):
+        """
+        Test receiver that is supposed to handle course enrollments being reactivated (re-enrolled).
+        """
+        # Create an unenrolled EnterpriseCourseEnrollment.
+        enterprise_enrollment = EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            unenrolled=True,
+            unenrolled_at=datetime.now() - timedelta(days=1),
+        )
+
+        # Simulate a previously inactive course enrollment being re-activated.
+        mock_enrollment_data = mock.Mock()
+        mock_enrollment_data.course.course_key = enterprise_enrollment.course_id
+        mock_enrollment_data.user.id = self.enterprise_customer_user.user.id
+        mock_enrollment_data.is_active = True
+        kwargs = {
+            'enrollment': mock_enrollment_data,
+        }
+        course_enrollment_changed_receiver(mock.Mock(), **kwargs)
+
+        # Make sure the previously inactive enterprise enrollment has now been re-activated in response to the system
+        # enrollment being re-activated.
+        enterprise_enrollment.refresh_from_db()
+        assert enterprise_enrollment.unenrolled is False
+        assert enterprise_enrollment.unenrolled_at is None
+
+    def test_enterprise_unenrollment_receiver(self):
+        """
+        Test receiver that is supposed to handle course enrollments being deactivated (unenrolled).
+        """
+        # Create an enrolled EnterpriseCourseEnrollment.
+        enterprise_enrollment = EnterpriseCourseEnrollmentFactory(
+            enterprise_customer_user=self.enterprise_customer_user,
+            unenrolled=None,
+            unenrolled_at=None,
+        )
+
+        # Simulate a previously active course enrollment being deactivated.
+        mock_enrollment_data = mock.Mock()
+        mock_enrollment_data.course.course_key = enterprise_enrollment.course_id
+        mock_enrollment_data.user.id = self.enterprise_customer_user.user.id
+        mock_enrollment_data.is_active = False
+        kwargs = {
+            'enrollment': mock_enrollment_data,
+        }
+        enterprise_unenrollment_receiver(mock.Mock(), **kwargs)
+
+        # Make sure the previously active enterprise enrollment has now been deactivated in response to the system
+        # enrollment being deactivated.
+        enterprise_enrollment.refresh_from_db()
+        assert enterprise_enrollment.unenrolled is True
+        assert enterprise_enrollment.unenrolled_at is not None
 
 
 @mark.django_db


### PR DESCRIPTION
Also, update ECE.unenrolled everywhere we update ECE.unenrolled_at. This field seems to have been completely overlooked. I'm not sure if we use the `unenrolled` field anywhere, but it certainly can be confusing to anyone looking at the database.

ENT-8991