### PR TITLE
fix: add waffle flag for enterprise customer support tool

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.21.6]
+---------
+* feat: add waffle flag for enterprise customer support tool
+
 [4.21.5]
 ---------
 * feat: allow PAs to access all enterprise customers

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.21.5"
+__version__ = "4.21.6"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -48,7 +48,7 @@ ENTERPRISE_GROUPS_V1 = WaffleFlag(
 # .. toggle_default: False
 # .. toggle_description: Enables the enterprise customer support tool
 # .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2024-07-16
+# .. toggle_creation_date: 2024-07-17
 ENTERPRISE_CUSTOMER_SUPPORT_TOOL = WaffleFlag(
     f'{ENTERPRISE_NAMESPACE}.enterprise_customer_support_tool',
     __name__,

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -43,6 +43,18 @@ ENTERPRISE_GROUPS_V1 = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.enterprise_customer_support_tool
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables the enterprise customer support tool
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-07-16
+ENTERPRISE_CUSTOMER_SUPPORT_TOOL = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.enterprise_customer_support_tool',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -65,6 +77,13 @@ def enterprise_groups_v1():
     return ENTERPRISE_GROUPS_V1.is_enabled()
 
 
+def enterprise_customer_support_tool():
+    """
+    Returns whether the enterprise customer support tool is enabled.
+    """
+    return ENTERPRISE_CUSTOMER_SUPPORT_TOOL.is_enabled()
+
+
 def enterprise_features():
     """
     Returns a dict of enterprise Waffle-based feature flags.
@@ -73,4 +92,5 @@ def enterprise_features():
         'top_down_assignment_real_time_lcm': top_down_assignment_real_time_lcm(),
         'feature_prequery_search_suggestions': feature_prequery_search_suggestions(),
         'enterprise_groups_v1': enterprise_groups_v1(),
+        'enterprise_customer_support_tool': enterprise_customer_support_tool(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -302,7 +302,8 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                 'enterprise_features': {
                     'top_down_assignment_real_time_lcm': False,
                     'feature_prequery_search_suggestions': False,
-                    'enterprise_groups_v1': False
+                    'enterprise_groups_v1': False,
+                    'enterprise_customer_support_tool': False,
                 }
             }
             assert response == mock_empty_200_success_response


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
