### PR TITLE
feat: extend enterprise customer serializer to add detail for support tool

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.21.6]
+---------
+* feat: extend enterprise customer serializer to add detail for support tool
+
 [4.21.5]
 ---------
 * feat: allow PAs to access all enterprise customers

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.21.5"
+__version__ = "4.21.6"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -37,6 +37,7 @@ from enterprise.models import (
 from enterprise.utils import (
     CourseEnrollmentDowngradeError,
     CourseEnrollmentPermissionError,
+    get_active_sso_configurations_for_customer,
     get_integrations_for_customers,
     get_last_course_run_end_date,
     has_course_run_available_for_enrollment,
@@ -339,6 +340,38 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
                 if not getattr(obj, notification_filter.filter, None):
                     notification_queryset = None
         return AdminNotificationSerializer(notification_queryset).data
+
+
+class EnterpriseCustomerSupportToolSerializer(EnterpriseCustomerSerializer):
+    """
+    Extends the EnterpriseCustomerSerializer with additional fields to needed in the
+    MFE Support tool.
+    """
+    class Meta:
+        model = models.EnterpriseCustomer
+        fields = (
+            'uuid', 'name', 'slug', 'active', 'auth_org_id', 'site', 'enable_data_sharing_consent',
+            'enforce_data_sharing_consent', 'branding_configuration', 'disable_expiry_messaging_for_learner_credit',
+            'identity_provider', 'enable_audit_enrollment', 'replace_sensitive_sso_username',
+            'enable_portal_code_management_screen', 'sync_learner_profile_data', 'enable_audit_data_reporting',
+            'enable_learner_portal', 'enable_learner_portal_offers', 'enable_portal_learner_credit_management_screen',
+            'enable_executive_education_2U_fulfillment', 'enable_portal_reporting_config_screen',
+            'enable_portal_saml_configuration_screen', 'contact_email',
+            'enable_portal_subscription_management_screen', 'hide_course_original_price', 'enable_analytics_screen',
+            'enable_integrated_customer_learner_portal_search', 'enable_generation_of_api_credentials',
+            'enable_portal_lms_configurations_screen', 'sender_alias', 'identity_providers',
+            'enterprise_customer_catalogs', 'reply_to', 'enterprise_notification_banner', 'hide_labor_market_data',
+            'modified', 'enable_universal_link', 'enable_browse_and_request', 'admin_users',
+            'enable_learner_portal_sidebar_message', 'learner_portal_sidebar_content',
+            'enable_pathways', 'enable_programs', 'enable_demo_data_for_analytics_and_lpr', 'enable_academies',
+            'enable_one_academy', 'active_integrations', 'show_videos_in_learner_portal_search_results',
+            'default_language', 'country', 'enable_slug_login', 'active_sso_configurations'
+        )
+
+    active_sso_configurations = serializers.SerializerMethodField()
+
+    def get_active_sso_configurations(self, obj):
+        return get_active_sso_configurations_for_customer(obj.uuid)
 
 
 class EnterpriseCustomerBasicSerializer(serializers.ModelSerializer):

--- a/enterprise/api/v1/views/enterprise_customer.py
+++ b/enterprise/api/v1/views/enterprise_customer.py
@@ -90,6 +90,8 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
     def get_serializer_class(self):
         if self.action == 'basic_list':
             return serializers.EnterpriseCustomerBasicSerializer
+        if self.action == 'support_tool':
+            return serializers.EnterpriseCustomerSupportToolSerializer
         return self.serializer_class
 
     @action(detail=False)
@@ -110,6 +112,22 @@ class EnterpriseCustomerViewSet(EnterpriseReadWriteModelViewSet):
             queryset = queryset.filter(name__istartswith=startswith)
         if name_or_uuid:
             queryset = queryset.filter(Q(name__icontains=name_or_uuid) | Q(uuid__icontains=name_or_uuid))
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
+    @action(detail=False)
+    # pylint: disable=unused-argument
+    def support_tool(self, request, *arg, **kwargs):
+        """
+        Enterprise Customer's detail data for the support tool
+
+        Supported query param:
+        - uuid: filter the enterprise customer uuid .
+        """
+        enterprise_uuid = request.GET.get('uuid')
+        queryset = self.get_queryset().order_by('name')
+        if enterprise_uuid:
+            queryset = queryset.filter(uuid=enterprise_uuid)
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 


### PR DESCRIPTION
# Description
Extend the EnterpriseCustomerSerializer in order to display the information in the support tool's customer datatable.

# Testing
1. Check that you have at least one existing customer here, if not, create one: http://localhost:18000/admin/enterprise/enterprisecustomer/ 
2. Create an SSO configuration for that existing customer here: http://localhost:18000/admin/enterprise/enterprisecustomerssoconfiguration/
3. Create an external LMS integration for that existing customer here: http://localhost:18000/admin/blackboard/blackboardenterprisecustomerconfiguration/ 
4. After creating the SSO and LMS integration, visit this endpoint http://localhost:18000/enterprise/api/v1/enterprise-customer/support_tool/?uuid=975863ad-d54a-469a-96d9-76d72f7431be and verify that you see `active_sso_configurations` and `active_integrations`

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
