### PR TITLE
Fixed search fetch crashing because of server taking too long for api request logs

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.21.9]
+---------
+* fix: fixed search fetch crashing because of server taking too long for api request logs.
+
 [4.21.8]
 ---------
 * fix: fixed 500 error for search filter for api request logs in admin view.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.21.8"
+__version__ = "4.21.9"

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -142,7 +142,7 @@ class IntegratedChannelAPIRequestLogAdmin(admin.ModelAdmin):
         Handle non-integer search terms and filter by 'enterprise_customer_configuration_id' if valid.
         """
         queryset, use_distinct = super().get_search_results(request, queryset, search_term)
-        
+
         try:
             enterprise_customer_configuration_id = int(search_term)
             queryset |= self.model.objects.filter(
@@ -150,7 +150,7 @@ class IntegratedChannelAPIRequestLogAdmin(admin.ModelAdmin):
             )
         except ValueError:
             pass
-        
+
         return queryset, use_distinct
 
     class Meta:

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -106,6 +106,7 @@ class IntegratedChannelAPIRequestLogAdmin(admin.ModelAdmin):
     search_fields = [
         "enterprise_customer__name__icontains",
         "enterprise_customer__uuid__iexact",
+        "enterprise_customer_configuration_id__iexact",
         "endpoint__icontains",
     ]
     readonly_fields = [
@@ -136,22 +137,6 @@ class IntegratedChannelAPIRequestLogAdmin(admin.ModelAdmin):
             'enterprise_customer__uuid',
             'enterprise_customer_configuration_id'
         )
-
-    def get_search_results(self, request, queryset, search_term):
-        """
-        Handle non-integer search terms and filter by 'enterprise_customer_configuration_id' if valid.
-        """
-        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
-
-        try:
-            enterprise_customer_configuration_id = int(search_term)
-            queryset |= self.model.objects.filter(
-                enterprise_customer_configuration_id=enterprise_customer_configuration_id
-            )
-        except ValueError:
-            pass
-
-        return queryset, use_distinct
 
     class Meta:
         model = IntegratedChannelAPIRequestLogs

--- a/integrated_channels/integrated_channel/admin/__init__.py
+++ b/integrated_channels/integrated_channel/admin/__init__.py
@@ -104,14 +104,9 @@ class IntegratedChannelAPIRequestLogAdmin(admin.ModelAdmin):
         "status_code",
     ]
     search_fields = [
-        "status_code",
-        "enterprise_customer__name",
-        "enterprise_customer__uuid",
-        "enterprise_customer_configuration_id",
-        "endpoint",
-        "time_taken",
-        "response_body",
-        "payload",
+        "enterprise_customer__name__icontains",
+        "enterprise_customer__uuid__iexact",
+        "endpoint__icontains",
     ]
     readonly_fields = [
         "status_code",
@@ -122,12 +117,41 @@ class IntegratedChannelAPIRequestLogAdmin(admin.ModelAdmin):
         "response_body",
         "payload",
     ]
+    list_filter = ('status_code',)
 
     list_per_page = 20
 
     def get_queryset(self, request):
+        """
+        Optimize queryset by selecting related 'enterprise_customer' and limiting fields.
+        """
         queryset = super().get_queryset(request)
-        return queryset.select_related('enterprise_customer')
+        return queryset.select_related('enterprise_customer').only(
+            'id',
+            'endpoint',
+            'enterprise_customer_id',
+            'time_taken',
+            'status_code',
+            'enterprise_customer__name',
+            'enterprise_customer__uuid',
+            'enterprise_customer_configuration_id'
+        )
+
+    def get_search_results(self, request, queryset, search_term):
+        """
+        Handle non-integer search terms and filter by 'enterprise_customer_configuration_id' if valid.
+        """
+        queryset, use_distinct = super().get_search_results(request, queryset, search_term)
+        
+        try:
+            enterprise_customer_configuration_id = int(search_term)
+            queryset |= self.model.objects.filter(
+                enterprise_customer_configuration_id=enterprise_customer_configuration_id
+            )
+        except ValueError:
+            pass
+        
+        return queryset, use_distinct
 
     class Meta:
         model = IntegratedChannelAPIRequestLogs

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -24,8 +24,7 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         self.site = AdminSite()
         self.admin = IntegratedChannelAPIRequestLogAdmin(IntegratedChannelAPIRequestLogs, self.site)
 
-        # Create test data
-        self.enterprise_customer = factories.EnterpriseCustomerFactory()
+        self.enterprise_customer = factories.EnterpriseCustomerFactory(name='Test Enterprise')
         self.log_entry = IntegratedChannelAPIRequestLogs.objects.create(
             enterprise_customer=self.enterprise_customer,
             enterprise_customer_configuration_id=1,
@@ -40,7 +39,7 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         """
         Test that the get_queryset method optimizes query by using select_related and only selecting specified fields.
         """
-        request = None  # or mock a request object if needed
+        request = None
         
         with CaptureQueriesContext(connection) as queries:
             queryset = self.admin.get_queryset(request)

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -68,5 +68,8 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         self.assertEqual(log_entry.endpoint, "http://test.com")
         self.assertEqual(log_entry.enterprise_customer.name, "Test Enterprise")
         
-        with self.assertRaises(AttributeError):
+        # Verify that accessing an unselected field causes an additional query
+        with CaptureQueriesContext(connection) as queries:
             _ = log_entry.payload
+
+        self.assertEqual(len(queries), 1, "Accessing unselected field should cause exactly one additional query")

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -41,39 +41,33 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         Test that the get_queryset method optimizes query by using select_related and only selecting specified fields.
         """
         request = None  # or mock a request object if needed
-
+        
         with CaptureQueriesContext(connection) as queries:
             queryset = self.admin.get_queryset(request)
-            # Force evaluation of the queryset
+
             list(queryset)
 
-        # Check that only one query is executed (thanks to select_related)
         self.assertEqual(len(queries), 1)
 
-        # Check that the query includes both the main table and the related table
         query = queries[0]['sql']
-        self.assertIn('integrated_channel_api_request_logs', query)
-        self.assertIn('enterprise_customer', query)
+        self.assertIn('integrated_channel_integratedchannelapirequestlogs', query)
+        self.assertIn('enterprise_enterprisecustomer', query)
 
-        # Check that only the specified fields are selected
-        self.assertIn('integrated_channel_api_request_logs.id', query)
-        self.assertIn('integrated_channel_api_request_logs.endpoint', query)
-        self.assertIn('integrated_channel_api_request_logs.enterprise_customer_id', query)
-        self.assertIn('integrated_channel_api_request_logs.time_taken', query)
-        self.assertIn('integrated_channel_api_request_logs.status_code', query)
-        self.assertIn('enterprise_customer.name', query)
-        self.assertIn('enterprise_customer.uuid', query)
-        self.assertIn('integrated_channel_api_request_logs.enterprise_customer_configuration_id', query)
+        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."id"', query)
+        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."endpoint"', query)
+        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."enterprise_customer_id"', query)
+        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."time_taken"', query)
+        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."status_code"', query)
+        self.assertIn('"enterprise_enterprisecustomer"."name"', query)
+        self.assertIn('"enterprise_enterprisecustomer"."uuid"', query)
+        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."enterprise_customer_configuration_id"', query)
 
-        # Check that unspecified fields are not selected
-        self.assertNotIn('integrated_channel_api_request_logs.payload', query)
-        self.assertNotIn('integrated_channel_api_request_logs.response_body', query)
+        self.assertNotIn('payload', query)
+        self.assertNotIn('response_body', query)
 
-        # Verify that the queryset returns the expected data
         log_entry = queryset.get(id=self.log_entry.id)
         self.assertEqual(log_entry.endpoint, "http://test.com")
         self.assertEqual(log_entry.enterprise_customer.name, "Test Enterprise")
-
-        # Verify that accessing an unselected field raises an error
+        
         with self.assertRaises(AttributeError):
             _ = log_entry.payload

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -1,9 +1,15 @@
-from django.test import TestCase
+"""
+Tests for the IntegratedChannelAPIRequest admin module in `edx-enterprise`.
+"""
+
 from django.contrib.admin.sites import AdminSite
 from django.db import connection
+from django.test import TestCase
 from django.test.utils import CaptureQueriesContext
+
 from integrated_channels.integrated_channel.admin import IntegratedChannelAPIRequestLogAdmin
-from integrated_channels.integrated_channel.models import IntegratedChannelAPIRequestLogs, EnterpriseCustomer
+from integrated_channels.integrated_channel.models import IntegratedChannelAPIRequestLogs
+from test_utils import factories
 
 
 class IntegratedChannelAPIRequestLogAdminTest(TestCase):
@@ -17,9 +23,9 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         """
         self.site = AdminSite()
         self.admin = IntegratedChannelAPIRequestLogAdmin(IntegratedChannelAPIRequestLogs, self.site)
-        
+
         # Create test data
-        self.enterprise_customer = EnterpriseCustomer.objects.create(name="Test Enterprise", uuid="test-uuid")
+        self.enterprise_customer = factories.EnterpriseCustomerFactory()
         self.log_entry = IntegratedChannelAPIRequestLogs.objects.create(
             enterprise_customer=self.enterprise_customer,
             enterprise_customer_configuration_id=1,
@@ -32,10 +38,10 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
 
     def test_get_queryset_optimization(self):
         """
-        Test that the get_queryset method optimizes the query by using select_related and only selecting specified fields.
+        Test that the get_queryset method optimizes query by using select_related and only selecting specified fields.
         """
         request = None  # or mock a request object if needed
-        
+
         with CaptureQueriesContext(connection) as queries:
             queryset = self.admin.get_queryset(request)
             # Force evaluation of the queryset
@@ -67,7 +73,7 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         log_entry = queryset.get(id=self.log_entry.id)
         self.assertEqual(log_entry.endpoint, "http://test.com")
         self.assertEqual(log_entry.enterprise_customer.name, "Test Enterprise")
-        
+
         # Verify that accessing an unselected field raises an error
         with self.assertRaises(AttributeError):
             _ = log_entry.payload

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -1,0 +1,73 @@
+from django.test import TestCase
+from django.contrib.admin.sites import AdminSite
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
+from integrated_channels.integrated_channel.admin import IntegratedChannelAPIRequestLogAdmin
+from integrated_channels.integrated_channel.models import IntegratedChannelAPIRequestLogs, EnterpriseCustomer
+
+
+class IntegratedChannelAPIRequestLogAdminTest(TestCase):
+    """
+    Test the admin functionality for the IntegratedChannelAPIRequestLogs model.
+    """
+
+    def setUp(self):
+        """
+        Set up the test environment by creating a test admin instance and sample data.
+        """
+        self.site = AdminSite()
+        self.admin = IntegratedChannelAPIRequestLogAdmin(IntegratedChannelAPIRequestLogs, self.site)
+        
+        # Create test data
+        self.enterprise_customer = EnterpriseCustomer.objects.create(name="Test Enterprise", uuid="test-uuid")
+        self.log_entry = IntegratedChannelAPIRequestLogs.objects.create(
+            enterprise_customer=self.enterprise_customer,
+            enterprise_customer_configuration_id=1,
+            endpoint="http://test.com",
+            payload="test payload",
+            time_taken=1.0,
+            status_code=200,
+            response_body="test response"
+        )
+
+    def test_get_queryset_optimization(self):
+        """
+        Test that the get_queryset method optimizes the query by using select_related and only selecting specified fields.
+        """
+        request = None  # or mock a request object if needed
+        
+        with CaptureQueriesContext(connection) as queries:
+            queryset = self.admin.get_queryset(request)
+            # Force evaluation of the queryset
+            list(queryset)
+
+        # Check that only one query is executed (thanks to select_related)
+        self.assertEqual(len(queries), 1)
+
+        # Check that the query includes both the main table and the related table
+        query = queries[0]['sql']
+        self.assertIn('integrated_channel_api_request_logs', query)
+        self.assertIn('enterprise_customer', query)
+
+        # Check that only the specified fields are selected
+        self.assertIn('integrated_channel_api_request_logs.id', query)
+        self.assertIn('integrated_channel_api_request_logs.endpoint', query)
+        self.assertIn('integrated_channel_api_request_logs.enterprise_customer_id', query)
+        self.assertIn('integrated_channel_api_request_logs.time_taken', query)
+        self.assertIn('integrated_channel_api_request_logs.status_code', query)
+        self.assertIn('enterprise_customer.name', query)
+        self.assertIn('enterprise_customer.uuid', query)
+        self.assertIn('integrated_channel_api_request_logs.enterprise_customer_configuration_id', query)
+
+        # Check that unspecified fields are not selected
+        self.assertNotIn('integrated_channel_api_request_logs.payload', query)
+        self.assertNotIn('integrated_channel_api_request_logs.response_body', query)
+
+        # Verify that the queryset returns the expected data
+        log_entry = queryset.get(id=self.log_entry.id)
+        self.assertEqual(log_entry.endpoint, "http://test.com")
+        self.assertEqual(log_entry.enterprise_customer.name, "Test Enterprise")
+        
+        # Verify that accessing an unselected field raises an error
+        with self.assertRaises(AttributeError):
+            _ = log_entry.payload

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -40,7 +40,7 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         Test that the get_queryset method optimizes query by using select_related and only selecting specified fields.
         """
         request = None
-        
+
         with CaptureQueriesContext(connection) as queries:
             queryset = self.admin.get_queryset(request)
 
@@ -59,7 +59,9 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."status_code"', query)
         self.assertIn('"enterprise_enterprisecustomer"."name"', query)
         self.assertIn('"enterprise_enterprisecustomer"."uuid"', query)
-        self.assertIn('"integrated_channel_integratedchannelapirequestlogs"."enterprise_customer_configuration_id"', query)
+        self.assertIn(
+            '"integrated_channel_integratedchannelapirequestlogs"."enterprise_customer_configuration_id"', query
+        )
 
         self.assertNotIn('payload', query)
         self.assertNotIn('response_body', query)
@@ -67,7 +69,7 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
         log_entry = queryset.get(id=self.log_entry.id)
         self.assertEqual(log_entry.endpoint, "http://test.com")
         self.assertEqual(log_entry.enterprise_customer.name, "Test Enterprise")
-        
+
         # Verify that accessing an unselected field causes an additional query
         with CaptureQueriesContext(connection) as queries:
             _ = log_entry.payload


### PR DESCRIPTION
Description:
Fixed search fetch crashing because of server taking too long for api request logs.

JIRA:
https://2u-internal.atlassian.net/jira/software/c/projects/ENT/issues/ENT-9175