### PR TITLE
fix: don't allow saving duplicate EnterpriseCatalogQuery content_filter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.23.1]
+---------
+* fix: don't allow saving duplicate EnterpriseCatalogQuery content_filter
+
 [4.22.6]
 ----------
 * feat: add created time to reponse

--- a/docs/decisions/0014-enterprise-catalog-sync-catalogs.rst
+++ b/docs/decisions/0014-enterprise-catalog-sync-catalogs.rst
@@ -1,0 +1,43 @@
+Catalog syncing behavior with enterprise-catalog service
+------------------------------------------------------------------------------
+
+Status
+======
+
+Accepted
+
+Context
+=======
+We would like to have a way to reuse a saved set of courses configured by a query and use them in multiple catalogs across customers.
+
+
+Decisions
+=========
+
+- **Sync catalog/customer data with enterprise-catalog**
+As the catalog data is saved in both edx-enterprise and enterprise-catalog, we need to make sure that catalog data is consistent across both.
+In the context of edx-enterprise, changes to EnterpriseCatalogQuery and EnterpriseCustomerCatalog will be propagated to their counterparts
+in the enterprise-catalog service.
+
+
+Consequences
+============
+
+- **EnterpriseCatalogQuery Sync Process**
+The enterprise-catalog service enforces a uniqueness constraint for the `content_filter` field, and so edx-enterprise must enforce it as well
+or the sync operation will fail and the entities will be out of sync with each other.
+
+In the Django Admin console, whenever a new EnterpriseCatalogQuery is created, or an existing one edited, we first query enterprise-catalog to see if its 
+`content_filter` is already in use (by calculating the `content_filter` hash via a call to enterprise-catalog, and then attempting to retrieve
+an existing catalog query from enterprise-catalog by that hash).  If the new `content_filter` is unique, we will save the changes and propagate
+them to enterprise-catalog. 
+
+If the `content_filter` is *not* unique, we display an error on the EnterpriseCatalogQuery edit page and don't commit the change. 
+
+
+- **EnterpriseCustomerCatalog Sync Process**
+In the Django Admin console, whenever a EnterpriseCustomerCatalog is created, or an existing one is edited, we simply pass the changes on to 
+enterprise-catalog without doing any checks for duplicates.
+
+When it comes to custom `content_filter` fields attached to EnterpriseCustomerCatalog objects, enterprise-catalog doesn't care if they are 
+non-unique, and will simply update the corresponding catalog entity to point to the catalog query that matches the `content_filter`.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.22.6"
+__version__ = "4.23.1"

--- a/enterprise/api_client/client.py
+++ b/enterprise/api_client/client.py
@@ -31,14 +31,15 @@ class APIClientMixin:
     APPEND_SLASH = False
     API_BASE_URL = ""
 
-    def get_api_url(self, path):
+    def get_api_url(self, path, append_slash=None):
         """
         Helper method to construct the API URL.
 
         Args:
             path (str): the API endpoint path string.
         """
-        return urljoin(f"{self.API_BASE_URL}/", f"{path.strip('/')}{'/' if self.APPEND_SLASH else ''}")
+        _APPEND_SLASH = self.APPEND_SLASH if append_slash is None else append_slash
+        return urljoin(f"{self.API_BASE_URL}/", f"{path.strip('/')}{'/' if _APPEND_SLASH else ''}")
 
 
 class BackendServiceAPIClient(APIClientMixin):


### PR DESCRIPTION
## Problem

[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-8661)

The EnterpriseCatalogQuery model is synced to a corresponding [CatalogQuery model](https://github.com/openedx/enterprise-catalog/blob/0c832240bd67a1748406d126fd0305eeb63733a2/enterprise_catalog/apps/catalog/models.py#L54) in enterprise-catalog.  Currently, if we save a EnterpriseCatalogQuery with a content_filter value that is a duplicate of another, and try to update the corresponding CatalogQuery, the update will fail and the two entities will be in an inconsistent state.

## Solution

When saving an EnterpriseCatalogQuery model with a changed content_filter, we will now check to see if the new content_filter already exists in enterprise-catalog, and raise a ValidationError if it does, showing an error on the admin page.

![image](https://github.com/user-attachments/assets/5a7d4a60-b543-4e98-8308-fe0d91a1e11e)



**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
