### PR TITLE
Feat: Add option to show soft deleted group memberships in django admin

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.23.9]
+----------
+* feat: Add option to show soft deleted group memberships in django admin
+
 [4.23.8]
 ----------
 * feat: updating enterprise-customer-support endpoint

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.23.8"
+__version__ = "4.23.9"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -1273,7 +1273,11 @@ class EnterpriseGroupMembershipAdmin(admin.ModelAdmin):
         """
         Return a QuerySet of all model instances.
         """
-        qs = self.model.available_objects.get_queryset()
+        show_soft_deletes = request.GET.get('is_removed__exact', False)
+        if show_soft_deletes:
+            qs = self.model.all_objects.get_queryset()
+        else:
+            qs = self.model.available_objects.get_queryset()
 
         ordering = self.get_ordering(request)
         if ordering:

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -1255,6 +1255,7 @@ class EnterpriseGroupMembershipAdmin(admin.ModelAdmin):
     """
     model = models.EnterpriseGroupMembership
     list_display = ('group', 'membership_user',)
+    list_filter = ('is_removed',)
     search_fields = (
         'uuid',
         'group__uuid',
@@ -1267,6 +1268,18 @@ class EnterpriseGroupMembershipAdmin(admin.ModelAdmin):
         'enterprise_customer_user',
         'pending_enterprise_customer_user',
     )
+
+    def get_queryset(self, request):
+        """
+        Return a QuerySet of all model instances.
+        """
+        qs = self.model.available_objects.get_queryset()
+
+        ordering = self.get_ordering(request)
+        if ordering:
+            qs = qs.order_by(*ordering)
+
+        return qs
 
 
 @admin.register(models.LearnerCreditEnterpriseCourseEnrollment)

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -1254,7 +1254,7 @@ class EnterpriseGroupMembershipAdmin(admin.ModelAdmin):
     Django admin for EnterpriseGroupMembership model.
     """
     model = models.EnterpriseGroupMembership
-    list_display = ('group', 'membership_user',)
+    list_display = ('group', 'membership_user', 'is_removed')
     list_filter = ('is_removed',)
     search_fields = (
         'uuid',

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -1,12 +1,13 @@
 """
 Tests for the IntegratedChannelAPIRequest admin module in `edx-enterprise`.
 """
-
 from django.contrib.admin.sites import AdminSite
 from django.db import connection
-from django.test import TestCase
+from django.test import TestCase, RequestFactory
 from django.test.utils import CaptureQueriesContext
 
+from enterprise.models import EnterpriseGroupMembership
+from enterprise.admin import EnterpriseGroupMembershipAdmin
 from integrated_channels.integrated_channel.admin import IntegratedChannelAPIRequestLogAdmin
 from integrated_channels.integrated_channel.models import IntegratedChannelAPIRequestLogs
 from test_utils import factories
@@ -75,3 +76,50 @@ class IntegratedChannelAPIRequestLogAdminTest(TestCase):
             _ = log_entry.payload
 
         self.assertEqual(len(queries), 1, "Accessing unselected field should cause exactly one additional query")
+
+
+class EnterpriseGroupMembershipAdminTest(TestCase):
+    """
+    Test the admin functionality for the EnterpriseGroupMembership model.
+    """
+
+    def setUp(self):
+        """
+        Set up the test environment by creating a test admin instance and sample data.
+        """
+        self.site = AdminSite()
+        self.admin = EnterpriseGroupMembershipAdmin(EnterpriseGroupMembership, self.site)
+
+        self.egm_1 = factories.EnterpriseGroupMembershipFactory()
+        self.egm_2 = factories.EnterpriseGroupMembershipFactory()
+
+        # mark enterprise group membership 2 to is_removed = True
+        self.egm_2.is_removed = True
+        self.egm_2.save()
+
+    def test_get_queryset(self):
+        """
+        Test that the get_queryset method optimizes query by using select_related and only selecting specified fields.
+        """
+        request = RequestFactory().get("/")
+        # ROUND 1 - set `is_removed__exact` = False
+        request.GET = {'is_removed__exact': False}
+        queryset = self.admin.get_queryset(request)
+        results = list(queryset)
+
+        # should only return the non-removed results
+        self.assertEqual(len(results), 1)
+        result_egm = results[0]
+        self.assertEqual(self.egm_1.uuid, result_egm.uuid)
+        # ensure is_removed = True, i.e. matching egm_1
+        self.assertEqual(self.egm_1.is_removed, result_egm.is_removed)
+
+        # ROUND 2 - set `is_removed__exact` = True
+        request.GET = {'is_removed__exact': True}
+        queryset = self.admin.get_queryset(request)
+        results = list(queryset)
+
+        # should return both results
+        self.assertEqual(len(results), 2)
+        # is_removed value should differ between the two results
+        self.assertNotEquals(results[0].is_removed, results[1].is_removed)

--- a/tests/test_admin/test_admin.py
+++ b/tests/test_admin/test_admin.py
@@ -3,11 +3,11 @@ Tests for the IntegratedChannelAPIRequest admin module in `edx-enterprise`.
 """
 from django.contrib.admin.sites import AdminSite
 from django.db import connection
-from django.test import TestCase, RequestFactory
+from django.test import RequestFactory, TestCase
 from django.test.utils import CaptureQueriesContext
 
-from enterprise.models import EnterpriseGroupMembership
 from enterprise.admin import EnterpriseGroupMembershipAdmin
+from enterprise.models import EnterpriseGroupMembership
 from integrated_channels.integrated_channel.admin import IntegratedChannelAPIRequestLogAdmin
 from integrated_channels.integrated_channel.models import IntegratedChannelAPIRequestLogs
 from test_utils import factories
@@ -122,4 +122,4 @@ class EnterpriseGroupMembershipAdminTest(TestCase):
         # should return both results
         self.assertEqual(len(results), 2)
         # is_removed value should differ between the two results
-        self.assertNotEquals(results[0].is_removed, results[1].is_removed)
+        self.assertNotEqual(results[0].is_removed, results[1].is_removed)


### PR DESCRIPTION
Adding option to show soft deleted group memberships in django admin
JIRA: https://2u-internal.atlassian.net/browse/ENT-9116

**Testing**
Setup:
EnterpriseCustomerUser `Davidson Jones` is part of soft deleted group membership by marking their record as "is_removed" = 1
EnterpriseCustomerUser `Jackson LLC` is not part of soft deleted group membership and their record has "is_removed" = 0

1. Keeping default behavior to only show non-soft deleted results:
<img width="1308" alt="all users" src="https://github.com/user-attachments/assets/5dd4d3f2-8025-4333-a953-002e1ede8eb4">


2. Filtering by `is_removed` = No shows non-deleted results (Jackson LLC):
<img width="1207" alt="not deleted" src="https://github.com/user-attachments/assets/2d5fe4ae-0bd6-48c0-8299-5be9aec8c0fb">


3. Filtering by `is_removed` = Yes shows only soft-deleted result (Davidson Jones):
<img width="1205" alt="soft deleted" src="https://github.com/user-attachments/assets/4cdc1bcf-b745-4024-b651-ca4c5ff3aed4">


4. Searching for soft deleted group membership displays warning
<img width="816" alt="is_removed" src="https://github.com/user-attachments/assets/4ace5a17-8526-4dd6-b9ef-f6d219fb0f7d">


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
