### PR TITLE
fix: send LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED from the correct place.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.25.9]
+----------
+* fix: send LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED from the correct place.
+
 [4.25.8]
 ----------
 * feat: added migration for removing unencrypted client credentials

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.25.8"
+__version__ = "4.25.9"

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -2097,13 +2097,31 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
     @property
     def license(self):
         """
-        Returns the license associated with this enterprise course enrollment if one exists.
+        Returns the license fulfillment associated with this enterprise course enrollment if one exists.
         """
         try:
             associated_license = self.licensedenterprisecourseenrollment_enrollment_fulfillment  # pylint: disable=no-member
         except LicensedEnterpriseCourseEnrollment.DoesNotExist:
             associated_license = None
         return associated_license
+
+    @property
+    def learner_credit_fulfillment(self):
+        """
+        Returns the Learner Credit fulfillment associated with this enterprise course enrollment if one exists.
+        """
+        try:
+            associated_fulfillment = self.learnercreditenterprisecourseenrollment_enrollment_fulfillment  # pylint: disable=no-member
+        except LearnerCreditEnterpriseCourseEnrollment.DoesNotExist:
+            associated_fulfillment = None
+        return associated_fulfillment
+
+    @property
+    def fulfillment(self):
+        """
+        Find and return the related EnterpriseFulfillmentSource subclass, or None.
+        """
+        return self.license or self.learner_credit_fulfillment
 
     @cached_property
     def course_enrollment(self):
@@ -2196,6 +2214,46 @@ class EnterpriseCourseEnrollment(TimeStampedModel):
             )
             return []
 
+    def set_unenrolled(self, desired_unenrolled):
+        """
+        Idempotently set this object's fields to appear (un)enrolled and (un)saved-for-later.
+
+        Also, attempt to revoke any related fulfillment, which in turn is also idempotent.
+
+        This method and the fulfillment's revoke() call each other!!! If you edit either method, make sure to preserve
+        base cases that terminate infinite recursion.
+
+        TODO: revoke entitlements as well?
+        """
+        changed = False
+        if desired_unenrolled:
+            if not self.unenrolled or not self.saved_for_later:
+                self.saved_for_later = True
+                self.unenrolled = True
+                self.unenrolled_at = localized_utcnow()
+                changed = True
+        else:
+            if self.unenrolled or self.saved_for_later:
+                self.saved_for_later = False
+                self.unenrolled = False
+                self.unenrolled_at = None
+                changed = True
+        if changed:
+            LOGGER.info(
+                f"Marking EnterpriseCourseEnrollment as unenrolled={desired_unenrolled} "
+                f"for LMS user {self.enterprise_customer_user.user_id} "
+                f"and course {self.course_id}"
+            )
+            self.save()
+            # Find and revoke/reactivate any related fulfillment.
+            # By only updating the related object on updates to self, we prevent infinite recursion.
+            if fulfillment := self.fulfillment:
+                if desired_unenrolled and not fulfillment.is_revoked:
+                    fulfillment.revoke()
+                # Fulfillment reactivation on ECE reenrollment is unsupported. We'd need to collect a
+                # transaction UUID from the caller, but the caller at the time of writing is not aware of any
+                # transaction.
+
     def __str__(self):
         """
         Create string representation of the enrollment.
@@ -2285,34 +2343,50 @@ class EnterpriseFulfillmentSource(TimeStampedModel):
 
     def revoke(self):
         """
-        Marks this object as revoked and marks the associated EnterpriseCourseEnrollment
-        as "saved for later".  This object and the associated EnterpriseCourseEnrollment are both saved.
+        Idempotently unenroll/revoke this fulfillment and associated EnterpriseCourseEnrollment.
 
-        Subclasses may override this function to additionally emit revocation events.
+        This method and EnterpriseCourseEnrollment.set_unenrolled() call each other!!! If you edit either method, make
+        sure to preserve base cases that terminate infinite recursion.
 
-        TODO: revoke entitlements as well?
+        Notes:
+        * This object and the associated EnterpriseCourseEnrollment may both be saved.
+        * Subclasses may override this function to additionally emit revocation events.
+
+        Returns:
+            bool: True if self.is_revoked was changed.
         """
-        if self.enterprise_course_enrollment:
-            self.enterprise_course_enrollment.saved_for_later = True
-            self.enterprise_course_enrollment.unenrolled = True
-            self.enterprise_course_enrollment.unenrolled_at = localized_utcnow()
-            self.enterprise_course_enrollment.save()
-
-        self.is_revoked = True
-        self.save()
+        changed = False
+        if not self.is_revoked:
+            LOGGER.info(f"Marking fulfillment {str(self)} as revoked.")
+            changed = True
+            self.is_revoked = True
+            self.save()
+            # Find and unenroll any related EnterpriseCourseEnrollment.
+            # By only updating the related object on updates to self, we prevent infinite recursion.
+            if ece := self.enterprise_course_enrollment:
+                if not ece.unenrolled:  # redundant base case to terminate loops.
+                    ece.set_unenrolled(True)
+        return changed
 
     def reactivate(self, **kwargs):
         """
         Idempotently reactivates this enterprise fulfillment source.
-        """
-        if self.enterprise_course_enrollment:
-            self.enterprise_course_enrollment.saved_for_later = False
-            self.enterprise_course_enrollment.unenrolled = False
-            self.enterprise_course_enrollment.unenrolled_at = None
-            self.enterprise_course_enrollment.save()
 
-        self.is_revoked = False
-        self.save()
+        Returns:
+            bool: True if self.is_revoked was changed.
+        """
+        changed = False
+        if self.is_revoked:
+            LOGGER.info(f"Marking fulfillment {str(self)} as reactivated.")
+            changed = True
+            self.is_revoked = False
+            self.save()
+            # Find and REenroll any related EnterpriseCourseEnrollment.
+            # By only updating the related object on updates to self, we prevent infinite recursion.
+            if ece := self.enterprise_course_enrollment:
+                if ece.unenrolled:  # redundant base case to terminate loops.
+                    ece.set_unenrolled(False)
+        return changed
 
     def __str__(self):
         """
@@ -2337,8 +2411,9 @@ class LearnerCreditEnterpriseCourseEnrollment(EnterpriseFulfillmentSource):
         """
         Revoke this LearnerCreditEnterpriseCourseEnrollment, and emit a revoked event.
         """
-        super().revoke()
-        send_learner_credit_course_enrollment_revoked_event(self)
+        if changed := super().revoke():
+            send_learner_credit_course_enrollment_revoked_event(self)
+        return changed
 
     def reactivate(self, transaction_id=None, **kwargs):
         """
@@ -2354,7 +2429,7 @@ class LearnerCreditEnterpriseCourseEnrollment(EnterpriseFulfillmentSource):
                 f"getting this enrollment for free."
             )
         self.transaction_id = transaction_id
-        super().reactivate()
+        return super().reactivate()
 
     transaction_id = models.UUIDField(
         primary_key=False,

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -17,7 +17,6 @@ from enterprise.tasks import create_enterprise_enrollment
 from enterprise.utils import (
     NotConnectedToOpenEdX,
     get_default_catalog_content_filter,
-    localized_utcnow,
     unset_enterprise_learner_language,
     unset_language_of_all_enterprise_learners,
 )
@@ -364,14 +363,7 @@ def course_enrollment_changed_receiver(sender, **kwargs):     # pylint: disable=
         enterprise_customer_user__user_id=enrollment.user.id,
     ).first()
     if enterprise_enrollment and enrollment.is_active:
-        logger.info(
-            f"Marking EnterpriseCourseEnrollment as enrolled (unenrolled_at=NULL) for user {enrollment.user} and "
-            f"course {enrollment.course.course_key}"
-        )
-        enterprise_enrollment.unenrolled = False
-        enterprise_enrollment.unenrolled_at = None
-        enterprise_enrollment.saved_for_later = False
-        enterprise_enrollment.save()
+        enterprise_enrollment.set_unenrolled(False)
     # Note: If the CourseEnrollment is being flipped to is_active=False, then this handler is a no-op.
     # In that case, the `enterprise_unenrollment_receiver` signal handler below will run.
 
@@ -386,13 +378,7 @@ def enterprise_unenrollment_receiver(sender, **kwargs):     # pylint: disable=un
         enterprise_customer_user__user_id=enrollment.user.id,
     ).first()
     if enterprise_enrollment:
-        logger.info(
-            f"Marking EnterpriseCourseEnrollment as unenrolled for user {enrollment.user} and "
-            f"course {enrollment.course.course_key}"
-        )
-        enterprise_enrollment.unenrolled = True
-        enterprise_enrollment.unenrolled_at = localized_utcnow()
-        enterprise_enrollment.save()
+        enterprise_enrollment.set_unenrolled(True)
 
 
 def create_enterprise_enrollment_receiver(sender, instance, **kwargs):     # pylint: disable=unused-argument

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -4152,6 +4152,7 @@ class TestEnterpriseSubsidyFulfillmentViewSet(BaseTestEnterpriseAPIViews):
         # user. Because the requesting user is an operator user, they should be able to see this enrollment.
         second_lc_enrollment = factories.LearnerCreditEnterpriseCourseEnrollmentFactory(
             enterprise_course_enrollment=second_enterprise_course_enrollment,
+            is_revoked=True,
         )
 
         self.enterprise_course_enrollment.unenrolled = True
@@ -4209,6 +4210,7 @@ class TestEnterpriseSubsidyFulfillmentViewSet(BaseTestEnterpriseAPIViews):
         )
         old_learner_credit_enrollment = factories.LearnerCreditEnterpriseCourseEnrollmentFactory(
             enterprise_course_enrollment=old_enterprise_course_enrollment,
+            is_revoked=True,
         )
         response = self.client.get(
             reverse('enterprise-subsidy-fulfillment-unenrolled') + self.unenrolled_after_filter


### PR DESCRIPTION
I had originally tried emitting this event from the `/cancel_enrollment`
API endpoint, but in reality the LMS and Enterprise dashboards were
calling the `/change_enrollment` endpoint.  The former is called by
enterprise-subsidy on transaction reversal, i.e. NOT learner-initiated.
The latter is learner-initiated, and that's the original goal of this
work.

Changes in this commit:
* Update the event emission to live closer to the fulfillment
  model itself (inside `revoke()`).
* Ensure that when an EnterpriseCourseEnrollment is unenrolled, the
  related Fulfillment subclass is revoked. This is a best-effort to
  improve internal consistency during learner-initiated unenrollment.
* Consumers of the various enrollment models are now expected to call
  helper functions to unenroll/reenroll/revoke/reactivate rather than
  directly set internal fields.

ENT-9213