### PR TITLE
fix: Don't import HttpClientError from edx-rest-api-client

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.25.14]
+---------
+* fix: Don't import HttpClientError from edx-rest-api-client
+
 [4.25.13]
 ----------
 * feat: add logging to debug SAP SuccessFactors transmission issues
@@ -257,7 +261,7 @@ Unreleased
 
 [4.20.7]
 --------
-* fix: add name from profile to group membership details 
+* fix: add name from profile to group membership details
 
 [4.20.6]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.25.13"
+__version__ = "4.25.14"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -8,11 +8,11 @@ from collections import defaultdict
 from collections.abc import Iterable
 
 import pytz
-from edx_rest_api_client.exceptions import HttpClientError
 from oauth2_provider.generators import generate_client_id, generate_client_secret
 from rest_framework import serializers
 from rest_framework.fields import empty
 from rest_framework.settings import api_settings
+from slumber.exceptions import HttpClientError
 
 from django.contrib import auth
 from django.contrib.sites.models import Site

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -13,13 +13,13 @@ from uuid import UUID, uuid4
 from config_models.models import ConfigurationModel
 from django_countries.fields import CountryField
 from edx_rbac.models import UserRole, UserRoleAssignment
-from edx_rest_api_client.exceptions import HttpClientError
 from fernet_fields import EncryptedCharField
 from jsonfield.encoder import JSONEncoder
 from jsonfield.fields import JSONField
 from multi_email_field.fields import MultiEmailField
 from requests.exceptions import HTTPError
 from simple_history.models import HistoricalRecords
+from slumber.exceptions import HttpClientError
 
 from django.apps import apps
 from django.conf import settings

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -15,7 +15,7 @@ import bleach
 import pytz
 from edx_django_utils.cache import TieredCache
 from edx_django_utils.cache import get_cache_key as get_django_cache_key
-from edx_rest_api_client.exceptions import HttpClientError
+from slumber.exceptions import HttpClientError
 
 from django.apps import apps
 from django.conf import settings

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -13,9 +13,9 @@ import pytz
 import waffle  # pylint: disable=invalid-django-waffle-import
 from dateutil.parser import parse
 from edx_django_utils import monitoring
-from edx_rest_api_client.exceptions import HttpClientError
 from opaque_keys import InvalidKeyError
 from opaque_keys.edx.keys import CourseKey
+from slumber.exceptions import HttpClientError
 
 from django.apps import apps
 from django.conf import settings

--- a/test_utils/fake_enrollment_api.py
+++ b/test_utils/fake_enrollment_api.py
@@ -6,7 +6,7 @@ import datetime
 import json
 import re
 
-from edx_rest_api_client.exceptions import HttpClientError
+from slumber.exceptions import HttpClientError
 
 from django.conf import settings
 

--- a/tests/test_admin/test_view.py
+++ b/tests/test_admin/test_view.py
@@ -9,8 +9,8 @@ from unittest.mock import ANY
 from urllib.parse import urlencode
 
 import ddt
-from edx_rest_api_client.exceptions import HttpClientError
 from pytest import mark
+from slumber.exceptions import HttpClientError
 
 from django.conf import settings
 from django.contrib import auth

--- a/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
+++ b/tests/test_enterprise/views/test_grant_data_sharing_permissions.py
@@ -8,8 +8,8 @@ from unittest import mock
 
 import ddt
 from dateutil.parser import parse
-from edx_rest_api_client.exceptions import HttpClientError
 from pytest import mark
+from slumber.exceptions import HttpClientError
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -15,11 +15,11 @@ from uuid import UUID
 
 import ddt
 import responses
-from edx_rest_api_client.exceptions import HttpClientError
 from faker import Factory as FakerFactory
 from freezegun.api import freeze_time
 from opaque_keys.edx.keys import CourseKey
 from pytest import mark, raises
+from slumber.exceptions import HttpClientError
 from testfixtures import LogCapture
 
 from django.conf import settings


### PR DESCRIPTION
edx-rest-api-client was doing a wildcard import of the underlying
Slumber exception.  This wildcard impart has been droped in the latest
release 6.0.0

This change updates the edx-enterprise code to not rely on this
indirection to import the exception class.

Relevant change: https://github.com/openedx/edx-rest-api-client/commit/f3a7cd00565c62e45a9e39590e44d152ceafc277#diff-d34240bacb445782a73762a7380c1c64efc25ded2afb18245bf2256fda8157ff