### PR TITLE
feat: add waffle flag for groups v2 features

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.25.14]
+---------
+* feat: add a waffle flag for enterprise groups v2 feature
+
 [4.25.13]
 ----------
 * feat: add logging to debug SAP SuccessFactors transmission issues

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.25.13"
+__version__ = "4.25.14"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -55,6 +55,18 @@ ENTERPRISE_CUSTOMER_SUPPORT_TOOL = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.enterprise_groups_v2
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables enterprise groups feature
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2024-09-24
+ENTERPRISE_GROUPS_V2 = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.enterprise_groups_v2',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -77,6 +89,13 @@ def enterprise_groups_v1():
     return ENTERPRISE_GROUPS_V1.is_enabled()
 
 
+def enterprise_groups_v2():
+    """
+    Returns whether the enterprise groups v2 feature flag is enabled.
+    """
+    return ENTERPRISE_GROUPS_V2.is_enabled()
+
+
 def enterprise_customer_support_tool():
     """
     Returns whether the enterprise customer support tool is enabled.
@@ -93,4 +112,5 @@ def enterprise_features():
         'feature_prequery_search_suggestions': feature_prequery_search_suggestions(),
         'enterprise_groups_v1': enterprise_groups_v1(),
         'enterprise_customer_support_tool': enterprise_customer_support_tool(),
+        'enterprise_groups_v2': enterprise_groups_v2(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -304,6 +304,7 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                     'feature_prequery_search_suggestions': False,
                     'enterprise_groups_v1': False,
                     'enterprise_customer_support_tool': False,
+                    'enterprise_groups_v2': False,
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -72,6 +72,7 @@ from enterprise.roles_api import admin_role
 from enterprise.toggles import (
     ENTERPRISE_CUSTOMER_SUPPORT_TOOL,
     ENTERPRISE_GROUPS_V1,
+    ENTERPRISE_GROUPS_V2,
     FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
     TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
 )
@@ -1949,62 +1950,64 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
 
     @ddt.data(
         # Request missing required permissions query param.
-        (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'}, False, False, False, False),
+        (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'},
+         False, False, False, False, False),
         # Staff user that does not have the specified group permission.
         (True, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False),
         # Staff user that does have the specified group permission.
         (True, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False),
+         True, None, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, nor do they have the group permission.
         (False, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, but does have the group permission.
         (False, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         False, None, False, False, False, False),
+         False, None, False, False, False, False, False),
         # Non staff user that is linked to the enterprise, but does not have the group permission.
         (False, True, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and does have the group permission
         (False, True, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False),
+         True, None, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and has group permission and the request has passed
         # multiple groups to check.
         (False, True, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None, False,
-         False, False, False),
+         False, False, False, False),
         # Staff user with group permission filtering on non existent enterprise id.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[1]}, False,
-         None, False, False, False, False),
+         None, False, False, False, False, False),
         # Staff user with group permission filtering on enterprise id successfully.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[0]}, True,
-         None, False, False, False, False),
+         None, False, False, False, False, False),
         # Staff user with group permission filtering on search param with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'blah'}, False,
-         None, False, False, False, False),
+         None, False, False, False, False, False),
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True,
-         None, False, False, False, False),
+         None, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, False, False, False, False),
+         None, False, False, False, False, False),
         # Staff user with group permissions filtering on slug with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
-         None, False, False, False, False),
+         None, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results, with
         # top down assignment & real-time LCM feature enabled,
         # prequery search results enabled and
         # enterprise groups v1 feature enabled
+        # enterprise groups v2 feature enabled
         # enterprise customer support tool enabled
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, True, True, True, True),
+         None, True, True, True, True, True),
     )
     @ddt.unpack
     @mock.patch('enterprise.utils.get_logo_url')
@@ -2019,6 +2022,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             is_top_down_assignment_real_time_lcm_enabled,
             feature_prequery_search_suggestions_enabled,
             enterprise_groups_v1_enabled,
+            enterprise_groups_v2_enabled,
             enterprise_customer_support_tool,
             mock_get_logo_url,
     ):
@@ -2086,6 +2090,13 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             active=enterprise_groups_v1_enabled
         ):
 
+            response = client.get(
+                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
+            )
+        with override_waffle_flag(
+            ENTERPRISE_GROUPS_V2,
+            active=enterprise_groups_v2_enabled
+        ):
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
@@ -2166,6 +2177,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'feature_prequery_search_suggestions': feature_prequery_search_suggestions_enabled,
                     'enterprise_groups_v1': enterprise_groups_v1_enabled,
                     'enterprise_customer_support_tool': enterprise_customer_support_tool,
+                    'enterprise_groups_v2': enterprise_groups_v2_enabled,
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)


### PR DESCRIPTION
Adds feature flag `ENTERPRISE_GROUPS_V2` for groups v2 work.
https://2u-internal.atlassian.net/browse/ENT-8782

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
