### PR TITLE
fix: Bump the version again.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,9 +17,13 @@ Unreleased
 ----------
 * nothing unreleased
 
-[4.25.14]
+[4.25.15]
 ---------
 * fix: Don't import HttpClientError from edx-rest-api-client
+
+[4.25.14]
+---------
+* This version was incorretly tagged and so wasn't properly released.
 
 [4.25.13]
 ----------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.25.14"
+__version__ = "4.25.15"


### PR DESCRIPTION
Version 4.25.14 was tagged in git but the version was not bumped in the
package so the release automation failed.

https://github.com/openedx/edx-enterprise/actions/runs/10907374740

Moving the last unreleased change to the next minor version so that we
can release it.
