### PR TITLE
feat: add pagination to the support tool customer list

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.25.17]
+---------
+* feat: add pagination to the support tool customer list
+
 [4.25.16]
 ---------
 * feat: add a waffle flag for enterprise groups v2 feature

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.25.16"
+__version__ = "4.25.17"

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1946,7 +1946,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
         self.create_items(factory, model_items)
         response = self.client.get(settings.TEST_SERVER + url)
         response = self.load_json(response.content)
-        assert sorted(expected_json, key=sorting_key) == sorted(response, key=sorting_key)
+        assert sorted(expected_json, key=sorting_key) == sorted(response['results'], key=sorting_key)
 
     @ddt.data(
         # Request missing required permissions query param.


### PR DESCRIPTION
# Description
Adds pagination to the support tool customer list view

# Test plan

> 1. visit link http://localhost:18000/enterprise/api/v1/enterprise-customer/support_tool/? and verify that the response is paginated 

<img width="1499" alt="Screenshot 2024-09-26 at 10 13 35 AM" src="https://github.com/user-attachments/assets/938f7167-06d6-4ceb-9f33-70be3b5cdea7">

>2. check that you can filter by customer name via query param `user_query` 
<img width="1349" alt="Screenshot 2024-09-26 at 10 45 48 AM" src="https://github.com/user-attachments/assets/a0f52916-36f7-42c9-bde1-6f1e37f6bbfe">


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
