### PR TITLE
feat: remove logging to debug SAP SuccessFactors transmission issues

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.25.18]
+----------
+* feat: remove logging to debug SAP SuccessFactors transmission issues
+
 [4.25.17]
 ---------
 * feat: add pagination to the support tool customer list

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.25.17"
+__version__ = "4.25.18"

--- a/integrated_channels/integrated_channel/exporters/learner_data.py
+++ b/integrated_channels/integrated_channel/exporters/learner_data.py
@@ -124,15 +124,6 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
         # Create a record of each subsection from every enterprise enrollment
         for enterprise_enrollment in enrollment_queryset:
             if not LearnerExporter.has_data_sharing_consent(enterprise_enrollment):
-                # Adding logging to debug the issue we are having with a customer using SAPSF channel
-                LOGGER.info(generate_formatted_log(
-                    self.enterprise_configuration.channel_code(),
-                    self.enterprise_configuration.enterprise_customer.uuid,
-                    None,
-                    None,
-                    f'[SAPSF] Transmission skipped for {enterprise_enrollment.enterprise_customer_user.user_id}'
-                    'due to missing data sharing consent.'
-                ))
                 continue
 
             assessment_grade_data = self._collect_assessment_grades_data(enterprise_enrollment)
@@ -201,16 +192,6 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
             detect_grade_updated=self.INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK,
         )
 
-        # Adding logging to debug the issue we are having with a customer using SAPSF channel
-        LOGGER.info(generate_formatted_log(     # pragma: no cover
-            self.enterprise_configuration.channel_code(),
-            self.enterprise_configuration.enterprise_customer.uuid,
-            None,
-            None,
-            f'[SAPSF] Transmission already sent for {enterprise_enrollment.enterprise_customer_user.user_id}'
-            f'is_already_transmitted returned {already_transmitted}'
-        ))
-
         if not (TransmissionAudit and already_transmitted) and LearnerExporter.has_data_sharing_consent(
                 enterprise_enrollment):
 
@@ -221,14 +202,6 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                 assessment_grade_data=assessment_grade_data,
             )
             if records:
-                # Adding logging to debug the issue we are having with a customer using SAPSF channel
-                LOGGER.info(generate_formatted_log(     # pragma: no cover
-                    self.enterprise_configuration.channel_code(),
-                    self.enterprise_configuration.enterprise_customer.uuid,
-                    None,
-                    None,
-                    f'[SAPSF] Transmission sent for {enterprise_enrollment.enterprise_customer_user.user_id}'
-                ))
                 # There are some cases where we won't receive a record from the above
                 # method; right now, that should only happen if we have an Enterprise-linked
                 # user for the integrated channel, and transmission of that user's
@@ -524,15 +497,6 @@ class LearnerExporter(ChannelSettingsMixin, Exporter):
                         grade,
                         detect_grade_updated=self.INCLUDE_GRADE_FOR_COMPLETION_AUDIT_CHECK,
                     ):
-                # Adding logging to debug the issue we are having with a customer using SAPSF channel
-                LOGGER.info(generate_formatted_log(
-                    self.enterprise_configuration.channel_code(),
-                    self.enterprise_configuration.enterprise_customer.uuid,
-                    None,
-                    None,
-                    f'[SAPSF] Transmission skipped for {enterprise_enrollment.enterprise_customer_user.user_id}'
-                    'transmission_audit and already_transmitted returned True.'
-                ))
                 # We've already sent a completion status for this enrollment
                 LOGGER.info(generate_formatted_log(
                     channel_name, enterprise_customer_uuid, lms_user_id, course_id,


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
