### PR TITLE
fix: serialize `best_mode_for_course_run` field in `DefaultEnterpriseEnrollmentIntentionSerializer`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,15 +17,9 @@ Unreleased
 ----------
 * nothing unreleased
 
-[4.31.1]
+[4.30.1]
 --------
 * fix: serialize best_mode_for_course_run field in DefaultEnterpriseEnrollmentIntentionSerializer.
-
-[4.31.0]
---------
-* feat: create DefaultEnterpriseEnrollmentRealization objects in bulk enrollment API, when applicable.
-* fix: Alter the realized_enrollment field in DefaultEnterpriseEnrollmentRealization to be a OneToOneField.
-* fix: rename metadata field in DefaultEnterpriseEnrollmentIntentionLearnerStatusSerializer.
 
 [4.30.0]
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,16 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.31.1]
+--------
+* fix: serialize best_mode_for_course_run field in DefaultEnterpriseEnrollmentIntentionSerializer.
+
+[4.31.0]
+--------
+* feat: create DefaultEnterpriseEnrollmentRealization objects in bulk enrollment API, when applicable.
+* fix: Alter the realized_enrollment field in DefaultEnterpriseEnrollmentRealization to be a OneToOneField.
+* fix: rename metadata field in DefaultEnterpriseEnrollmentIntentionLearnerStatusSerializer.
+
 [4.30.0]
 --------
 * feat: REST APIs for default-enterprise-enrollment-intentions

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.30.0"
+__version__ = "4.31.1"

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.31.1"
+__version__ = "4.30.1"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1915,6 +1915,7 @@ class DefaultEnterpriseEnrollmentIntentionSerializer(serializers.ModelSerializer
             'course_key',
             'course_run_key',
             'is_course_run_enrollable',
+            'best_mode_for_course_run',
             'applicable_enterprise_catalog_uuids',
             'course_run_normalized_metadata',
             'created',
@@ -1941,6 +1942,12 @@ class DefaultEnterpriseEnrollmentIntentionSerializer(serializers.ModelSerializer
 
     def get_applicable_enterprise_catalog_uuids(self, obj):
         return obj.applicable_enterprise_catalog_uuids
+
+    def get_best_mode_for_course_run(self, obj):
+        """
+        Get the best course mode for the course run.
+        """
+        return obj.best_mode_for_course_run
 
 
 class DefaultEnterpriseEnrollmentIntentionWithEnrollmentStateSerializer(DefaultEnterpriseEnrollmentIntentionSerializer):

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -9,6 +9,10 @@ from functools import reduce
 from unittest import mock
 
 from test_utils import FAKE_UUIDS
+from tests.test_enterprise.api.constants import (
+    AUDIT_COURSE_MODE,
+    VERIFIED_COURSE_MODE,
+)
 
 FAKE_URL = 'https://fake.url'
 
@@ -26,7 +30,7 @@ FAKE_COURSE_RUN_TO_CREATE = {
     'marketing_url': 'course/demo-course?utm_=test_enterprise&utm_medium=enterprise',
     'seats': [
         {
-            'type': 'audit',
+            'type': AUDIT_COURSE_MODE,
             'price': '0.00',
             'currency': 'USD',
             'upgrade_deadline': None,
@@ -35,7 +39,7 @@ FAKE_COURSE_RUN_TO_CREATE = {
             'sku': '68EFFFF'
         },
         {
-            'type': 'verified',
+            'type': VERIFIED_COURSE_MODE,
             'price': '149.00',
             'currency': 'USD',
             'upgrade_deadline': '2018-08-03T16:44:26.595896Z',
@@ -50,7 +54,7 @@ FAKE_COURSE_RUN_TO_CREATE = {
     'enrollment_end': None,
     'enrollment_url': FAKE_URL,
     'pacing_type': 'instructor_paced',
-    'type': 'verified',
+    'type': VERIFIED_COURSE_MODE,
     'status': 'published',
     'course': 'edX+DemoX',
     'full_description': 'Lorem ipsum dolor sit amet, consectetur adipiscing elit.',
@@ -110,7 +114,7 @@ FAKE_COURSE_RUN = {
     'marketing_url': 'course/demo-course?utm_=test_enterprise&utm_medium=enterprise',
     'seats': [
         {
-            'type': 'audit',
+            'type': AUDIT_COURSE_MODE,
             'price': 0,
             'currency': 'USD',
             'upgrade_deadline': None,
@@ -119,7 +123,7 @@ FAKE_COURSE_RUN = {
             'sku': '68EFFFF'
         },
         {
-            'type': 'verified',
+            'type': VERIFIED_COURSE_MODE,
             'price': 149,
             'currency': 'USD',
             'upgrade_deadline': '2018-08-03T16:44:26.595896Z',
@@ -135,7 +139,7 @@ FAKE_COURSE_RUN = {
     'enrollment_end': None,
     'enrollment_url': FAKE_URL,
     'pacing_type': 'instructor_paced',
-    'type': 'verified',
+    'type': VERIFIED_COURSE_MODE,
     'status': 'published',
     "is_enrollable": True,
     "is_marketable": True,
@@ -403,7 +407,7 @@ FAKE_PROGRAM_RESPONSE1 = {
     "staff": [],
     "credit_redemption_overview": "This is a test Program.",
     "applicable_seat_types": [
-        "audit"
+        AUDIT_COURSE_MODE
     ],
 }
 
@@ -567,7 +571,7 @@ FAKE_PROGRAM_RESPONSE3 = {
     "min_hours_effort_per_week": 5,
     "max_hours_effort_per_week": 10,
     "applicable_seat_types": [
-        "verified",
+        VERIFIED_COURSE_MODE,
         "professional",
         "credit",
     ],
@@ -598,7 +602,7 @@ FAKE_PROGRAM_TYPE = {
         }
     },
     "applicable_seat_types": [
-        "verified",
+        VERIFIED_COURSE_MODE,
         "professional",
         "credit"
     ],
@@ -623,7 +627,7 @@ FAKE_COURSE_RUNS_RESPONSE = [
                 "credit_hours": None
             },
             {
-                "type": "audit",
+                "type": AUDIT_COURSE_MODE,
                 "price": "0.00",
                 "currency": "USD",
                 "upgrade_deadline": None,
@@ -669,7 +673,7 @@ FAKE_COURSE_RUNS_RESPONSE = [
                 "credit_hours": None
             },
             {
-                "type": "audit",
+                "type": AUDIT_COURSE_MODE,
                 "price": "0.00",
                 "currency": "AED",
                 "upgrade_deadline": None,
@@ -847,14 +851,14 @@ FAKE_CATALOG_COURSE_DETAILS_RESPONSES = {
                 "enrollment_start": None,
                 "enrollment_end": None,
                 "pacing_type": "instructor_paced",
-                "type": "audit",
+                "type": AUDIT_COURSE_MODE,
                 "course": "edX+DemoX",
                 "full_description": None,
                 "announcement": None,
                 "video": None,
                 "seats": [
                     {
-                        "type": "audit",
+                        "type": AUDIT_COURSE_MODE,
                         "price": "0.00",
                         "currency": "USD",
                         "upgrade_deadline": None,
@@ -1103,8 +1107,8 @@ FAKE_SEARCH_ALL_COURSE_RESULT = {
     "course_runs": [],
     "full_description": None,
     "seat_types": [
-        "audit",
-        "verified"
+        AUDIT_COURSE_MODE,
+        VERIFIED_COURSE_MODE,
     ],
     "mobile_available": False,
     "end": None,
@@ -1122,7 +1126,7 @@ FAKE_SEARCH_ALL_COURSE_RESULT = {
     "staff_uuids": [],
     "language": None,
     "number": "DemoX",
-    "type": "verified",
+    "type": VERIFIED_COURSE_MODE,
     "key": "course-v1:edX+DemoX+Demo_Course",
     "org": "edX",
     "level_type": None,
@@ -1375,7 +1379,7 @@ FAKE_SEARCH_ALL_COURSE_RESULT_3 = {
     "course_runs": [
         {
             "enrollment_end": None,
-            "enrollment_mode": "verified",
+            "enrollment_mode": VERIFIED_COURSE_MODE,
             "key": "course-v1:edX+DemoX+Demo_Course",
             "enrollment_start": None,
             "pacing_type": "instructor_paced",
@@ -1542,7 +1546,7 @@ def create_course_run_dict(start="2014-10-14T13:11:03Z", end="3000-10-13T13:11:0
         "status": status,
         "enrollment_start": enrollment_start,
         "enrollment_end": enrollment_end,
-        "seats": [{"type": "verified", "upgrade_deadline": upgrade_deadline}],
+        "seats": [{"type": VERIFIED_COURSE_MODE, "upgrade_deadline": upgrade_deadline}],
         "availability": availability,
         "weeks_to_complete": weeks_to_complete,
         "uuid": uuid,

--- a/test_utils/fake_catalog_api.py
+++ b/test_utils/fake_catalog_api.py
@@ -9,10 +9,7 @@ from functools import reduce
 from unittest import mock
 
 from test_utils import FAKE_UUIDS
-from tests.test_enterprise.api.constants import (
-    AUDIT_COURSE_MODE,
-    VERIFIED_COURSE_MODE,
-)
+from tests.test_enterprise.api.constants import AUDIT_COURSE_MODE, VERIFIED_COURSE_MODE
 
 FAKE_URL = 'https://fake.url'
 

--- a/tests/test_enterprise/api/constants.py
+++ b/tests/test_enterprise/api/constants.py
@@ -11,3 +11,7 @@ FAKE_SSO_METADATA_XML_WITH_ENTITY_ID = [
     ('<md:EntitiesDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata"> <md:EntityDescriptor entityID="https://idp1.example.com"> <md:IDPSSODescriptor></md:IDPSSODescriptor> </md:EntityDescriptor> <md:EntityDescriptor entityID="https://idp2.example.com"> <md:IDPSSODescriptor></md:IDPSSODescriptor> </md:EntityDescriptor> </md:EntitiesDescriptor>', "https://idp1.example.com"),  # pylint: disable=line-too-long
     ('<EntitiesDescriptor xmlns="urn:oasis:names:tc:SAML:2.0:metadata"><EntityDescriptor entityID="https://example.com"></EntityDescriptor></EntitiesDescriptor>', "https://example.com")  # pylint: disable=line-too-long
 ]
+
+# Course Modes
+VERIFIED_COURSE_MODE = 'verified'
+AUDIT_COURSE_MODE = 'audit'

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -111,11 +111,7 @@ from test_utils.factories import (
 )
 from test_utils.fake_enterprise_api import get_default_branding_object
 
-from .constants import (
-    AUDIT_COURSE_MODE,
-    FAKE_SSO_METADATA_XML_WITH_ENTITY_ID,
-    VERIFIED_COURSE_MODE,
-)
+from .constants import AUDIT_COURSE_MODE, FAKE_SSO_METADATA_XML_WITH_ENTITY_ID, VERIFIED_COURSE_MODE
 
 Application = get_application_model()
 fake = Faker()


### PR DESCRIPTION
## Description

Exposes `best_mode_for_course_run` in `DefaultEnterpriseEnrollmentIntentionSerializer`, which will be used when attempting bulk enrollment for enrollable default enterprise enrollment intentions. That is, the bulk enrollment API accepts a `mode` property, which `best_mode_for_course_run` will be passed.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
