### PR TITLE
fix: ensure correct `admin_users` in EnterpriseCustomerUserViewSet response

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[4.32.2]
+--------
+* fix: ensure admin_users in EnterpriseCustomerUserViewSet is correct.
+
 [4.32.1]
 --------
 * feat: enable search filter on learner data transmission audit admin views for all integrated channels.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "4.32.1"
+__version__ = "4.32.2"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -721,24 +721,11 @@ class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):
         )
 
     user = UserSerializer()
+    enterprise_customer = serializers.SerializerMethodField()
     data_sharing_consent_records = serializers.SerializerMethodField()
     groups = serializers.SerializerMethodField()
     role_assignments = serializers.SerializerMethodField()
     enterprise_group = serializers.SerializerMethodField()
-
-    def to_representation(self, instance):
-        """
-        Override to pass the instance of `enterprise_customer` to the nested serializer.
-        """
-        representation = super().to_representation(instance)
-        enterprise_customer_instance = instance.enterprise_customer
-        enterprise_customer_serializer = EnterpriseCustomerSerializer(
-            instance=enterprise_customer_instance,
-            context=self.context
-        )
-        representation['enterprise_customer'] = enterprise_customer_serializer.data
-
-        return representation
 
     def _get_role_assignments_by_ecu_id(self, enterprise_customer_users):
         """
@@ -768,6 +755,15 @@ class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):
                 instance if isinstance(instance, Iterable) else [instance]
             )
             self.role_assignments_by_ecu_id = role_assignments_by_ecu_id
+
+    def get_enterprise_customer(self, obj):
+        """
+        Return serialization of EnterpriseCustomer associated with the EnterpriseCustomerUser.
+        """
+        return EnterpriseCustomerSerializer(
+            instance=obj.enterprise_customer,
+            context=self.context
+        ).data
 
     def get_data_sharing_consent_records(self, obj):
         """

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -721,11 +721,24 @@ class EnterpriseCustomerUserReadOnlySerializer(serializers.ModelSerializer):
         )
 
     user = UserSerializer()
-    enterprise_customer = EnterpriseCustomerSerializer()
     data_sharing_consent_records = serializers.SerializerMethodField()
     groups = serializers.SerializerMethodField()
     role_assignments = serializers.SerializerMethodField()
     enterprise_group = serializers.SerializerMethodField()
+
+    def to_representation(self, instance):
+        """
+        Override to pass the instance of `enterprise_customer` to the nested serializer.
+        """
+        representation = super().to_representation(instance)
+        enterprise_customer_instance = instance.enterprise_customer
+        enterprise_customer_serializer = EnterpriseCustomerSerializer(
+            instance=enterprise_customer_instance,
+            context=self.context
+        )
+        representation['enterprise_customer'] = enterprise_customer_serializer.data
+
+        return representation
 
     def _get_role_assignments_by_ecu_id(self, enterprise_customer_users):
         """

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -555,6 +555,37 @@ class TestEnterpriseCustomerUser(BaseTestEnterpriseAPIViews):
         response = self.load_json(response.content)
         assert response['enterprise_features'] is not None
 
+    def test_get_enterprise_customer_user_contains_admin_users(self):
+        """
+        Assert whether the paginated response contains `enterprise_customer.admin_users`.
+        """
+        user = factories.UserFactory()
+        enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])
+        factories.EnterpriseCustomerUserFactory(
+            user_id=user.id,
+            enterprise_customer=enterprise_customer
+        )
+        admin_user = factories.UserFactory()
+        SystemWideEnterpriseUserRoleAssignment.objects.create(
+            role=admin_role(),
+            user=admin_user,
+            enterprise_customer=enterprise_customer
+        )
+        response = self.client.get(
+            '{host}{path}?username={username}'.format(
+                host=settings.TEST_SERVER,
+                path=ENTERPRISE_LEARNER_LIST_ENDPOINT,
+                username=user.username
+            )
+        )
+        response = self.load_json(response.content)
+        assert response['results'][0]['enterprise_customer']['admin_users'] == [
+            {
+                'email': admin_user.email,
+                'lms_user_id': admin_user.id,
+            }
+        ]
+
     def test_get_enterprise_customer_user_contains_consent_records(self):
         user = factories.UserFactory()
         enterprise_customer = factories.EnterpriseCustomerFactory(uuid=FAKE_UUIDS[0])


### PR DESCRIPTION
https://2u-internal.atlassian.net/browse/ENT-9741

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
