### PR TITLE
fix: use single constant for course mode priority; only fetch catalog list with resolved course run

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.3.1]
+-------
+* fix: rely on single constant to define course mode priority order (i.e., ensure all enrollable modes are considered; previously missing honor mode in `enroll_learners_in_courses`).
+* fix: prevent fetching catalog list without a resolved course run in the property `applicable_enterprise_catalog_uuids` within `DefaultEnterpriseEnrollmentIntention`.
+
 [5.3.0]
 --------
 * refactor: Removed unused django setting.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.3.0"
+__version__ = "5.3.1"

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -59,6 +59,7 @@ class CourseModes:
     VERIFIED = 'verified'
     UNPAID_EXECUTIVE_EDUCATION = 'unpaid-executive-education'
 
+
 # Course mode sorting based on slug
 COURSE_MODE_SORT_ORDER = [
     CourseModes.VERIFIED,

--- a/enterprise/constants.py
+++ b/enterprise/constants.py
@@ -59,14 +59,6 @@ class CourseModes:
     VERIFIED = 'verified'
     UNPAID_EXECUTIVE_EDUCATION = 'unpaid-executive-education'
 
-
-BEST_MODE_ORDER = [
-    CourseModes.VERIFIED,
-    CourseModes.PROFESSIONAL,
-    CourseModes.NO_ID_PROFESSIONAL,
-    CourseModes.UNPAID_EXECUTIVE_EDUCATION,
-]
-
 # Course mode sorting based on slug
 COURSE_MODE_SORT_ORDER = [
     CourseModes.VERIFIED,

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -2630,6 +2630,10 @@ class DefaultEnterpriseEnrollmentIntention(TimeStampedModel, SoftDeletableModel)
         """
         Returns a list of UUIDs for applicable enterprise catalogs.
         """
+        if not self.course_run_key:
+            # Without a resolved course run key, prevent the enterprise catalog list from being fetched.
+            return []
+
         contains_content_items_response = get_and_cache_enterprise_contains_content_items(
             enterprise_customer_uuid=self.enterprise_customer.uuid,
             content_keys=[self.course_run_key],

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -37,7 +37,7 @@ from django.utils.translation import ngettext
 
 from enterprise.constants import (
     ALLOWED_TAGS,
-    BEST_MODE_ORDER,
+    COURSE_MODE_SORT_ORDER,
     DEFAULT_CATALOG_CONTENT_FILTER,
     LMS_API_DATETIME_FORMAT,
     LMS_API_DATETIME_FORMAT_WITHOUT_TIMEZONE,
@@ -2404,7 +2404,7 @@ def get_best_mode_from_course_key(course_key):
     enterprise learner in.
     """
     course_modes = [mode.slug for mode in CourseMode.objects.filter(course_id=course_key)]
-    if best_mode := [mode for mode in BEST_MODE_ORDER if mode in course_modes]:
+    if best_mode := [mode for mode in COURSE_MODE_SORT_ORDER if mode in course_modes]:
         return best_mode[0]
     return CourseModes.AUDIT
 


### PR DESCRIPTION
### Description

1. During stage QA, it was observed that a course run with only an `honor` seat was not enrollable via the LMS bulk enrollment API when realizing default enterprise enrollment intentions. It was determined that this was due to relying on a constant `BEST_MODE_ORDER` that didn't include audit/honor seat modes; as such, when trying to enroll in this `honor`-only course run, it was falling back to attempt to enroll in a non-existent `audit` seat, resulting in a 409 on the LMS bulk enrollment API. This PR removes `BEST_MODE_ORDER` to singularly rely on the existing `COURSE_MODE_SORT_ORDER` instead, which includes `honor`.
2. When calling the `/enterprise/api/v1/default-enterprise-enrollment-intentions/learner-status/` LMS API locally with a default enrollment intention configured for course with a non-existent advertised course run, the `DefaultEnterpriseEnrollmentIntention` model continues to attempt to call `contains_content_items` to retrieve a list of applicable catalog UUIDs associated with a resolved course run. However, if a course run cannot be resolved, we shouldn't be making the call to enterprise-catalog, and simply fallback to an empty list in the model's `applicable_enterprise_catalog_uuids` property.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
