### PR TITLE
fix: Fixed the query fetching enterprise customer members

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.4.3]
+--------
+* fix: Fixed the query fetching enterprise customer members
+
 [5.4.2]
 --------
 * feat: Added a management command to update the Social Auth UID's for an enterprise.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.4.2"
+__version__ = "5.4.3"

--- a/enterprise/api/v1/views/enterprise_customer_members.py
+++ b/enterprise/api/v1/views/enterprise_customer_members.py
@@ -78,7 +78,7 @@ class EnterpriseCustomerMembersViewSet(EnterpriseReadOnlyModelViewSet):
                     au.id,
                     au.email,
                     au.date_joined,
-                    coalesce(NULLIF(aup.name, ''), (au.first_name || ' ' || au.last_name)) as full_name
+                    coalesce(NULLIF(aup.name, ''), au.username) as full_name
                 FROM enterprise_enterprisecustomeruser ecu
                 INNER JOIN auth_user as au on ecu.user_id = au.id
                 LEFT JOIN auth_userprofile as aup on au.id = aup.user_id

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -4699,7 +4699,7 @@ class EnterpriseGroup(TimeStampedModel, SoftDeletableModel):
             with users as (
                 select ecu.id,
                 au.email,
-                coalesce(NULLIF(aup.name, ''), (au.first_name || ' ' || au.last_name)) as full_name
+                coalesce(NULLIF(aup.name, ''), au.username) as full_name
                 from enterprise_enterprisecustomeruser ecu
                 inner join auth_user au on ecu.user_id = au.id
                 left join auth_userprofile aup on au.id = aup.user_id


### PR DESCRIPTION
Couldn't figure out an easy way to get this concatenation syntax working correctly (CONCAT function was tried previously), so now just falling back to one field (username) instead. This should not impact production data as the vast majority of users have data populated in the auth_userprofile table, but this will give us better testable data on stage.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
