### PR TITLE
feat: adds sorting support to enterprise-customer-members endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.6.0]
+--------
+* feat: Adds sorting support to enterprise-customer-members endpoint 
+
 [5.5.2]
 --------
 * feat: Add page_size support to enterprise-customer-members endpoint

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.5.2"
+__version__ = "5.6.0"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1922,7 +1922,22 @@ class EnterpriseUserSerializer(serializers.Serializer):
             return None
 
 
-class EnterpriseMembersSerializer(serializers.Serializer):
+class EnterpriseCustomerMembersRequestQuerySerializer(serializers.Serializer):
+    """
+    Serializer for the Enterprise Customer Members endpoint query filter
+    """
+    user_query = serializers.CharField(required=False, max_length=250)
+    sort_by = serializers.ChoiceField(
+        choices=[
+            ('name', 'name'),
+            ('joined_org', 'joined_org'),
+        ],
+        required=False,
+    )
+    is_reversed = serializers.BooleanField(required=False, default=False)
+
+
+class EnterpriseMembersSerializer(serializers.ModelSerializer):
     """
     Serializer for EnterpriseCustomerUser model with additions.
     """
@@ -1954,6 +1969,7 @@ class EnterpriseMembersSerializer(serializers.Serializer):
         """
         if user := obj:
             return {
+                "user_id": user[0],
                 "email": user[1],
                 "joined_org": user[2].strftime("%b %d, %Y"),
                 "name": user[3],

--- a/enterprise/api/v1/views/enterprise_customer_members.py
+++ b/enterprise/api/v1/views/enterprise_customer_members.py
@@ -72,9 +72,9 @@ class EnterpriseCustomerMembersViewSet(EnterpriseReadOnlyModelViewSet):
         - ``user_query`` (string, optional): Filter the returned members by user name and email with a provided
         sub-string
         - ``sort_by`` (string, optional): Specify how the returned members should be ordered. Supported sorting values
-        are `joined_org`, `name`, and `enrollments`. Ordering can be reversed by supplying a `-` at the
-        beginning of the sorting value ie `-joined_org`.
-        - ``is_reversed`` (bool, optional): Include to reverse the order of returned records.
+        are `joined_org`, `name`, and `enrollments`.
+        - ``is_reversed`` (bool, optional): Include to reverse the records in descending order. By default, the results
+        returned are in ascending order.
         """
         query_params = self.request.query_params
         param_serializers = serializers.EnterpriseCustomerMembersRequestQuerySerializer(

--- a/enterprise/api/v1/views/enterprise_customer_members.py
+++ b/enterprise/api/v1/views/enterprise_customer_members.py
@@ -6,6 +6,7 @@ from collections import OrderedDict
 
 from rest_framework import permissions, response, status
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
 
 from django.core.exceptions import ValidationError
 from django.db import connection
@@ -63,13 +64,31 @@ class EnterpriseCustomerMembersViewSet(EnterpriseReadOnlyModelViewSet):
     def get_members(self, request, *args, **kwargs):
         """
         Get all members associated with that enterprise customer
+
+        Request Arguments:
+        - ``enterprise_uuid`` (URL location, required): The uuid of the enterprise from which learners should be listed.
+
+        Optional query params:
+        - ``user_query`` (string, optional): Filter the returned members by user name and email with a provided
+        sub-string
+        - ``sort_by`` (string, optional): Specify how the returned members should be ordered. Supported sorting values
+        are `joined_org`, `name`, and `enrollments`. Ordering can be reversed by supplying a `-` at the
+        beginning of the sorting value ie `-joined_org`.
+        - ``is_reversed`` (bool, optional): Include to reverse the order of returned records.
         """
+        query_params = self.request.query_params
+        param_serializers = serializers.EnterpriseCustomerMembersRequestQuerySerializer(
+            data=query_params
+        )
+        if not param_serializers.is_valid():
+            return Response(param_serializers.errors, status=400)
         enterprise_uuid = kwargs.get("enterprise_uuid", None)
         # Raw sql is picky about uuid format
         uuid_no_dashes = str(enterprise_uuid).replace("-", "")
         users = []
-        user_query = self.request.query_params.get("user_query", None)
-
+        user_query = param_serializers.validated_data.get('user_query')
+        is_reversed = param_serializers.validated_data.get('is_reversed', False)
+        sort_by = param_serializers.validated_data.get('sort_by')
         # On logistration, the name field of auth_userprofile is populated, but if it's not
         # filled in, we check the auth_user model for it's first/last name fields
         # https://2u-internal.atlassian.net/wiki/spaces/ENGAGE/pages/747143186/Use+of+full+name+in+edX#Data-on-Name-Field
@@ -108,6 +127,14 @@ class EnterpriseCustomerMembersViewSet(EnterpriseReadOnlyModelViewSet):
                 {"detail": "Could not find enterprise uuid {}".format(enterprise_uuid)},
                 status=status.HTTP_404_NOT_FOUND,
             )
+
+        if sort_by:
+            lambda_keys = {
+                # 3 and 2 are indices in the tuple associated to a user row (uuid, email, joined_org, name)
+                'name': lambda t: t[3],
+                'joined_org': lambda t: t[2],
+            }
+            users = sorted(users, key=lambda_keys.get(sort_by), reverse=is_reversed)
 
         # paginate the queryset
         users_page = self.paginator.paginate_queryset(users, request, view=self)

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -589,6 +589,7 @@ class TestEnterpriseMembersSerializer(TestCase):
     def test_serialize_users(self):
         expected_user = {
             'enterprise_customer_user': {
+                'user_id': self.user_1.id,
                 'email': self.user_1.email,
                 'joined_org': self.user_1.date_joined.strftime("%b %d, %Y"),
                 'name': (self.user_1.first_name + ' ' + self.user_1.last_name),
@@ -609,6 +610,7 @@ class TestEnterpriseMembersSerializer(TestCase):
 
         expected_user_2 = {
             'enterprise_customer_user': {
+                'user_id': self.user_2.id,
                 'email': self.user_2.email,
                 'joined_org': self.user_2.date_joined.strftime("%b %d, %Y"),
                 'name': self.user_2.first_name + ' ' + self.user_2.last_name,


### PR DESCRIPTION
Adds sorting support to the `enterprise-customer-members` endpoint to allow a user to sort by a member's `joined_org` date and member's `name`. 

https://2u-internal.atlassian.net/browse/ENT-9861

Testing instructions:
1. add users to an enterprise via the `Manage learners` page: http://localhost:18000/admin/enterprise/enterprisecustomer/7dbf461e-8d3d-4a4a-9b20-9c9121f04806/manage_learners 
2. go to the `enterprise-customer-members` endpoint and verify that you can sort the results by `joined_org` and `name` via the following parameters: 
-`sort_by=name`: http://localhost:18000/enterprise/api/v1/enterprise-customer-members/7dbf461e-8d3d-4a4a-9b20-9c9121f04806?sort_by=name
![Screenshot 2025-01-10 at 10 46 38 AM](https://github.com/user-attachments/assets/6afdf86e-8453-41dd-adac-b5d18dcdc1d7)
- `sort_by=name&is_reversed=true`
![Screenshot 2025-01-10 at 10 48 15 AM](https://github.com/user-attachments/assets/e0512417-f41a-4fee-976b-a829ad2d0b97)
- `sort_by=joined_org`: http://localhost:18000/enterprise/api/v1/enterprise-customer-members/7dbf461e-8d3d-4a4a-9b20-9c9121f04806?sort_by=joined_org
![Screenshot 2025-01-10 at 10 45 49 AM](https://github.com/user-attachments/assets/7bd26bf3-f256-4048-b602-b8c5c49fe471)
- `sort_by=joined_org&is_reversed=true`
![Screenshot 2025-01-10 at 10 46 18 AM](https://github.com/user-attachments/assets/8f7f35d9-6e5d-4388-90bb-0fb10fb5a50b)


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
