### PR TITLE
fix: enrollment intention saves should not be blocked on catalog inclusion

### DIFF
--- a/docs/decisions/0015-default-enrollments.rst
+++ b/docs/decisions/0015-default-enrollments.rst
@@ -65,7 +65,7 @@ will always primarily be associated with the course run associated with the ``De
 * If the content_key is a specific course run, we'll always try to enroll in the explicitly
   configured course run key (not the advertised course run).
 
-This content_key will be passed to the ``EnterpriseCatalogApiClient().get_content_metadata_content_identifier``
+This content_key will be passed to the ``EnterpriseCatalogApiClient().get_customer_content_metadata_content_identifier``
 method. When passing a course run key to this endpoint, it'll actually return the top-level *course* metadata
 associated with the course run, not just the specified course run's metadata
 (this is primarily due to catalogs containing courses, not course runs, and we generally say that

--- a/enterprise/api_client/discovery.py
+++ b/enterprise/api_client/discovery.py
@@ -283,7 +283,7 @@ class CourseCatalogApiClient(UserAPIClient):
             course_run_id(string): Course run ID (aka Course Key) in string format.
 
         Returns:
-            dict: Course run data provided by Course Catalog API.
+            dict: Course run data provided by Course Catalog API, or empty dict if not found.
 
         """
         return self._load_data(

--- a/enterprise/content_metadata/api.py
+++ b/enterprise/content_metadata/api.py
@@ -16,6 +16,44 @@ logger = logging.getLogger(__name__)
 DEFAULT_CACHE_TIMEOUT = getattr(settings, 'CONTENT_METADATA_CACHE_TIMEOUT', 60 * 5)
 
 
+def get_and_cache_content_metadata(content_key, timeout=None):
+    """
+    Returns the metadata corresponding to the requested ``content_key``
+    REGARDLESS of catalog/customer associations.
+
+    The response is cached in a ``TieredCache`` (meaning in both the RequestCache,
+    _and_ the django cache for the configured expiration period).
+
+    Returns: A dict with content metadata for the given key.
+    Raises: An HTTPError if there's a problem getting the content metadata
+      via the enterprise-catalog service.
+    """
+    cache_key = versioned_cache_key('get_content_metadata_content_identifier', content_key)
+    cached_response = TieredCache.get_cached_response(cache_key)
+    if cached_response.is_found:
+        logger.info(f'cache hit for content_key {content_key}')
+        return cached_response.value
+
+    try:
+        result = EnterpriseCatalogApiClient().get_content_metadata_content_identifier(
+            content_id=content_key,
+        )
+    except HTTPError as exc:
+        raise exc
+
+    if not result:
+        logger.warning('No content found for content_key %s', content_key)
+        return {}
+
+    logger.info(
+        'Fetched catalog for content_key %s. Result = %s',
+        content_key,
+        result,
+    )
+    TieredCache.set_all_tiers(cache_key, result, timeout or DEFAULT_CACHE_TIMEOUT)
+    return result
+
+
 def get_and_cache_customer_content_metadata(enterprise_customer_uuid, content_key, timeout=None):
     """
     Returns the metadata corresponding to the requested
@@ -28,14 +66,18 @@ def get_and_cache_customer_content_metadata(enterprise_customer_uuid, content_ke
     Raises: An HTTPError if there's a problem getting the content metadata
       via the enterprise-catalog service.
     """
-    cache_key = versioned_cache_key('get_content_metadata_content_identifier', enterprise_customer_uuid, content_key)
+    cache_key = versioned_cache_key(
+        'get_customer_content_metadata_content_identifier',
+        enterprise_customer_uuid,
+        content_key,
+    )
     cached_response = TieredCache.get_cached_response(cache_key)
     if cached_response.is_found:
         logger.info(f'cache hit for enterprise customer {enterprise_customer_uuid} and content {content_key}')
         return cached_response.value
 
     try:
-        result = EnterpriseCatalogApiClient().get_content_metadata_content_identifier(
+        result = EnterpriseCatalogApiClient().get_customer_content_metadata_content_identifier(
             enterprise_uuid=enterprise_customer_uuid,
             content_id=content_key,
         )

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -62,7 +62,7 @@ from enterprise.constants import (
     json_serialized_course_modes,
 )
 from enterprise.content_metadata.api import (
-    get_and_cache_customer_content_metadata,
+    get_and_cache_content_metadata,
     get_and_cache_enterprise_contains_content_items,
 )
 from enterprise.errors import LinkUserToEnterpriseError
@@ -2541,11 +2541,16 @@ class DefaultEnterpriseEnrollmentIntention(TimeStampedModel, SoftDeletableModel)
     @property
     def content_metadata_for_content_key(self):
         """
-        Retrieves the content metadata for the instance's enterprise customer and content key.
+        Retrieves the content metadata for the instance's content key.
+
+        NOTE (ENT-9840): Prior versions of this method used `get_and_cache_customer_content_metadata()` instead of
+        `get_and_cache_content_metadata()`. The goal was to ensure that model saves only succeed when the requested
+        content is actually contained in the customer's catalogs.  However, as part of ENT-9840 we are relaxing this
+        requirement because delays in discovery->catalog replication can easily result in default intentions being
+        un-saveable when simultaneously modifying catalog definitions to include the content.
         """
         try:
-            return get_and_cache_customer_content_metadata(
-                enterprise_customer_uuid=self.enterprise_customer.uuid,
+            return get_and_cache_content_metadata(
                 content_key=self.content_key,
             )
         except HTTPError as e:
@@ -2638,6 +2643,8 @@ class DefaultEnterpriseEnrollmentIntention(TimeStampedModel, SoftDeletableModel)
             enterprise_customer_uuid=self.enterprise_customer.uuid,
             content_keys=[self.course_run_key],
         )
+        if not contains_content_items_response.get('contains_content_items'):
+            return []
         return contains_content_items_response.get('catalog_list', [])
 
     def determine_content_type(self):
@@ -2693,6 +2700,11 @@ class DefaultEnterpriseEnrollmentIntention(TimeStampedModel, SoftDeletableModel)
         if not self.course_run:
             # NOTE: This validation check also acts as an inferred check on the derived content_type
             # from the content metadata.
+            # NOTE 2: This check does NOT assert that the content is actually contained in the
+            # customer's catalogs. ADR 0015, as written, would _like_ for that check to exist in
+            # this clean() method, but that has proven infeasible due to the nature of how data
+            # replication delays from discovery->catalog cause contains_content_items calls to be
+            # temporarily unreliable. Instead this only checks that the content key exists at all.
             raise ValidationError({
                 'content_key': _('The content key did not resolve to a valid course run.')
             })

--- a/integrated_channels/degreed2/client.py
+++ b/integrated_channels/degreed2/client.py
@@ -349,7 +349,7 @@ class Degreed2APIClient(IntegratedChannelApiClient):
         # We need to do 2 steps here:
         # 1. Fetch skills from enterprise-catalog
 
-        metadata = self.enterprise_catalog_api_client.get_content_metadata_content_identifier(
+        metadata = self.enterprise_catalog_api_client.get_customer_content_metadata_content_identifier(
             enterprise_uuid=self.enterprise_configuration.enterprise_customer.uuid,
             content_id=external_id)
         LOGGER.info(

--- a/tests/test_enterprise/api/test_default_enrollment_views.py
+++ b/tests/test_enterprise/api/test_default_enrollment_views.py
@@ -200,7 +200,6 @@ class TestDefaultEnterpriseEnrollmentIntentionViewSet(BaseTestEnterpriseAPIViews
         enrollment_intention = create_mock_default_enterprise_enrollment_intention(
             enterprise_customer=self.enterprise_customer,
             mock_catalog_api_client=mock_catalog_api_client,
-            contains_content_items=False,
             catalog_list=[],
         )
         query_params = f'enterprise_customer_uuid={str(self.enterprise_customer.uuid)}'
@@ -370,7 +369,6 @@ class TestDefaultEnterpriseEnrollmentIntentionViewSet(BaseTestEnterpriseAPIViews
         enrollment_intention = create_mock_default_enterprise_enrollment_intention(
             enterprise_customer=self.enterprise_customer,
             mock_catalog_api_client=mock_catalog_api_client,
-            contains_content_items=False,
             catalog_list=[],
         )
         mock_get_best_mode_from_course_key.return_value = VERIFIED_COURSE_MODE

--- a/tests/test_integrated_channels/test_degreed2/test_client.py
+++ b/tests/test_integrated_channels/test_degreed2/test_client.py
@@ -256,7 +256,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
         responses.add(
             responses.GET,
             EnterpriseCatalogApiClient.API_BASE_URL
-            + EnterpriseCatalogApiClient.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
+            + EnterpriseCatalogApiClient.CUSTOMER_CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
                 enterprise_config.enterprise_customer.uuid, "key/"
             ),
             json={"skill_names": ["Supply Chain", "Supply Chain Management"]},
@@ -316,7 +316,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
         responses.add(
             responses.GET,
             EnterpriseCatalogApiClient.API_BASE_URL
-            + EnterpriseCatalogApiClient.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
+            + EnterpriseCatalogApiClient.CUSTOMER_CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
                 enterprise_config.enterprise_customer.uuid, "key/"
             ),
             json={"skill_names": ["Supply Chain", "Supply Chain Management"]},
@@ -422,7 +422,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
         responses.add(
             responses.GET,
             EnterpriseCatalogApiClient.API_BASE_URL
-            + EnterpriseCatalogApiClient.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
+            + EnterpriseCatalogApiClient.CUSTOMER_CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
                 enterprise_config.enterprise_customer.uuid, "key/"
             ),
             json={"skill_names": ["Supply Chain", "Supply Chain Management"]},
@@ -479,7 +479,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
         responses.add(
             responses.GET,
             EnterpriseCatalogApiClient.API_BASE_URL
-            + EnterpriseCatalogApiClient.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
+            + EnterpriseCatalogApiClient.CUSTOMER_CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
                 enterprise_config.enterprise_customer.uuid, "key/"
             ),
             json={"skill_names": ["Supply Chain", "Supply Chain Management"]},
@@ -651,7 +651,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
         responses.add(
             responses.GET,
             EnterpriseCatalogApiClient.API_BASE_URL
-            + EnterpriseCatalogApiClient.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
+            + EnterpriseCatalogApiClient.CUSTOMER_CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
                 enterprise_config.enterprise_customer.uuid, "key/"
             ),
             json={"skill_names": ["Supply Chain", "Supply Chain Management"]},
@@ -730,7 +730,7 @@ class TestDegreed2ApiClient(unittest.TestCase):
         responses.add(
             responses.GET,
             EnterpriseCatalogApiClient.API_BASE_URL
-            + EnterpriseCatalogApiClient.CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
+            + EnterpriseCatalogApiClient.CUSTOMER_CONTENT_METADATA_IDENTIFIER_ENDPOINT.format(
                 enterprise_config.enterprise_customer.uuid, "key/"
             ),
             json={"skill_names": ["Supply Chain", "Supply Chain Management"]},

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -247,11 +247,11 @@ class TestDefaultEnterpriseEnrollmentIntention(unittest.TestCase):
         DefaultEnterpriseEnrollmentIntention.objects.all().delete()
 
     @mock.patch(
-        'enterprise.models.get_and_cache_customer_content_metadata',
+        'enterprise.models.get_and_cache_content_metadata',
         return_value=mock.MagicMock(),
     )
-    def test_retrieve_course_run_advertised_course_run(self, mock_get_and_cache_customer_content_metadata):
-        mock_get_and_cache_customer_content_metadata.return_value = self.mock_course
+    def test_retrieve_course_run_advertised_course_run(self, mock_get_and_cache_content_metadata):
+        mock_get_and_cache_content_metadata.return_value = self.mock_course
         default_enterprise_enrollment_intention = DefaultEnterpriseEnrollmentIntention.objects.create(
             enterprise_customer=self.test_enterprise_customer_1,
             content_key='edX+DemoX',
@@ -262,11 +262,11 @@ class TestDefaultEnterpriseEnrollmentIntention(unittest.TestCase):
         assert default_enterprise_enrollment_intention.content_type == DefaultEnterpriseEnrollmentIntention.COURSE
 
     @mock.patch(
-        'enterprise.models.get_and_cache_customer_content_metadata',
+        'enterprise.models.get_and_cache_content_metadata',
         return_value=mock.MagicMock(),
     )
-    def test_retrieve_course_run_with_explicit_course_run(self, mock_get_and_cache_customer_content_metadata):
-        mock_get_and_cache_customer_content_metadata.return_value = self.mock_course
+    def test_retrieve_course_run_with_explicit_course_run(self, mock_get_and_cache_content_metadata):
+        mock_get_and_cache_content_metadata.return_value = self.mock_course
         default_enterprise_enrollment_intention = DefaultEnterpriseEnrollmentIntention.objects.create(
             enterprise_customer=self.test_enterprise_customer_1,
             content_key='course-v1:edX+DemoX+2T2023',
@@ -277,12 +277,12 @@ class TestDefaultEnterpriseEnrollmentIntention(unittest.TestCase):
         assert default_enterprise_enrollment_intention.content_type == DefaultEnterpriseEnrollmentIntention.COURSE_RUN
 
     @mock.patch(
-        'enterprise.models.get_and_cache_customer_content_metadata',
+        'enterprise.models.get_and_cache_content_metadata',
         return_value=mock.MagicMock(),
     )
-    def test_validate_missing_course_run(self, mock_get_and_cache_customer_content_metadata):
+    def test_validate_missing_course_run(self, mock_get_and_cache_content_metadata):
         # Simulate a 404 Not Found by raising an HTTPError exception
-        mock_get_and_cache_customer_content_metadata.side_effect = HTTPError
+        mock_get_and_cache_content_metadata.side_effect = HTTPError
         with self.assertRaises(ValidationError) as exc_info:
             DefaultEnterpriseEnrollmentIntention.objects.create(
                 enterprise_customer=self.test_enterprise_customer_1,
@@ -291,12 +291,12 @@ class TestDefaultEnterpriseEnrollmentIntention(unittest.TestCase):
         self.assertIn('The content key did not resolve to a valid course run.', str(exc_info.exception))
 
     @mock.patch(
-        'enterprise.models.get_and_cache_customer_content_metadata',
+        'enterprise.models.get_and_cache_content_metadata',
         return_value=mock.MagicMock(),
     )
     @override_settings(ROOT_URLCONF="test_utils.admin_urls")
-    def test_validate_existing_soft_deleted_record(self, mock_get_and_cache_customer_content_metadata):
-        mock_get_and_cache_customer_content_metadata.return_value = self.mock_course
+    def test_validate_existing_soft_deleted_record(self, mock_get_and_cache_content_metadata):
+        mock_get_and_cache_content_metadata.return_value = self.mock_course
         existing_record = DefaultEnterpriseEnrollmentIntention.objects.create(
             enterprise_customer=self.test_enterprise_customer_1,
             content_key='edX+DemoX',


### PR DESCRIPTION
Before this commit, normal replication delays from discovery->catalog can easily result in enrollment intentions being un-saveable when simultaneously modifying catalog definitions to include the content. Conversely, normal replication delays can also allow saving an enrollment intention that would eventually become invalid due to content being removed from the catalog, creating a false sense of correctness.

After this commit, we no longer assert during intention save() that the customer's catalogs actually contain the content. Instead, we assert that the content exists at all in the enterprise-catalog database by querying the customer- and catalog-agnostic
`/api/v1/content-metadata/?content_identifiers=<content_key>` endpoint.

Subsequent commits/PRs may introduce dynamic warning messaging (non-blocking) on django admin pages for the customer and intention when the intention's content key is not contained in the customer's catalogs.

ENT-9840