### PR TITLE
fix: Do NOT skip validating intentions which have NO related catalog queries

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.6.9]
+--------
+* fix: Do NOT skip validating intentions which have NO related catalog queries
+
 [5.6.8]
 --------
 * chore: Upgrade Python requirements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.6.8"
+__version__ = "5.6.9"


### PR DESCRIPTION
When testing in prod, I found that Verizon Skills Forward was skipped because it only had a custom/curated catalog (catalog query was NULL). Greatest() in MySQL returns NULL if any input is NULL (unlike PostgreSQL), so adding Coalesce() with an arbitrarily old date is necessary to mimic the PostgreSQL behavior.

ENT-9941