### PR TITLE
fix: cast datetime.datetime to DateTimeField as required by Coalesce()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.6.10]
+--------
+* fix: cast datetime.datetime to DateTimeField as required by Coalesce()
+
 [5.6.9]
 --------
 * fix: Do NOT skip validating intentions which have NO related catalog queries

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.6.9"
+__version__ = "5.6.10"


### PR DESCRIPTION
ENT-9941

Relevant docs
===
<img width="887" alt="Screenshot 2025-02-03 at 4 10 40 PM" src="https://github.com/user-attachments/assets/a8b13884-5fba-47dd-a43d-9deed3214475" />


Testing
===

Before this PR, invoking the management command in devstack results in this ambiguous error (despite unit tests running via SQLite functioning properly):
```
Traceback (most recent call last):
  File "/edx/app/edxapp/edx-platform/./manage.py", line 106, in <module>
    execute_from_command_line([sys.argv[0]] + django_args)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/__init__.py", line 436, in execute
    self.fetch_command(subcommand).run_from_argv(self.argv)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/base.py", line 412, in run_from_argv
    self.execute(*args, **cmd_options)
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/core/management/base.py", line 458, in execute
    output = self.handle(*args, **options)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/src/edx-enterprise/enterprise/management/commands/validate_default_enrollment_intentions.py", line 109, in handle
    results = {intention: self.handle_intention(intention) for intention in intentions}
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/db/models/query.py", line 398, in __iter__
    self._fetch_all()
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/db/models/query.py", line 1881, in _fetch_all
    self._result_cache = list(self._iterable_class(self))
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/db/models/query.py", line 121, in __iter__
    for row in compiler.results_iter(results):
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/db/models/sql/compiler.py", line 1500, in apply_converters
    value = converter(value, expression, connection)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/db/backends/mysql/operations.py", line 331, in convert_datetimefield_value
    value = timezone.make_aware(value, self.connection.timezone)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/utils/timezone.py", line 290, in make_aware
    if is_aware(value):
       ^^^^^^^^^^^^^^^
  File "/edx/app/edxapp/venvs/edxapp/lib/python3.11/site-packages/django/utils/timezone.py", line 256, in is_aware
    return value.utcoffset() is not None
           ^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'utcoffset'
```

After this PR, the management command works properly in a MySQL environment:
```
2025-02-04 00:07:35,790 INFO 1124 [enterprise.management.commands.validate_default_enrollment_intentions] [user None] [ip None] validate_default_enrollment_intentions.py:78 - handle_default_enrollment_intention(): Default enrollment intention <DefaultEnterpriseEnrollmentIntention for customer=298629a4-0fbf-44db-bcfb-9c604eca0bc8 and content_key=edX+DemoX> is compatible with the customer's catalogs.
2025-02-04 00:07:35,790 INFO 1124 [enterprise.management.commands.validate_default_enrollment_intentions] [user None] [ip None] validate_default_enrollment_intentions.py:122 - 1 total enrollment intentions found, and 1/1 were evaluated (0/1 skipped).
2025-02-04 00:07:35,790 INFO 1124 [enterprise.management.commands.validate_default_enrollment_intentions] [user None] [ip None] validate_default_enrollment_intentions.py:127 - Out of 1 total evaluated enrollment intentions, 1/1 passed validation (0/1 invalid).
2025-02-04 00:07:35,790 INFO 1124 [enterprise.management.commands.validate_default_enrollment_intentions] [user None] [ip None] validate_default_enrollment_intentions.py:136 - SUCCESS: All default enrollment intentions are valid!
```