### PR TITLE
Refactor  add foreign key to ecu part 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.8.5]
+--------
+* feat: add management command to backfill `user_fk` values in `EnterpriseCustomerUser` model. Part 3 of adding auth_user as a foreign key.
+
 [5.8.4]
 --------
 * chore: upgrade python requirements.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.8.4"
+__version__ = "5.8.5"

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -82,10 +82,9 @@ class Command(BaseCommand):
         batch_sleep = options.get('batch_sleep', 2)
         max_retries = options.get('max_retries', 5)
 
-        total_rows = EnterpriseCustomerUser.objects.filter(user_fk__isnull=True).count()
-        log.info(f"Starting backfill of {total_rows} rows in batches of {batch_limit}...")
-
         queryset = EnterpriseCustomerUser.objects.filter(user_fk__isnull=True)
+        total_rows = queryset.count()
+
         total_processed = 0
         print('queryset: ', queryset)
 

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -55,29 +55,23 @@ class Command(BaseCommand):
         batch_limit = options['batch_limit']
         batch_sleep = options['batch_sleep']
 
-        role = SystemWideEnterpriseRole.objects.get(name=ENTERPRISE_LEARNER_ROLE)
-        ecus = EnterpriseCustomerUser.objects.select_related('enterprise_customer').filter(linked=True)
+        ecus = EnterpriseCustomerUser.objects.all().filter(user_fk__isnull=True)
 
         for ecu_batch in batch(ecus, batch_size=batch_limit):
+            user_fk_updates = []
             for ecu in ecu_batch:
                 log.info('Processing EnterpriseCustomerUser %s', ecu)
 
-                user = User.objects.get(id=ecu.user_id)
-                enterprise_customer = ecu.enterprise_customer
-                role_assignment, created = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
-                    user=user,
-                    role=role,
-                    enterprise_customer=enterprise_customer
+                ecu.user_fk = ecu.user_id
+                user_fk_updates.append(ecu)
+
+            if user_fk_updates:
+                EnterpriseCustomerUser.objects.bulk_update(
+                    user_fk_updates,
+                    ['user_fk'],
+                    batch_size=batch_limit # setting batch_size for extra safety
                 )
-                if created:
-                    log.info(
-                        'Created SystemWideEnterpriseUserRoleAssignment %s for enterprise user %s',
-                        role_assignment, ecu
-                    )
-                else:
-                    log.info(
-                        'Did not create role assignment for enterprise user %s', ecu
-                    )
+                log.info('Updated %d EnterpriseCustomerUser records', len(user_fk_updates))
 
             sleep(batch_sleep)
 
@@ -85,8 +79,8 @@ class Command(BaseCommand):
         """
         Entry point for management command execution.
         """
-        log.info('Starting assigning enterprise_learner roles to users!')
+        log.info('Starting backfilling ECU user_fk field from user_id!')
 
         self.backfill_ecu_table_user_foreign_key(options)
 
-        log.info('Successfully finished assigning enterprise_learner roles to users!')
+        log.info('Successfully finished backfilling ECU user_fk field from user_id!')

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -8,10 +8,11 @@ from time import sleep
 
 from django.contrib import auth
 from django.core.management.base import BaseCommand
+from django.db import transaction, DatabaseError
 
-from enterprise.constants import ENTERPRISE_LEARNER_ROLE
-from enterprise.models import EnterpriseCustomerUser, SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+from enterprise.models import EnterpriseCustomerUser
 from enterprise.utils import batch
+
 
 log = logging.getLogger(__name__)
 User = auth.get_user_model()
@@ -38,44 +39,70 @@ class Command(BaseCommand):
             help='Number of records in each batch.',
             type=int,
         )
-
+        parser.add_argument(
+            '--max-retries',
+            action='store',
+            dest='max_retries',
+            default=5,
+            help='Max retries for each batch.',
+            type=int,
+        )
         parser.add_argument(
             '--batch-sleep',
             action='store',
             dest='batch_sleep',
-            default=5,
+            default=2,
             help='How long to sleep between batches.',
             type=int,
         )
 
+    def safe_bulk_update(self, entries, max_retries, batch_limit):
+        """Performs bulk_update with retry logic."""
+        count = entries.count()
+        for attempt in range(1, max_retries + 1):
+            try:
+                with transaction.atomic():
+                    EnterpriseCustomerUser.objects.bulk_update(
+                        entries, ['user_fk']
+                    )
+                return count
+            except DatabaseError as e:
+                wait_time = 2 ** attempt
+                log.warning(f"Attempt {attempt}/{max_retries} failed: {e}. Retrying in {wait_time}s.")
+                sleep(wait_time)
+        raise Exception(f"Bulk update failed after {max_retries} retries.")
+
     def backfill_ecu_table_user_foreign_key(self, options):
         """
-        Assigns enterprise_learner role to users.
+        Backfills user_fk from user_id in batches with timeout, retries, and progress reporting.
         """
-        batch_limit = options['batch_limit']
-        batch_sleep = options['batch_sleep']
+        batch_limit = options.get('batch_limit', 250)
+        batch_sleep = options.get('batch_sleep', 2)
+        max_retries = options.get('max_retries', 5)
 
-        ecus = EnterpriseCustomerUser.objects.all().filter(user_fk__isnull=True)
+        total_rows = EnterpriseCustomerUser.objects.filter(user_fk__isnull=True).count()
+        log.info(f"Starting backfill of {total_rows} rows in batches of {batch_limit}...")
 
-        for ecu_batch in batch(ecus, batch_size=batch_limit):
-            user_fk_updates = []
+        queryset = EnterpriseCustomerUser.objects.filter(user_fk__isnull=True)
+        total_processed = 0
+        print('queryset: ', queryset)
+
+        while queryset.exists():
+            ecu_batch = queryset[:batch_limit]
+
             for ecu in ecu_batch:
-                log.info('Processing EnterpriseCustomerUser %s', ecu)
-
+                log.info(f"Processing EnterpriseCustomerUser {ecu.id}")
                 ecu.user_fk = ecu.user_id
-                user_fk_updates.append(ecu)
 
-            if user_fk_updates:
-                EnterpriseCustomerUser.objects.bulk_update(
-                    user_fk_updates,
-                    ['user_fk'],
-                    batch_size=batch_limit # setting batch_size for extra safety
-                )
-                log.info('Updated %d EnterpriseCustomerUser records', len(user_fk_updates))
-
+            count = self.safe_bulk_update(ecu_batch, max_retries, batch_limit)
+            total_processed += count
+            log.info(f"Processed {total_processed}/{total_rows} rows.")
             sleep(batch_sleep)
 
-    def handle(self, *args, **options):
+        log.info(f"Backfill complete! Processed {total_processed}/{total_rows} records.")
+
+
+    def handle(self, **options):
         """
         Entry point for management command execution.
         """

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -8,10 +8,9 @@ from time import sleep
 
 from django.contrib import auth
 from django.core.management.base import BaseCommand
-from django.db import transaction, DatabaseError
+from django.db import DatabaseError, transaction
 
 from enterprise.models import EnterpriseCustomerUser
-
 
 log = logging.getLogger(__name__)
 User = auth.get_user_model()
@@ -104,8 +103,7 @@ class Command(BaseCommand):
 
         log.info(f"Backfill complete! Processed {total_processed}/{total_rows} records.")
 
-
-    def handle(self, *args, **options): # pylint: disable=unused-argument
+    def handle(self, *_args, **options):
         """
         Entry point for management command execution.
         """

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -1,0 +1,92 @@
+"""
+Management command for assigning enterprise_learner roles
+to existing linked enterprise users that are missing them.
+"""
+
+import logging
+from time import sleep
+
+from django.contrib import auth
+from django.core.management.base import BaseCommand
+
+from enterprise.constants import ENTERPRISE_LEARNER_ROLE
+from enterprise.models import EnterpriseCustomerUser, SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+from enterprise.utils import batch
+
+log = logging.getLogger(__name__)
+User = auth.get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Management command to copy `user_id` values to the foreign key `user_fk` field in the enterprise_customer_user table.
+
+    Example usage:
+        $ ./manage.py backfill_ecu_table_user_foreign_key
+    """
+    help = 'Goes through the Enterprise Customer User table in batches and copies the user_id to the user_fk foreign key.'
+
+    def add_arguments(self, parser):
+        """
+        Entry point for subclassed commands to add custom arguments.
+        """
+        parser.add_argument(
+            '--batch-limit',
+            action='store',
+            dest='batch_limit',
+            default=250,
+            help='Number of records in each batch.',
+            type=int,
+        )
+
+        parser.add_argument(
+            '--batch-sleep',
+            action='store',
+            dest='batch_sleep',
+            default=5,
+            help='How long to sleep between batches.',
+            type=int,
+        )
+
+    def backfill_ecu_table_user_foreign_key(self, options):
+        """
+        Assigns enterprise_learner role to users.
+        """
+        batch_limit = options['batch_limit']
+        batch_sleep = options['batch_sleep']
+
+        role = SystemWideEnterpriseRole.objects.get(name=ENTERPRISE_LEARNER_ROLE)
+        ecus = EnterpriseCustomerUser.objects.select_related('enterprise_customer').filter(linked=True)
+
+        for ecu_batch in batch(ecus, batch_size=batch_limit):
+            for ecu in ecu_batch:
+                log.info('Processing EnterpriseCustomerUser %s', ecu)
+
+                user = User.objects.get(id=ecu.user_id)
+                enterprise_customer = ecu.enterprise_customer
+                role_assignment, created = SystemWideEnterpriseUserRoleAssignment.objects.get_or_create(
+                    user=user,
+                    role=role,
+                    enterprise_customer=enterprise_customer
+                )
+                if created:
+                    log.info(
+                        'Created SystemWideEnterpriseUserRoleAssignment %s for enterprise user %s',
+                        role_assignment, ecu
+                    )
+                else:
+                    log.info(
+                        'Did not create role assignment for enterprise user %s', ecu
+                    )
+
+            sleep(batch_sleep)
+
+    def handle(self, *args, **options):
+        """
+        Entry point for management command execution.
+        """
+        log.info('Starting assigning enterprise_learner roles to users!')
+
+        self.backfill_ecu_table_user_foreign_key(options)
+
+        log.info('Successfully finished assigning enterprise_learner roles to users!')

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -23,7 +23,7 @@ def safe_bulk_update(entries, properties, max_retries):
     for attempt in range(1, max_retries + 1):
         try:
             with transaction.atomic():
-                EnterpriseCustomerUser.objects.bulk_update(
+                EnterpriseCustomerUser.all_objects.bulk_update(
                     entries, properties
                 )
             return len(entries)

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -38,7 +38,8 @@ def _fetch_and_update_in_batches(queryset, batch_limit, batch_sleep, max_retries
     """
     Fetches and updates records in batches.
     Only loads and updates a subset of records at a time to avoid memory and performance issues.
-    Note: you cannot use django's queryset.iterator() method as MySQL does not support it and will still load everything into memory.
+    Note: you cannot use django's queryset.iterator() method
+    as MySQL does not support it and will still load everything into memory.
     """
     batch_counter = 1
     total_processed = 0

--- a/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
+++ b/enterprise/management/commands/backfill_ecu_table_user_foreign_key.py
@@ -29,6 +29,7 @@ def safe_bulk_update(entries, properties, max_retries):
             wait_time = 2 ** attempt
             log.warning(f"Attempt {attempt}/{max_retries} failed: {e}. Retrying in {wait_time}s.")
             sleep(wait_time)
+
     raise Exception(f"Bulk update failed after {max_retries} retries.")
 
 

--- a/enterprise/models.py
+++ b/enterprise/models.py
@@ -1148,6 +1148,8 @@ class EnterpriseCustomerUser(TimeStampedModel):
                 enterprise_customer=self.enterprise_customer,
             )
 
+        self.user_fk = self.user_id
+
         return super().save(*args, **kwargs)
 
     @property

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -24,7 +24,6 @@ from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import validate_email
 from django.db import utils
-from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
 from django.http import Http404
@@ -1828,29 +1827,6 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
             if created:
                 track_enrollment('admin-enrollment', user.id, course_id)
     return succeeded
-
-
-def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000):
-    """
-    yield per batch efficiently
-    using limit/offset does a lot of table scanning to reach higher offsets
-    this scanning can be slow on very large tables
-    if you order by pk, you can use the pk as a pivot rather than offset
-    this utilizes the index, which is faster than scanning to reach offset
-    Example usage:
-    csod_only_filter = Q(integrated_channel_code='CSOD')
-    for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_only_filter):
-        for item in items_batch:
-            ...
-    """
-    qs = ModelClass.objects.filter(extra_filter).order_by('pk')[:batch_size]
-    while qs.exists():
-        yield qs
-        # qs.last() doesn't work here because we've already sliced
-        # loop through so we eventually grab the last one
-        for item in qs:
-            start_pk = item.pk
-        qs = ModelClass.objects.filter(pk__gt=start_pk).filter(extra_filter).order_by('pk')[:batch_size]
 
 
 def customer_admin_enroll_user_with_status(

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -24,6 +24,7 @@ from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import validate_email
 from django.db import utils
+from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
 from django.http import Http404
@@ -1827,6 +1828,29 @@ def enroll_user(enterprise_customer, user, course_mode, *course_ids, **kwargs):
             if created:
                 track_enrollment('admin-enrollment', user.id, course_id)
     return succeeded
+
+
+def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000):
+    """
+    yield per batch efficiently
+    using limit/offset does a lot of table scanning to reach higher offsets
+    this scanning can be slow on very large tables
+    if you order by pk, you can use the pk as a pivot rather than offset
+    this utilizes the index, which is faster than scanning to reach offset
+    Example usage:
+    csod_only_filter = Q(integrated_channel_code='CSOD')
+    for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_only_filter):
+        for item in items_batch:
+            ...
+    """
+    qs = ModelClass.objects.filter(extra_filter).order_by('pk')[:batch_size]
+    while qs.exists():
+        yield qs
+        # qs.last() doesn't work here because we've already sliced
+        # loop through so we eventually grab the last one
+        for item in qs:
+            start_pk = item.pk
+        qs = ModelClass.objects.filter(pk__gt=start_pk).filter(extra_filter).order_by('pk')[:batch_size]
 
 
 def customer_admin_enroll_user_with_status(

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -438,7 +438,7 @@ def batch_by_pk(ModelClass, extra_filter=Q(), batch_size=10000, model_manager=No
         # loop through so we eventually grab the last one
         for item in qs:
             start_pk = item.pk
-        qs = ModelClass.objects.filter(pk__gt=start_pk).filter(extra_filter).order_by('pk')[:batch_size]
+        qs = model_manager.filter(pk__gt=start_pk).filter(extra_filter).order_by('pk')[:batch_size]
 
 
 def truncate_item_dicts(items_to_create, items_to_update, items_to_delete, combined_maximum_size):

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -21,11 +21,8 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from django.utils.html import strip_tags
 
-from enterprise.utils import (
-    parse_datetime_handle_invalid,
-    parse_lms_api_datetime,
-    batch_by_pk as enterprise_batch_by_pk
-)
+from enterprise.utils import batch_by_pk as enterprise_batch_by_pk
+from enterprise.utils import parse_datetime_handle_invalid, parse_lms_api_datetime
 from integrated_channels.catalog_service_utils import get_course_run_for_enrollment
 
 UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -21,7 +21,11 @@ from django.core.exceptions import ObjectDoesNotExist
 from django.utils import timezone
 from django.utils.html import strip_tags
 
-from enterprise.utils import parse_datetime_handle_invalid, parse_lms_api_datetime, batch_by_pk as enterprise_batch_by_pk
+from enterprise.utils import (
+  parse_datetime_handle_invalid,
+  parse_lms_api_datetime,
+  batch_by_pk as enterprise_batch_by_pk
+)
 from integrated_channels.catalog_service_utils import get_course_run_for_enrollment
 
 UNIX_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -22,9 +22,9 @@ from django.utils import timezone
 from django.utils.html import strip_tags
 
 from enterprise.utils import (
-  parse_datetime_handle_invalid,
-  parse_lms_api_datetime,
-  batch_by_pk as enterprise_batch_by_pk
+    parse_datetime_handle_invalid,
+    parse_lms_api_datetime,
+    batch_by_pk as enterprise_batch_by_pk
 )
 from integrated_channels.catalog_service_utils import get_course_run_for_enrollment
 

--- a/integrated_channels/utils.py
+++ b/integrated_channels/utils.py
@@ -417,6 +417,18 @@ def is_valid_url(url):
 
 
 def batch_by_pk(*args, **kwargs):
+    """
+    yield per batch efficiently
+    using limit/offset does a lot of table scanning to reach higher offsets
+    this scanning can be slow on very large tables
+    if you order by pk, you can use the pk as a pivot rather than offset
+    this utilizes the index, which is faster than scanning to reach offset
+    Example usage:
+    csod_only_filter = Q(integrated_channel_code='CSOD')
+    for items_batch in batch_by_pk(ContentMetadataItemTransmission, extra_filter=csod_only_filter):
+        for item in items_batch:
+            ...
+    """
     return enterprise_batch_by_pk(*args, **kwargs)
 
 

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -1,0 +1,146 @@
+"""
+Tests for the Django management command `backfill_ecu_table_user_foreign_key`.
+"""
+
+# import ddt
+# import factory
+# from pytest import mark
+
+# from django.core.management import call_command
+from django.test import TestCase
+# from django.contrib import auth
+# from django.db.models import signals
+
+# from enterprise.models import EnterpriseCustomerUser, EnterpriseCustomer
+# from test_utils import factories
+# EXCEPTION = "DUMMY_TRACE_BACK"
+
+# User = auth.get_user_model()
+
+# @mark.django_db
+# @ddt.ddt
+class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
+    """
+    Test command `backfill_ecu_table_user_foreign_key`.
+    """
+    command = 'backfill_ecu_table_user_foreign_key'
+
+    def test_verify(self):
+        assert 1 == 1
+
+    # @factory.django.mute_signals(signals.post_save)
+    # def setUp(self):
+    #     super().setUp()
+    #     self.cleanup_test_objects()
+
+    #     for i in range(100):
+    #         factories.UserFactory(username=f'user-{i}')
+
+    #     self.alpha_customer = factories.EnterpriseCustomerFactory(
+    #         name='alpha',
+    #     )
+    #     self.beta_customer = factories.EnterpriseCustomerFactory(
+    #         name='beta',
+    #     )
+
+    #     users = User.objects.all()
+
+    #     # Make a bunch of users for an ENT customer
+    #     for index, user in enumerate(users[0:30]):
+    #         factories.EnterpriseCustomerUserFactory(
+    #             user_id=user.id,
+    #             enterprise_customer=self.alpha_customer,
+    #         )
+
+    #     # Make a bunch of users for another ENT customer
+    #     for index, user in enumerate(users[30:65]):
+    #         factories.EnterpriseCustomerUserFactory(
+    #             user_id=user.id,
+    #             enterprise_customer=self.beta_customer,
+    #         )
+
+    #     # Make some users that are NOT LINKED, so we should ignore them
+    #     for index, user in enumerate(users[65:75]):
+    #         ecu = factories.EnterpriseCustomerUserFactory(
+    #             user_id=user.id,
+    #             enterprise_customer=self.alpha_customer,
+    #         )
+    #         ecu.linked = False
+    #         ecu.save()
+
+    #     # Now make a subset of first set of enterprise customers also have
+    #     # EnterpriseCustomerUser records with a 2nd enterprise customer
+    #     for index, user in enumerate(users[0:15]):
+    #         factories.EnterpriseCustomerUserFactory(
+    #             user_id=user.id,
+    #             enterprise_customer=self.beta_customer,
+    #         )
+
+    #     self.addCleanup(self.cleanup_test_objects)
+
+    # # def test_user_role_assignments_created(self):
+    # #     """
+    # #     Verify that the management command correctly creates User Role Assignments
+    # #     for enterprise customer users missing them.
+    # #     """
+
+    # #     assert EnterpriseCustomerUser.all_objects.count() == 90
+    # #     assert SystemWideEnterpriseUserRoleAssignment.objects.filter(
+    # #         enterprise_customer=self.alpha_customer
+    # #     ).count() == 15
+    # #     assert SystemWideEnterpriseUserRoleAssignment.objects.filter(
+    # #         enterprise_customer=self.beta_customer
+    # #     ).count() == 24
+
+    # #     call_command(
+    # #         'backfill_learner_role_assignments',
+    # #         '--batch-sleep',
+    # #         '0',
+    # #         '--batch-limit',
+    # #         '10',
+    # #     )
+
+    # #     # Notice the discrepancy of values: 90 != 30 + 50
+    # #     # That's because 10 ECU records are linked=False, so we dont
+    # #     # create a role assignment for them
+    # #     assert EnterpriseCustomerUser.all_objects.count() == 90
+    # #     assert SystemWideEnterpriseUserRoleAssignment.objects.filter(
+    # #         enterprise_customer=self.alpha_customer
+    # #     ).count() == 30
+    # #     assert SystemWideEnterpriseUserRoleAssignment.objects.filter(
+    # #         enterprise_customer=self.beta_customer
+    # #     ).count() == 50
+    # #     for ecu in EnterpriseCustomerUser.objects.all():
+    # #         assert SystemWideEnterpriseUserRoleAssignment.objects.filter(user=ecu.user).exists()
+
+    # def cleanup_test_objects(self):
+    #     """
+    #     Helper to delete all instances of role assignments, ECUs, Enterprise customers, and Users.
+    #     """
+    #     EnterpriseCustomerUser.objects.all().delete()
+    #     EnterpriseCustomer.objects.all().delete()
+    #     User.objects.all().delete()
+
+    # def test_copies_user_id_to_user_fk(self):
+    #     assert EnterpriseCustomerUser.objects.first().user_fk is None
+    #     call_command(self.command)
+    #     assert EnterpriseCustomerUser.objects.first().user_fk is EnterpriseCustomerUser.objects.first().user_id
+    
+    # def test_runs_in_batches(self):
+    #     pass
+    
+    # def test_sleeps_between_batches(self):
+    #     pass
+    
+    # def test_skips_rows_that_already_have_user_fk(self):
+    #     pass
+    
+    # def test_times_out_after_5_seconds_per_batch(self):
+    #     pass
+    
+    # def test_retry_5_times_on_failure(self):
+    #     pass
+    
+    # def test_logs_progress_and_errors(self):
+    #     pass
+

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -125,4 +125,4 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
         queryset = kwargs.get("queryset")
 
         # Check that QuerySet was NOT evaluated before `_fetch_and_update_in_batches`
-        assert queryset._result_cache is None, "QuerySet was evaluated too early!" # pylint: disable=protected-access
+        assert queryset._result_cache is None, "QuerySet was evaluated too early!"  # pylint: disable=protected-access

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -13,11 +13,13 @@ from django.core.management import call_command
 from django.db.models import signals
 from django.test import TestCase
 
-from enterprise.models import EnterpriseCustomerUser, EnterpriseCustomer
+from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
 from test_utils import factories
+
 EXCEPTION = "DUMMY_TRACE_BACK"
 
 User = auth.get_user_model()
+
 
 @mark.django_db
 @ddt.ddt
@@ -83,8 +85,8 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
     @patch('logging.Logger.warning')
     def test_retry_5_times_on_failure(self, mock_log):
         with patch(
-            ("enterprise.management.commands.backfill_ecu_table_user_foreign_key."
-            "EnterpriseCustomerUser.objects.bulk_update"),
+            ("enterprise.management.commands.backfill_ecu_table_user_foreign_key." +
+                "EnterpriseCustomerUser.objects.bulk_update"),
             side_effect=Exception(EXCEPTION)
         ):
             with self.assertRaises(Exception) as e:

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -2,81 +2,81 @@
 Tests for the Django management command `backfill_ecu_table_user_foreign_key`.
 """
 
-# import ddt
-# import factory
-# from pytest import mark
+import ddt
+import factory
+from pytest import mark
+from unittest.mock import patch
 
-# from django.core.management import call_command
+from django.core.management import call_command
 from django.test import TestCase
-# from django.contrib import auth
-# from django.db.models import signals
+from django.contrib import auth
+from django.db.models import signals
 
-# from enterprise.models import EnterpriseCustomerUser, EnterpriseCustomer
-# from test_utils import factories
-# EXCEPTION = "DUMMY_TRACE_BACK"
+from enterprise.models import EnterpriseCustomerUser, EnterpriseCustomer
+from test_utils import factories
+EXCEPTION = "DUMMY_TRACE_BACK"
 
-# User = auth.get_user_model()
+User = auth.get_user_model()
 
-# @mark.django_db
-# @ddt.ddt
+@mark.django_db
+@ddt.ddt
 class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
     """
     Test command `backfill_ecu_table_user_foreign_key`.
     """
     command = 'backfill_ecu_table_user_foreign_key'
 
-    def test_verify(self):
-        assert 1 == 1
 
-    # @factory.django.mute_signals(signals.post_save)
-    # def setUp(self):
-    #     super().setUp()
-    #     self.cleanup_test_objects()
 
-    #     for i in range(100):
-    #         factories.UserFactory(username=f'user-{i}')
+    @factory.django.mute_signals(signals.post_save)
+    def setUp(self):
+        super().setUp()
+        self.cleanup_test_objects()
 
-    #     self.alpha_customer = factories.EnterpriseCustomerFactory(
-    #         name='alpha',
-    #     )
-    #     self.beta_customer = factories.EnterpriseCustomerFactory(
-    #         name='beta',
-    #     )
+        for i in range(100):
+            factories.UserFactory(username=f'user-{i}')
 
-    #     users = User.objects.all()
+        self.alpha_customer = factories.EnterpriseCustomerFactory(
+            name='alpha',
+        )
+        self.beta_customer = factories.EnterpriseCustomerFactory(
+            name='beta',
+        )
 
-    #     # Make a bunch of users for an ENT customer
-    #     for index, user in enumerate(users[0:30]):
-    #         factories.EnterpriseCustomerUserFactory(
-    #             user_id=user.id,
-    #             enterprise_customer=self.alpha_customer,
-    #         )
+        users = User.objects.all()
 
-    #     # Make a bunch of users for another ENT customer
-    #     for index, user in enumerate(users[30:65]):
-    #         factories.EnterpriseCustomerUserFactory(
-    #             user_id=user.id,
-    #             enterprise_customer=self.beta_customer,
-    #         )
+        # Make a bunch of users for an ENT customer
+        for index, user in enumerate(users[0:30]):
+            factories.EnterpriseCustomerUserFactory(
+                user_id=user.id,
+                enterprise_customer=self.alpha_customer,
+            )
 
-    #     # Make some users that are NOT LINKED, so we should ignore them
-    #     for index, user in enumerate(users[65:75]):
-    #         ecu = factories.EnterpriseCustomerUserFactory(
-    #             user_id=user.id,
-    #             enterprise_customer=self.alpha_customer,
-    #         )
-    #         ecu.linked = False
-    #         ecu.save()
+        # Make a bunch of users for another ENT customer
+        for index, user in enumerate(users[30:65]):
+            factories.EnterpriseCustomerUserFactory(
+                user_id=user.id,
+                enterprise_customer=self.beta_customer,
+            )
 
-    #     # Now make a subset of first set of enterprise customers also have
-    #     # EnterpriseCustomerUser records with a 2nd enterprise customer
-    #     for index, user in enumerate(users[0:15]):
-    #         factories.EnterpriseCustomerUserFactory(
-    #             user_id=user.id,
-    #             enterprise_customer=self.beta_customer,
-    #         )
+        # Make some users that are NOT LINKED, so we should ignore them
+        for index, user in enumerate(users[65:75]):
+            ecu = factories.EnterpriseCustomerUserFactory(
+                user_id=user.id,
+                enterprise_customer=self.alpha_customer,
+            )
+            ecu.linked = False
+            ecu.save()
 
-    #     self.addCleanup(self.cleanup_test_objects)
+        # Now make a subset of first set of enterprise customers also have
+        # EnterpriseCustomerUser records with a 2nd enterprise customer
+        for index, user in enumerate(users[0:15]):
+            factories.EnterpriseCustomerUserFactory(
+                user_id=user.id,
+                enterprise_customer=self.beta_customer,
+            )
+
+        self.addCleanup(self.cleanup_test_objects)
 
     # # def test_user_role_assignments_created(self):
     # #     """
@@ -113,34 +113,35 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
     # #     for ecu in EnterpriseCustomerUser.objects.all():
     # #         assert SystemWideEnterpriseUserRoleAssignment.objects.filter(user=ecu.user).exists()
 
-    # def cleanup_test_objects(self):
-    #     """
-    #     Helper to delete all instances of role assignments, ECUs, Enterprise customers, and Users.
-    #     """
-    #     EnterpriseCustomerUser.objects.all().delete()
-    #     EnterpriseCustomer.objects.all().delete()
-    #     User.objects.all().delete()
+    def cleanup_test_objects(self):
+        """
+        Helper to delete all instances of role assignments, ECUs, Enterprise customers, and Users.
+        """
+        EnterpriseCustomerUser.objects.all().delete()
+        EnterpriseCustomer.objects.all().delete()
+        User.objects.all().delete()
 
-    # def test_copies_user_id_to_user_fk(self):
-    #     assert EnterpriseCustomerUser.objects.first().user_fk is None
-    #     call_command(self.command)
-    #     assert EnterpriseCustomerUser.objects.first().user_fk is EnterpriseCustomerUser.objects.first().user_id
-    
-    # def test_runs_in_batches(self):
-    #     pass
-    
-    # def test_sleeps_between_batches(self):
-    #     pass
-    
-    # def test_skips_rows_that_already_have_user_fk(self):
-    #     pass
-    
+    def test_copies_user_id_to_user_fk(self):
+        assert EnterpriseCustomerUser.objects.first().user_fk is None
+        call_command(self.command)
+        assert EnterpriseCustomerUser.objects.first().user_fk is EnterpriseCustomerUser.objects.first().user_id
+
+    @patch('logging.Logger.info')
+    @patch('time.sleep')
+    def test_runs_in_batches(self, mock_sleep, mock_log):
+        call_command(self.command, batch_limit=10)
+        assert mock_sleep.call_count == 8
+        assert mock_log.called_with('Updated %d EnterpriseCustomerUser records', 10)
+
+    def test_skips_rows_that_already_have_user_fk(self):
+        ecu = EnterpriseCustomerUser.objects.first()
+        ecu.user_fk = -1
+        ecu.save()
+        call_command(self.command)
+        assert EnterpriseCustomerUser.objects.first().user_fk == -1
+
     # def test_times_out_after_5_seconds_per_batch(self):
-    #     pass
-    
-    # def test_retry_5_times_on_failure(self):
-    #     pass
-    
-    # def test_logs_progress_and_errors(self):
-    #     pass
 
+    # def test_retry_5_times_on_failure(self):
+
+    # def test_logs_progress_and_errors(self):

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -2,15 +2,16 @@
 Tests for the Django management command `backfill_ecu_table_user_foreign_key`.
 """
 
+from unittest.mock import patch
+
 import ddt
 import factory
 from pytest import mark
-from unittest.mock import patch
 
-from django.core.management import call_command
-from django.test import TestCase
 from django.contrib import auth
+from django.core.management import call_command
 from django.db.models import signals
+from django.test import TestCase
 
 from enterprise.models import EnterpriseCustomerUser, EnterpriseCustomer
 from test_utils import factories
@@ -41,7 +42,7 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
         users = User.objects.all()
 
         # Make a bunch of users for an ENT customer
-        for index, user in enumerate(users[0:10]):
+        for _index, user in enumerate(users[0:10]):
             factories.EnterpriseCustomerUserFactory(
                 user_id=user.id,
                 enterprise_customer=self.customer,

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -108,10 +108,9 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
             side_effect=DatabaseError(EXCEPTION)
         ):
             with self.assertRaises(Exception) as e:
-                call_command(self.command, max_retries=5)
+                call_command(self.command, max_retries=2)
             mock_log.assert_any_call('Attempt 1/2 failed: DUMMY_TRACE_BACK. Retrying in 2s.')
             mock_log.assert_any_call('Attempt 2/2 failed: DUMMY_TRACE_BACK. Retrying in 4s.')
-            mock_log.assert_any_call('No.')
 
     @patch("enterprise.management.commands.backfill_ecu_table_user_foreign_key._fetch_and_update_in_batches")
     def test_doesnt_load_all_rows_into_memory(self, mock_fetch_and_update):

--- a/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
+++ b/tests/test_enterprise/management/test_backfill_ecu_table_user_foreign_key.py
@@ -107,7 +107,7 @@ class CreateEnterpriseCourseEnrollmentCommandTests(TestCase):
                 "EnterpriseCustomerUser.objects.bulk_update"),
             side_effect=DatabaseError(EXCEPTION)
         ):
-            with self.assertRaises(Exception) as e:
+            with self.assertRaises(Exception):
                 call_command(self.command, max_retries=2)
             mock_log.assert_any_call('Attempt 1/2 failed: DUMMY_TRACE_BACK. Retrying in 2s.')
             mock_log.assert_any_call('Attempt 2/2 failed: DUMMY_TRACE_BACK. Retrying in 4s.')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -814,6 +814,29 @@ class TestEnterpriseCustomerUser(unittest.TestCase):
         enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=42)
         assert enterprise_customer_user.user_email is None
 
+    def test_on_create_should_set_user_fk_to_user_id(self):
+        """Test that user_fk is set to user_id when creating a record."""
+        user_id = 123
+        enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=user_id)
+        enterprise_customer_user.refresh_from_db()
+
+        assert enterprise_customer_user.user_fk == user_id, (
+            f"Expected user_fk to be {user_id}, but got {enterprise_customer_user.user_fk}"
+        )
+
+    def test_on_update_should_set_user_fk_to_user_id(self):
+        """Test that user_fk updates when user_id is modified and saved."""
+        enterprise_customer_user = factories.EnterpriseCustomerUserFactory(user_id=100)
+
+        new_user_id = 200
+        enterprise_customer_user.user_id = new_user_id
+        enterprise_customer_user.save()
+        enterprise_customer_user.refresh_from_db()
+
+        assert enterprise_customer_user.user_fk == new_user_id, (
+            f"Expected user_fk to update to {new_user_id}, but got {enterprise_customer_user.user_fk}"
+        )
+
     @ddt.data("alberteinstein", "richardfeynman", "leosusskind")
     def test_username_property_user_exists(self, username):
         user_instance = factories.UserFactory(username=username)


### PR DESCRIPTION
Part 3 of #2338 .

Should be merged after other two parts are merged and deployed.

To Do:
Edit save() method or something to make sure any record added after merge will add the correct value to `user_fk`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
