### PR TITLE
feat: expose catalog_query_search_filters_enabled feature flag

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.8.0]
+--------
+* feat: exposes Waffle flag for MFEs' incremental migration to querying Algolia with non-enterprise-specific data
+
 [5.7.0]
 --------
 * feat: adds endpoint to list group memberships for a learner

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.7.0"
+__version__ = "5.8.0"

--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -91,6 +91,18 @@ ADMIN_PORTAL_LEARNER_PROFILE_VIEW_ENABLED = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
+# .. toggle_name: enterprise.catalog_query_search_filters_enabled
+# .. toggle_implementation: WaffleFlag
+# .. toggle_default: False
+# .. toggle_description: Enables filtering search results by catalog queries vs. enterprise-specific attributes.
+# .. toggle_use_cases: open_edx
+# .. toggle_creation_date: 2025-03-02
+CATALOG_QUERY_SEARCH_FILTERS_ENABLED = WaffleFlag(
+    f'{ENTERPRISE_NAMESPACE}.catalog_query_search_filters_enabled',
+    __name__,
+    ENTERPRISE_LOG_PREFIX,
+)
+
 
 def top_down_assignment_real_time_lcm():
     """
@@ -141,6 +153,13 @@ def admin_portal_learner_profile_view_enabled():
     return ADMIN_PORTAL_LEARNER_PROFILE_VIEW_ENABLED.is_enabled()
 
 
+def catalog_query_search_filters_enabled():
+    """
+    Returns whether the catalog query search filters feature flag is enabled.
+    """
+    return CATALOG_QUERY_SEARCH_FILTERS_ENABLED.is_enabled()
+
+
 def enterprise_features():
     """
     Returns a dict of enterprise Waffle-based feature flags.
@@ -153,4 +172,5 @@ def enterprise_features():
         'enterprise_groups_v2': enterprise_groups_v2(),
         'enterprise_learner_bff_enabled': enterprise_learner_bff_enabled(),
         'admin_portal_learner_profile_view_enabled': admin_portal_learner_profile_view_enabled(),
+        'catalog_query_search_filters_enabled': catalog_query_search_filters_enabled(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -307,6 +307,7 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                     'enterprise_groups_v2': False,
                     'enterprise_learner_bff_enabled': False,
                     'admin_portal_learner_profile_view_enabled': False,
+                    'catalog_query_search_filters_enabled': False,
                 }
             }
             assert response == mock_empty_200_success_response

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -72,6 +72,7 @@ from enterprise.models import (
 from enterprise.roles_api import admin_role
 from enterprise.toggles import (
     ADMIN_PORTAL_LEARNER_PROFILE_VIEW_ENABLED,
+    CATALOG_QUERY_SEARCH_FILTERS_ENABLED,
     ENTERPRISE_CUSTOMER_SUPPORT_TOOL,
     ENTERPRISE_GROUPS_V1,
     ENTERPRISE_GROUPS_V2,
@@ -2027,64 +2028,65 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
     @ddt.data(
         # Request missing required permissions query param.
         (True, False, [], {}, False, {'detail': 'User is not allowed to access the view.'},
-         False, False, False, False, False, False, False),
+         False, False, False, False, False, False, False, False),
         # Staff user that does not have the specified group permission.
         (True, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False, False, False, False),
         # Staff user that does have the specified group permission.
         (True, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False, False, False, False),
+         True, None, False, False, False, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, nor do they have the group permission.
         (False, False, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False, False, False, False),
         # Non staff user that is not linked to the enterprise, but does have the group permission.
         (False, False, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         False, None, False, False, False, False, False, False, False),
+         False, None, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise, but does not have the group permission.
         (False, True, [], {'permissions': ['enterprise_enrollment_api_access']}, False,
-         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False, False, False),
+         {'detail': 'User is not allowed to access the view.'}, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and does have the group permission
         (False, True, ['enterprise_enrollment_api_access'], {'permissions': ['enterprise_enrollment_api_access']},
-         True, None, False, False, False, False, False, False, False),
+         True, None, False, False, False, False, False, False, False, False),
         # Non staff user that is linked to the enterprise and has group permission and the request has passed
         # multiple groups to check.
         (False, True, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access', 'enterprise_data_api_access']}, True, None, False,
-         False, False, False, False, False, False),
+         False, False, False, False, False, False, False),
         # Staff user with group permission filtering on non existent enterprise id.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[1]}, False,
-         None, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on enterprise id successfully.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'enterprise_id': FAKE_UUIDS[0]}, True,
-         None, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on search param with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'blah'}, False,
-         None, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on search param with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'search': 'test'}, True,
-         None, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False),
         # Staff user with group permissions filtering on slug with no results.
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': 'blah'}, False,
-         None, False, False, False, False, False, False, False),
+         None, False, False, False, False, False, False, False, False),
         # Staff user with group permission filtering on slug with results, with
         # top down assignment & real-time LCM feature enabled,
         # prequery search results enabled and
         # enterprise groups v1 feature enabled
         # enterprise groups v2 feature enabled
         # enterprise customer support tool enabled
-        # enterprise learner bff enabled
+        # enterprise learner bff enabled,
+        # admin portal learner profile view enabled
         (True, False, ['enterprise_enrollment_api_access'],
          {'permissions': ['enterprise_enrollment_api_access'], 'slug': TEST_SLUG}, True,
-         None, True, True, True, True, True, True, True),
+         None, True, True, True, True, True, True, True, True),
     )
     @ddt.unpack
     @mock.patch('enterprise.utils.get_logo_url')
@@ -2103,6 +2105,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             enterprise_customer_support_tool_enabled,
             enterprise_learner_bff_enabled,
             admin_portal_learner_profile_view_enabled,
+            catalog_query_search_filters_enabled,
             mock_get_logo_url,
     ):
         """
@@ -2152,7 +2155,6 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
             active=is_top_down_assignment_real_time_lcm_enabled
         ):
-
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
@@ -2160,7 +2162,6 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
             active=feature_prequery_search_suggestions_enabled
         ):
-
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
@@ -2195,6 +2196,13 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
         with override_waffle_flag(
             ADMIN_PORTAL_LEARNER_PROFILE_VIEW_ENABLED,
             active=admin_portal_learner_profile_view_enabled
+        ):
+            response = client.get(
+                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
+            )
+        with override_waffle_flag(
+            CATALOG_QUERY_SEARCH_FILTERS_ENABLED,
+            active=catalog_query_search_filters_enabled
         ):
             response = client.get(
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
@@ -2271,6 +2279,7 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'enterprise_groups_v2': enterprise_groups_v2_enabled,
                     'enterprise_learner_bff_enabled': enterprise_learner_bff_enabled,
                     'admin_portal_learner_profile_view_enabled': admin_portal_learner_profile_view_enabled,
+                    'catalog_query_search_filters_enabled': catalog_query_search_filters_enabled,
                 }
             }
             assert response in (expected_error, mock_empty_200_success_response)


### PR DESCRIPTION
[ENT-10106](https://2u-internal.atlassian.net/browse/ENT-10106)

> To de-risk changes where possible, we would like to avoid an instant cutover from querying Algolia in the Enterprise Learner/Admin Portal MFEs by enterprise-specific attributes (e.g., `enterprise_customer_uuids`) to non-enterprise-specific attributes (e.g., `enterprise_catalog_query_uuids`). Instead, we’d like to expose a Waffle flag for an percentage-based incremental migration from the current filtering strategy to the new.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
