### PR TITLE
chore: migrate analytics_summary API to Xpert v2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.8.3]
+--------
+* chore: migrate Xpert API to v2 for analytics_summary endpoint.
+
 [5.8.2]
 --------
 * feat: add index to `user_fk` in `EnterpriseCustomerUser` model. Part 2 of adding auth_user as a foreign key.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.8.2"
+__version__ = "5.8.3"

--- a/enterprise/api/v1/views/analytics_summary.py
+++ b/enterprise/api/v1/views/analytics_summary.py
@@ -20,7 +20,7 @@ from enterprise.models import ChatGPTResponse, EnterpriseCustomer
 
 class AnalyticsSummaryView(generics.GenericAPIView):
     """
-    API to generate a signed token for an enterprise admin to use Plotly analytics.
+    API to retrieve analytics summary using Xpert AI
     """
     authentication_classes = [JwtAuthentication, SessionAuthentication]
     permission_classes = (IsAuthenticated,)
@@ -33,9 +33,9 @@ class AnalyticsSummaryView(generics.GenericAPIView):
     )
     def post(self, request, enterprise_uuid):
         """
-        Generate auth token for plotly.
+        Perform analysis on given data and return result from Xpert AI.
         """
-        role = 'system'
+        role = 'user'
         enterprise_customer = get_object_or_404(EnterpriseCustomer, uuid=enterprise_uuid)
 
         # Validate payload data

--- a/enterprise/api_client/xpert_ai.py
+++ b/enterprise/api_client/xpert_ai.py
@@ -25,13 +25,16 @@ def chat_completion(prompt, role):
     """
     headers = {
         'Content-Type': 'application/json',
-        'x-api-key': settings.CHAT_COMPLETION_API_KEY
     }
 
-    body = {'message_list': [{'role': role, 'content': prompt},]}
+    body = {
+        'messages': [{'role': role, 'content': prompt},],
+        'client_id': settings.ENTERPRISE_ANALYSIS_CLIENT_ID,
+        'system_message': settings.ENTERPRISE_ANALYSIS_SYSTEM_PROMPT
+    }
 
     response = requests.post(
-        settings.CHAT_COMPLETION_API,
+        settings.CHAT_COMPLETION_API_V2,
         headers=headers,
         data=json.dumps(body),
         timeout=(CONNECT_TIMOUET_SECONDS, READ_TIMEOUT_SECONDS)

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -366,8 +366,9 @@ EXEC_ED_LANDING_PAGE = 'https://www.edx-external.com/account'
 # disable indexing on history_date. Otherwise it will add new alter migrations.
 SIMPLE_HISTORY_DATE_INDEX = False
 
-CHAT_COMPLETION_API = 'https://example.com/chat/completion'
-CHAT_COMPLETION_API_KEY = 'i am a key'
+CHAT_COMPLETION_API_V2 = 'https://example.com/chat/completion'
+ENTERPRISE_ANALYSIS_CLIENT_ID = 'test_client_id'
+ENTERPRISE_ANALYSIS_SYSTEM_PROMPT = 'This is a test prompt'
 
 LEARNER_ENGAGEMENT_PROMPT_FOR_ACTIVE_CONTRACT = 'Create learner engagement report for active contracts.'
 LEARNER_ENGAGEMENT_PROMPT_FOR_NON_ACTIVE_CONTRACT = 'Create learner engagement report for non active contracts.'


### PR DESCRIPTION
**Ticket:** [ENT-10098](https://2u-internal.atlassian.net/browse/ENT-10098)
**Description:** Migrated analytics_summary API to Xpert API v2. I've also created a [PR](https://github.com/edx/edx-internal/pull/12424) in `edx-internal` to include `client_id` in environment variables.
**Dependency**: We need to merge and deploy `edx-internal` [PR](https://github.com/edx/edx-internal/pull/12424) before merging this PR.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
