### PR TITLE
build: remove braze from base requirements

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.10.0]
+--------
+* build: remove edx-braze-client from ``base.in`` dependencies.
+
 [5.9.2]
 --------
 * fix: sleep time argument in ecu backfill management command

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.9.2"
+__version__ = "5.10.0"

--- a/requirements/base.in
+++ b/requirements/base.in
@@ -21,7 +21,6 @@ django-waffle
 django
 djangorestframework-xml
 djangorestframework
-edx-braze-client
 edx-django-utils>=3.12.0
 edx-drf-extensions
 edx-opaque-keys[django]

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -22,7 +22,7 @@ six==1.17.0
     # via tox
 tox==3.28.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/ci.in
 virtualenv==20.29.3
     # via tox

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -16,3 +16,4 @@ testfixtures              # Mock objects for unit tests and doc tests
 tox                       # virtualenv management for tests
 twine==1.11.0             # Utility for PyPI package uploads
 wheel                     # For generation of wheels for PyPI
+edx-braze-client

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,54 +6,54 @@
 #
 accessible-pygments==0.0.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
 aiohappyeyeballs==2.4.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
 aiohttp==3.11.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openai
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
 alabaster==1.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 amqp==5.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   kombu
 aniso8601==10.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-tincan-py35
 asgiref==3.8.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
 astroid==3.3.9
     # via
@@ -61,77 +61,77 @@ astroid==3.3.9
     #   pylint-celery
 attrs==25.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   openedx-events
     #   pytest
 babel==2.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
     #   sphinx
 bcrypt==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   paramiko
 beautifulsoup4==4.13.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
 billiard==4.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 build==1.2.2.post1
     # via pip-tools
 celery==5.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 certifi==2025.1.31
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/test.txt
     #   diff-cover
 charset-normalizer==2.0.12
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
 click==8.1.8
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
     #   click-log
@@ -143,40 +143,40 @@ click==8.1.8
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 click-log==0.4.0
     # via edx-lint
 click-plugins==1.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 code-annotations==2.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
 coverage[toml]==7.6.12
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
 cryptography==44.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -185,25 +185,25 @@ cryptography==44.0.2
     #   pyopenssl
     #   snowflake-connector-python
 ddt==1.3.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   djangorestframework-xml
 diff-cover==9.2.4
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 dill==0.3.9
     # via pylint
 distlib==0.3.9
     # via virtualenv
 django==4.2.19
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -216,6 +216,7 @@ django==4.2.19
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
+    #   edx-braze-client
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-i18n-tools
@@ -225,82 +226,82 @@ django==4.2.19
     #   openedx-events
 django-cache-memoize==0.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-config-models==2.8.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-countries==7.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-ipware==7.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-rbac
 django-multi-email-field==0.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-oauth-toolkit==1.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-object-actions==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-simple-history==3.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-waffle==4.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
 djangorestframework==3.14.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
@@ -308,20 +309,20 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pymongo
 doc8==1.1.2
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    # via -r requirements/doc.txt
 docutils==0.21.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   doc8
     #   pydata-sphinx-theme
     #   readme-renderer
@@ -329,47 +330,49 @@ docutils==0.21.2
     #   sphinx
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-yasg==1.21.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-edx-braze-client==0.2.5
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+edx-braze-client==1.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/dev.in
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openedx-events
 edx-django-utils==7.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-config-models
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-rbac
 edx-i18n-tools==1.6.3
     # via -r requirements/dev.in
@@ -377,89 +380,89 @@ edx-lint==5.6.0
     # via -r requirements/dev.in
 edx-opaque-keys[django]==2.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-rest-api-client==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-tincan-py35==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-toggles==5.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 factory-boy==3.3.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
 faker==37.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   factory-boy
 fastavro==1.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openedx-events
 filelock==3.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
 freezegun==0.3.14
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 frozenlist==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   aiosignal
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
     #   yarl
 imagesize==1.4.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 iniconfig==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest
 isort==6.0.1
     # via
@@ -467,33 +470,33 @@ isort==6.0.1
     #   pylint
 jinja2==3.1.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   diff-cover
     #   sphinx
 jsondiff==2.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 jsonfield==3.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 jwcrypto==1.5.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-oauth-toolkit
 kombu==5.4.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 lxml[html-clean,html_clean]==5.3.1
     # via
@@ -503,54 +506,54 @@ lxml-html-clean==0.4.1
     # via lxml
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   jinja2
 mccabe==0.7.0
     # via pylint
 mock==3.0.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 multidict==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 newrelic==10.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 nh3==0.2.21
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-oauth-toolkit
 openai==0.28.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 openedx-events==9.18.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 packaging==24.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   build
     #   drf-yasg
     #   pydata-sphinx-theme
@@ -560,53 +563,53 @@ packaging==24.2
     #   tox
 paramiko==3.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 path==16.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
     #   path-py
 path-py==12.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   stevedore
 pgpy==0.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 pillow==11.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 pip-tools==7.4.1
     # via -r requirements/dev.in
 pkginfo==1.12.1.2
     # via twine
 platformdirs==4.3.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pylint
     #   snowflake-connector-python
     #   virtualenv
 pluggy==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   diff-cover
     #   pytest
     #   tox
@@ -614,53 +617,53 @@ polib==1.2.0
     # via edx-i18n-tools
 prompt-toolkit==3.0.50
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   click-repl
 propcache==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 py==1.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest
     #   tox
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pgpy
 pycodestyle==2.12.1
     # via -r requirements/dev.in
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   cffi
 pydata-sphinx-theme==0.15.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx-book-theme
 pydocstyle==6.3.0
     # via -r requirements/dev.in
 pygments==2.19.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   accessible-pygments
     #   diff-cover
     #   doc8
@@ -669,9 +672,9 @@ pygments==2.19.1
     #   sphinx
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -692,22 +695,22 @@ pylint-plugin-utils==0.8.2
     #   pylint-django
 pymongo==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
 pyproject-hooks==1.2.0
     # via
@@ -715,60 +718,61 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==6.2.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==6.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 pytest-django==4.5.2
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
     #   freezegun
 python-ipware==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
 pytz==2025.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   djangorestframework
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   drf-yasg
     #   edx-i18n-tools
     #   jsondiff
 readme-renderer==44.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    # via -r requirements/doc.txt
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-oauth-toolkit
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openai
@@ -782,32 +786,32 @@ requests-toolbelt==1.0.0
     # via twine
 responses==0.10.15
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   doc8
 roman-numerals-py==3.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 rules==3.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ccx-keys
     #   edx-lint
     #   edx-rbac
@@ -818,117 +822,117 @@ six==1.17.0
     #   tox
 slumber==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 snowballstemmer==2.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydocstyle
     #   sphinx
 snowflake-connector-python==3.14.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 sortedcontainers==2.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
 soupsieve==2.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   beautifulsoup4
 sphinx==8.2.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
     #   sphinx-book-theme
 sphinx-book-theme==1.1.4
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    # via -r requirements/doc.txt
 sphinxcontrib-applehelp==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-devhelp==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-jsmath==1.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-qthelp==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   doc8
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==8.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
     #   -r requirements/dev.in
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   python-slugify
 toml==0.10.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest
 tomlkit==0.13.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pylint
     #   snowflake-connector-python
 tox==3.28.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/dev.in
 tqdm==4.67.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openai
     #   twine
 twine==1.11.0
     # via -r requirements/dev.in
 typing-extensions==4.12.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -938,35 +942,35 @@ typing-extensions==4.12.2
     #   snowflake-connector-python
 tzdata==2025.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
     #   faker
     #   kombu
 unicodecsv==0.14.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 uritemplate==4.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   requests
 vine==5.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   amqp
     #   celery
     #   kombu
@@ -974,15 +978,15 @@ virtualenv==20.29.3
     # via tox
 wcwidth==0.2.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   bleach
 wheel==0.45.1
     # via
@@ -990,9 +994,9 @@ wheel==0.45.1
     #   pip-tools
 yarl==1.18.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -10,3 +10,4 @@ Sphinx                    # Documentation builder
 docutils
 factory-boy
 pytest
+edx-braze-client

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,38 +8,38 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 aiohappyeyeballs==2.4.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 aiohttp==3.11.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 alabaster==1.0.0
     # via sphinx
 amqp==5.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   kombu
 aniso8601==10.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-tincan-py35
 asgiref==3.8.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 attrs==25.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   openedx-events
     #   pytest
@@ -49,39 +49,39 @@ babel==2.17.0
     #   sphinx
 bcrypt==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   paramiko
 beautifulsoup4==4.13.3
     # via pydata-sphinx-theme
 billiard==4.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 bleach==6.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 celery==5.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test-master.txt
 certifi==2025.1.31
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
 charset-normalizer==2.0.12
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
 click==8.1.8
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -90,23 +90,23 @@ click==8.1.8
     #   edx-django-utils
 click-didyoumean==0.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 code-annotations==2.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-toggles
 cryptography==44.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -116,12 +116,12 @@ cryptography==44.0.2
     #   snowflake-connector-python
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   djangorestframework-xml
 django==4.2.19
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -134,6 +134,7 @@ django==4.2.19
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
+    #   edx-braze-client
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
@@ -141,56 +142,56 @@ django==4.2.19
     #   jsonfield
     #   openedx-events
 django-cache-memoize==0.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-config-models==2.8.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-countries==7.6.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-filter==25.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-ipware==7.0.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-rbac
 django-multi-email-field==0.7.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-oauth-toolkit==1.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-object-actions==4.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-simple-history==3.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test-master.txt
 django-waffle==4.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
 djangorestframework==3.14.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pymongo
 doc8==1.1.2
     # via -r requirements/doc.in
@@ -204,68 +205,71 @@ docutils==0.21.2
     #   sphinx
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 drf-yasg==1.21.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-edx-braze-client==0.2.5
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
+edx-braze-client==1.0.0
+    # via
+    #   -r requirements/doc.in
+    #   -r requirements/test-master.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
 edx-django-utils==7.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-rbac
 edx-opaque-keys[django]==2.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.10.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-rest-api-client==6.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-tincan-py35==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-toggles==5.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 factory-boy==3.3.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
 faker==37.0.0
     # via factory-boy
 fastavro==1.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
 filelock==3.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 frozenlist==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   aiosignal
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
     #   yarl
@@ -273,102 +277,102 @@ imagesize==1.4.1
     # via sphinx
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   sphinx
 jsondiff==2.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jsonfield==3.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jwcrypto==1.5.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
 kombu==5.4.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   jinja2
 multidict==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 newrelic==10.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
 nh3==0.2.21
     # via readme-renderer
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
 openai==0.28.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 openedx-events==9.18.2
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 packaging==24.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
     #   pydata-sphinx-theme
     #   pytest
     #   snowflake-connector-python
     #   sphinx
 paramiko==3.5.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 path==16.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   path-py
 path-py==12.5.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   stevedore
 pgpy==0.6.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 pillow==11.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 platformdirs==4.3.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pluggy==1.5.0
     # via pytest
 prompt-toolkit==3.0.50
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   click-repl
 propcache==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
 py==1.11.0
     # via pytest
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pgpy
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
@@ -381,50 +385,50 @@ pygments==2.19.1
     #   sphinx
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   snowflake-connector-python
 pymongo==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pytest==6.2.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 python-ipware==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
 pytz==2025.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   djangorestframework
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   drf-yasg
     #   jsondiff
@@ -432,8 +436,9 @@ readme-renderer==44.0
     # via -r requirements/doc.in
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openai
@@ -445,26 +450,26 @@ restructuredtext-lint==1.4.0
 roman-numerals-py==3.1.0
     # via sphinx
 rules==3.5
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ccx-keys
     #   edx-rbac
     #   python-dateutil
 slumber==0.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 snowballstemmer==2.2.0
     # via sphinx
 snowflake-connector-python==3.14.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 sortedcontainers==2.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 soupsieve==2.6
     # via beautifulsoup4
@@ -489,34 +494,34 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   doc8
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==8.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   python-slugify
 toml==0.10.2
     # via pytest
 tomlkit==0.13.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 tqdm==4.67.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
 typing-extensions==4.12.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   beautifulsoup4
     #   django-countries
     #   edx-opaque-keys
@@ -526,38 +531,38 @@ typing-extensions==4.12.2
     #   snowflake-connector-python
 tzdata==2025.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   faker
     #   kombu
 unicodecsv==0.14.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 uritemplate==4.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test-master.txt
     #   requests
 vine==5.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   bleach
 yarl==1.18.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -198,6 +198,7 @@ django==4.2.19
     #   edx-ace
     #   edx-api-doc-tools
     #   edx-auth-backends
+    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-celeryutils
     #   edx-completion
@@ -399,7 +400,7 @@ edx-api-doc-tools==2.0.0
     #   edx-name-affirmation
 edx-auth-backends==4.4.0
     # via -r requirements/edx/kernel.in
-edx-braze-client==0.2.5
+edx-braze-client==1.0.0
     # via
     #   -r requirements/edx/bundled.in
     #   edx-enterprise
@@ -433,6 +434,7 @@ edx-django-utils==7.2.0
     #   -r requirements/edx/kernel.in
     #   django-config-models
     #   edx-ace
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-enterprise
     #   edx-event-bus-kafka
@@ -457,7 +459,7 @@ edx-drf-extensions==10.5.0
     #   edx-when
     #   edxval
     #   openedx-learning
-edx-enterprise==5.8.2
+edx-enterprise==5.9.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -530,7 +532,7 @@ edx-when==2.5.1
     # via
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-edxval==2.9.1
+edxval==2.10.0
     # via -r requirements/edx/kernel.in
 elasticsearch==7.9.1
     # via
@@ -1036,6 +1038,7 @@ requests==2.32.3
     #   analytics-python
     #   cachecontrol
     #   django-oauth-toolkit
+    #   edx-braze-client
     #   edx-bulk-grades
     #   edx-drf-extensions
     #   edx-enterprise

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-attrs==25.1.0
+attrs==25.3.0
     # via
     #   outcome
     #   trio
@@ -91,7 +91,7 @@ typing-extensions==4.12.2
     # via selenium
 urllib3[socks]==2.2.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
+    #   -c requirements/common_constraints.txt
     #   selenium
 websocket-client==1.8.0
     # via selenium

--- a/requirements/test-master.in
+++ b/requirements/test-master.in
@@ -7,3 +7,4 @@
 -r base.in
 
 edx-api-doc-tools  # for installing an api-docs page for enterprise
+edx-braze-client

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -6,64 +6,64 @@
 #
 aiohappyeyeballs==2.4.6
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
 aiohttp==3.11.13
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openai
 aiosignal==1.3.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
 amqp==5.3.1
     # via kombu
 aniso8601==10.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-tincan-py35
 asgiref==3.8.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 attrs==25.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   openedx-events
 bcrypt==4.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   paramiko
 billiard==4.2.1
     # via celery
 bleach==6.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 celery==5.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 certifi==2025.1.31
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
 charset-normalizer==2.0.12
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   requests
     #   snowflake-connector-python
 click==8.1.8
@@ -78,19 +78,19 @@ click-didyoumean==0.3.1
     # via celery
 click-plugins==1.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   celery
 click-repl==0.3.0
     # via celery
 code-annotations==2.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-toggles
 cryptography==44.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -100,13 +100,13 @@ cryptography==44.0.2
     #   snowflake-connector-python
 defusedxml==0.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   djangorestframework-xml
 django==4.2.19
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -119,6 +119,7 @@ django==4.2.19
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
+    #   edx-braze-client
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
@@ -127,67 +128,67 @@ django==4.2.19
     #   openedx-events
 django-cache-memoize==0.2.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-config-models==2.8.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-countries==7.6.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-crum==0.7.9
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-filter==25.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-ipware==7.0.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-model-utils==5.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-rbac
 django-multi-email-field==0.7.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-oauth-toolkit==1.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-object-actions==4.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-simple-history==3.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
 django-waffle==4.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
 djangorestframework==3.14.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
@@ -195,239 +196,241 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 dnspython==2.7.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-drf-extensions
 drf-yasg==1.21.9
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/test-master.in
-edx-braze-client==0.2.5
+edx-braze-client==1.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/test-master.in
 edx-ccx-keys==2.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openedx-events
 edx-django-utils==7.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-config-models
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-rbac
 edx-opaque-keys[django]==2.11.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.10.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 edx-rest-api-client==6.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 edx-tincan-py35==2.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 edx-toggles==5.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 fastavro==1.10.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openedx-events
 filelock==3.17.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 frozenlist==1.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   aiosignal
 idna==3.10
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   requests
     #   snowflake-connector-python
     #   yarl
 inflection==0.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-yasg
 jinja2==3.1.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
 jsondiff==2.2.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 jsonfield==3.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 jwcrypto==1.5.6
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-oauth-toolkit
 kombu==5.4.2
     # via celery
 markupsafe==3.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   jinja2
 multidict==6.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   yarl
 newrelic==10.6.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-django-utils
 oauthlib==3.2.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-oauth-toolkit
 openai==0.28.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 openedx-events==9.18.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 packaging==24.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-yasg
     #   snowflake-connector-python
 paramiko==3.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 path==16.11.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   path-py
 path-py==12.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 pbr==6.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   stevedore
 pgpy==0.6.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 pillow==11.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 platformdirs==4.3.6
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 prompt-toolkit==3.0.50
     # via click-repl
 propcache==0.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   yarl
 psutil==7.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-django-utils
 pyasn1==0.6.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   pgpy
 pycparser==2.22
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   cffi
 pyjwt[crypto]==2.10.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   snowflake-connector-python
 pymongo==4.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 python-dateutil==2.9.0.post0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   celery
 python-ipware==3.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
 pytz==2025.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   djangorestframework
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
     #   drf-yasg
     #   jsondiff
 requests==2.32.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-oauth-toolkit
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openai
@@ -435,60 +438,60 @@ requests==2.32.3
     #   snowflake-connector-python
 rules==3.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 semantic-version==2.10.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-drf-extensions
 six==1.17.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-ccx-keys
     #   edx-rbac
     #   python-dateutil
 slumber==0.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 snowflake-connector-python==3.14.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 sortedcontainers==2.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 sqlparse==0.5.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==8.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 text-unidecode==1.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   python-slugify
 tomlkit==0.13.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 tqdm==4.67.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openai
 typing-extensions==4.12.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-countries
     #   edx-opaque-keys
     #   jwcrypto
@@ -496,21 +499,21 @@ typing-extensions==4.12.2
     #   snowflake-connector-python
 tzdata==2025.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   celery
     #   kombu
 unicodecsv==0.14.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 uritemplate==4.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-yasg
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   requests
 vine==5.1.0
     # via
@@ -519,15 +522,15 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   bleach
 yarl==1.18.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,3 +13,4 @@ pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 responses                 # utility library for mocking out the requests library
 testfixtures              # Mock objects for unit tests and doc tests
+edx-braze-client

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,58 +6,58 @@
 #
 aiohappyeyeballs==2.4.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 aiohttp==3.11.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
 aiosignal==1.3.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   kombu
 aniso8601==10.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-tincan-py35
 asgiref==3.8.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 attrs==25.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   openedx-events
     #   pytest
 bcrypt==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   paramiko
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 bleach==6.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test-master.txt
 certifi==2025.1.31
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
@@ -65,11 +65,11 @@ chardet==5.2.0
     # via diff-cover
 charset-normalizer==2.0.12
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -77,24 +77,24 @@ charset-normalizer==2.0.12
     #   code-annotations
     #   edx-django-utils
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 click-plugins==1.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 code-annotations==2.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-toggles
 coverage[toml]==7.6.12
     # via pytest-cov
 cryptography==44.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -106,13 +106,13 @@ ddt==1.3.1
     # via -r requirements/test.in
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   djangorestframework-xml
 diff-cover==9.2.4
     # via -r requirements/test.in
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -125,6 +125,7 @@ diff-cover==9.2.4
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
+    #   edx-braze-client
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-rbac
@@ -132,253 +133,256 @@ diff-cover==9.2.4
     #   jsonfield
     #   openedx-events
 django-cache-memoize==0.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-config-models==2.8.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-countries==7.6.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-filter==25.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-ipware==7.0.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   -r requirements/test.in
     #   edx-rbac
 django-multi-email-field==0.7.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-oauth-toolkit==1.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-object-actions==4.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-simple-history==3.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test-master.txt
 django-waffle==4.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
 djangorestframework==3.14.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 drf-yasg==1.21.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-api-doc-tools
 edx-api-doc-tools==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-edx-braze-client==0.2.5
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
+edx-braze-client==1.0.0
+    # via
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.in
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
 edx-django-utils==7.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   edx-toggles
     #   openedx-events
 edx-drf-extensions==10.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-rbac
 edx-opaque-keys[django]==2.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==1.10.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-rest-api-client==6.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-tincan-py35==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-toggles==5.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 factory-boy==3.3.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 faker==37.0.0
     # via factory-boy
 fastavro==1.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
 filelock==3.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 freezegun==0.3.14
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 frozenlist==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   aiosignal
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
     #   yarl
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 iniconfig==2.0.0
     # via pytest
 jinja2==3.1.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   diff-cover
 jsondiff==2.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jsonfield==3.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jwcrypto==1.5.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   jinja2
 mock==3.0.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 multidict==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 newrelic==10.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
 oauthlib==3.2.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
 openai==0.28.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 openedx-events==9.18.2
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 packaging==24.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
     #   pytest
     #   snowflake-connector-python
 paramiko==3.5.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 path==16.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   path-py
 path-py==12.5.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 pbr==6.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   stevedore
 pgpy==0.6.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 pillow==11.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 platformdirs==4.3.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pluggy==1.5.0
     # via
     #   diff-cover
     #   pytest
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   click-repl
 propcache==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
 py==1.11.0
     # via pytest
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pgpy
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cffi
 pygments==2.19.1
     # via diff-cover
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   snowflake-connector-python
 pymongo==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pytest==6.2.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==6.0.0
@@ -387,34 +391,35 @@ pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   freezegun
 python-ipware==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
 pytz==2025.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   djangorestframework
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   drf-yasg
     #   jsondiff
 requests==2.32.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
+    #   edx-braze-client
     #   edx-drf-extensions
     #   edx-rest-api-client
     #   openai
@@ -423,17 +428,17 @@ requests==2.32.3
     #   snowflake-connector-python
 responses==0.10.15
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 rules==3.5
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ccx-keys
     #   edx-rbac
     #   freezegun
@@ -441,44 +446,44 @@ six==1.17.0
     #   python-dateutil
     #   responses
 slumber==0.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 snowflake-connector-python==3.14.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 sortedcontainers==2.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
 stevedore==5.4.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==8.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   -r requirements/test.in
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   python-slugify
 toml==0.10.2
     # via pytest
 tomlkit==0.13.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 tqdm==4.67.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
 typing-extensions==4.12.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-countries
     #   edx-opaque-keys
     #   jwcrypto
@@ -486,37 +491,37 @@ typing-extensions==4.12.2
     #   snowflake-connector-python
 tzdata==2025.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   faker
     #   kombu
 unicodecsv==0.14.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 uritemplate==4.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 urllib3==2.2.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test-master.txt
     #   requests
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   bleach
 yarl==1.18.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/setup.py
+++ b/setup.py
@@ -106,6 +106,9 @@ setup(
     include_package_data=True,
     install_requires=REQUIREMENTS,
     dependency_links=DEPENDENCY_LINKS,
+    extras_require={
+        "braze": ["edx-braze-client"],
+    },
     license="AGPL 3.0",
     zip_safe=False,
     keywords="Django edx",


### PR DESCRIPTION
Makes `edx-braze-client` a dependency for dev and test, but no longer for `base.in`. This _may_ allow us to remove `edx-braze-client` in edx-platform, which installs edx-enterprise and its dependecies based on edx-enterprise's `base.in`.

This also includes edx-braze-client in `setup.py` as an extra requirement. You can try this out from within edx-enterprise as follows:
```
pyenv local enterprise-with-braze # activates my virtual environment for test installation
pip freeze | grep braze
# nothin
pip install . # installs edx-enterprise into your test virtualenv
pip freeze | grep braze
# should still not be installed
pip install .[braze] # install with the extra requirement "braze"
pip freeze | grep braze
# should return edx-braze-client==1.0.0
```

**Merge checklist:**
- [x] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [x] `make static` has been run to update webpack bundling if any static content was updated
- [x] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [x] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
