### PR TITLE
feat: updated the _get_course_run_url to pass external_identifier as a parameter

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.12.0]
+--------
+* feat. updated the _get_course_run_url to pass external_identifier as a parameter
+
 [5.11.1]
 --------
 * fix: move BrazeClient import warning to ``BrazeAPIClient.__init__()``.
@@ -25,9 +29,6 @@ Unreleased
 --------
 * feat: Add foreign key to field `user_fk` of `EnterpriseCustomerUser` model. Part 5 of adding auth_user as a foreign key.
 * Important: If you want to avoid downtime for a large EnterpriseCustomerUser table, you must ensure that no entries in that table are NULL (but the field remains nullable). To do this, deploy https://github.com/openedx/edx-enterprise/pull/2341 first and run the management command as defined there.
-[5.11.0]
---------
-* feat. updated the _get_course_run_url to pass external_identifier as a parameter
 
 [5.10.3]
 --------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,6 +25,9 @@ Unreleased
 --------
 * feat: Add foreign key to field `user_fk` of `EnterpriseCustomerUser` model. Part 5 of adding auth_user as a foreign key.
 * Important: If you want to avoid downtime for a large EnterpriseCustomerUser table, you must ensure that no entries in that table are NULL (but the field remains nullable). To do this, deploy https://github.com/openedx/edx-enterprise/pull/2341 first and run the management command as defined there.
+[5.11.0]
+--------
+* feat. updated the _get_course_run_url to pass external_identifier as a parameter
 
 [5.10.3]
 --------

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.11.1"
+__version__ = "5.12.0"

--- a/enterprise_learner_portal/api/v1/serializers.py
+++ b/enterprise_learner_portal/api/v1/serializers.py
@@ -97,6 +97,13 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
                         certificate_info,
                         instance
                     )
+                    olc_course_id = course_details.external_identifier
+                    representation['external_identifier'] = olc_course_id
+                    representation['course_run_url'] = self._get_course_run_url(
+                        request,
+                        course_run_id,
+                        olc_course_id
+                    )
 
         return representation
 
@@ -110,7 +117,7 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
 
         return None
 
-    def _get_course_run_url(self, request, course_run_id):
+    def _get_course_run_url(self, request, course_run_id, olc_course_id=None):
         """
         Get the appropriate course url while incorporating Executive Education content.
         """
@@ -120,6 +127,8 @@ class EnterpriseCourseEnrollmentSerializer(serializers.Serializer):  # pylint: d
             active_enterprise_customer = EnterpriseCustomerUser.get_active_enterprise_users(request.user.id).first()
             if active_enterprise_customer and active_enterprise_customer.enterprise_customer.auth_org_id:
                 params = {'org_id': active_enterprise_customer.enterprise_customer.auth_org_id}
+                if olc_course_id:
+                    params['course_id'] = olc_course_id
                 course_run_url = '{}?{}'.format(exec_ed_base_url, urlencode(params))
 
         return course_run_url

--- a/tests/test_enterprise/api/test_serializers.py
+++ b/tests/test_enterprise/api/test_serializers.py
@@ -18,6 +18,7 @@ from django.test import TestCase
 from enterprise.api.v1.serializers import (
     EnterpriseCourseEnrollmentAdminViewSerializer,
     EnterpriseCustomerApiCredentialSerializer,
+    EnterpriseCustomerBrandingConfigurationSerializer,
     EnterpriseCustomerReportingConfigurationSerializer,
     EnterpriseCustomerSerializer,
     EnterpriseCustomerUserReadOnlySerializer,
@@ -26,7 +27,11 @@ from enterprise.api.v1.serializers import (
     ImmutableStateSerializer,
 )
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE
-from enterprise.models import SystemWideEnterpriseRole, SystemWideEnterpriseUserRoleAssignment
+from enterprise.models import (
+    EnterpriseCustomerBrandingConfiguration,
+    SystemWideEnterpriseRole,
+    SystemWideEnterpriseUserRoleAssignment,
+)
 from test_utils import FAKE_UUIDS, TEST_PGP_KEY, TEST_USERNAME, APITest, factories
 
 Application = get_application_model()
@@ -630,6 +635,35 @@ class TestEnterpriseMembersSerializer(TestCase):
         serializer = EnterpriseMembersSerializer(serializer_input_2)
         serialized_user = serializer.data
         self.assertEqual(serialized_user, expected_user_2)
+
+
+class TestEnterpriseCustomerBrandingConfigurationSerializer(TestCase):
+    """
+    Tests for EnterpriseCustomerBrandingConfigurationSerializer.
+    """
+    def setUp(self):
+        super().setUp()
+        self.enterprise_customer = factories.EnterpriseCustomerFactory()
+
+    def test_branding_configuration(self):
+        branding_config = EnterpriseCustomerBrandingConfiguration(
+            enterprise_customer=self.enterprise_customer)
+
+        branding_config.logo = 'https://example.com/logo.png'
+        branding_config.primary_color = '#000000'
+        branding_config.secondary_color = '#FFFFFF'
+        branding_config.tertiary_color = '#0000FF'
+        branding_config.save()
+
+        saved_config = EnterpriseCustomerBrandingConfiguration.objects.get(
+            enterprise_customer=self.enterprise_customer)
+
+        serializer = EnterpriseCustomerBrandingConfigurationSerializer(saved_config)
+        data = serializer.data
+        self.assertEqual(data['primary_color'], branding_config.primary_color)
+        self.assertEqual(data['secondary_color'], branding_config.secondary_color)
+        self.assertEqual(data['tertiary_color'], branding_config.tertiary_color)
+        self.assertEqual(data['logo'], branding_config.logo)
 
 
 @mark.django_db


### PR DESCRIPTION
**Description**
The enterprise_course_enrollments API serves the data for the enrollment cards on the Learner Portal dashboard, serving the course_run_url powering the “Start”/”Resume” CTA amongst other metadata.

This PR sends the course_id as an additional parameter to GetSmarter dashboard.

This will remove the intermediary step of landing on the GetSmarter dashboard. Instead, the “Start course” / “Resume” CTA from the Learner Portal dashboard for Exec Ed course cards would link directly to the OLC, without the learner needing to go through the Dashboard.

The existing GetSmarter dashboard link URL used today will now also accept _course_id_. When passed, the URL will authenticate via SSO through the _org_id_ and subsequently redirect on its own to the _course_id_.

The course_id reflects the UUID for GEAG product, implemented via external_identifier

**Related PR**
https://github.com/edx/federated-content-connector/pull/30

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
