### PR TITLE
fix: defensively import edx-braze-client.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.10.1]
+--------
+* fix: defensively import edx-braze-client so that tests in the edx-platform CI context won't raise ``ImportErrors``.
+
 [5.10.0]
 --------
 * build: remove edx-braze-client from ``base.in`` dependencies.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.10.0"
+__version__ = "5.10.1"

--- a/enterprise/api_client/braze.py
+++ b/enterprise/api_client/braze.py
@@ -3,36 +3,41 @@ API clients to communicate with Braze services.
 """
 import logging
 
-from braze.client import BrazeClient
-
 from django.conf import settings
 
 logger = logging.getLogger(__name__)
+
+try:
+    from braze.client import BrazeClient
+except ImportError:
+    logger.warning('Cannot import BrazeClient, calls to Braze will not work')
+    BrazeClient = None
 
 ENTERPRISE_BRAZE_ALIAS_LABEL = 'Enterprise'  # Do Not change this, this is consistent with other uses across edX repos.
 # https://www.braze.com/docs/api/endpoints/user_data/post_user_identify/
 MAX_NUM_IDENTIFY_USERS_ALIASES = 50
 
 
-class BrazeAPIClient(BrazeClient):
+class BrazeAPIClient(BrazeClient or object):
     """
     API client for calls to Braze.
     """
     def __init__(self):
-        braze_api_key = getattr(settings, 'ENTERPRISE_BRAZE_API_KEY', None)
-        braze_api_url = getattr(settings, 'EDX_BRAZE_API_SERVER', None)
-        required_settings = ['ENTERPRISE_BRAZE_API_KEY', 'EDX_BRAZE_API_SERVER']
-        for setting in required_settings:
-            if not getattr(settings, setting, None):
-                msg = f'Missing {setting} in settings required for Braze API Client.'
-                logger.error(msg)
-                raise ValueError(msg)
+        if BrazeClient:
+            braze_api_key = getattr(settings, 'ENTERPRISE_BRAZE_API_KEY', None)
+            braze_api_url = getattr(settings, 'EDX_BRAZE_API_SERVER', None)
+            required_settings = ['ENTERPRISE_BRAZE_API_KEY', 'EDX_BRAZE_API_SERVER']
+            for setting in required_settings:
+                if not getattr(settings, setting, None):
+                    msg = f'Missing {setting} in settings required for Braze API Client.'
+                    logger.error(msg)
+                    raise ValueError(msg)
 
-        super().__init__(
-            api_key=braze_api_key,
-            api_url=braze_api_url,
-            app_id='',
-        )
+            super().__init__(
+                api_key=braze_api_key,
+                api_url=braze_api_url,
+                app_id='',
+            )
 
     def generate_mailto_link(self, emails):
         """

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -4,7 +4,6 @@ Django tasks.
 
 from logging import getLogger
 
-from braze.exceptions import BrazeClientError
 from celery import shared_task
 from edx_django_utils.monitoring import set_code_owner_attribute
 
@@ -20,6 +19,12 @@ from enterprise.constants import SSO_BRAZE_CAMPAIGN_ID
 from enterprise.utils import batch_dict, get_enterprise_customer, localized_utcnow, send_email_notification_message
 
 LOGGER = getLogger(__name__)
+
+try:
+    from braze.exceptions import BrazeClientError
+except ImportError:
+    LOGGER.warning('Cannot import BrazeClientError')
+    BrazeClientError = Exception
 
 
 @shared_task

--- a/requirements/test.in
+++ b/requirements/test.in
@@ -13,4 +13,3 @@ pytest-cov                # pytest extension for code coverage statistics
 pytest-django             # pytest extension for better Django support
 responses                 # utility library for mocking out the requests library
 testfixtures              # Mock objects for unit tests and doc tests
-edx-braze-client

--- a/tests/test_enterprise/test_tasks.py
+++ b/tests/test_enterprise/test_tasks.py
@@ -8,7 +8,6 @@ import uuid
 from datetime import datetime
 from unittest import mock
 
-from braze.exceptions import BrazeClientError
 from pytest import mark, raises
 
 from enterprise.api_client.braze import ENTERPRISE_BRAZE_ALIAS_LABEL
@@ -31,6 +30,11 @@ from test_utils.factories import (
     PendingEnterpriseCustomerUserFactory,
     UserFactory,
 )
+
+try:
+    from braze.exceptions import BrazeClientError
+except ImportError:
+    BrazeClientError = Exception
 
 
 @mark.django_db


### PR DESCRIPTION
ENT-10147 | defensively import edx-braze-client so that tests in the edx-platform CI context won't raise ``ImportErrors``.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
