### PR TITLE
fix: move BrazeClient import warning to BrazeAPIClient.__init__()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.11.1]
+--------
+* fix: move BrazeClient import warning to ``BrazeAPIClient.__init__()``.
+
 [5.11.0]
 --------
 * feat: Add foreign key to field `user_fk` of `EnterpriseCustomerUser` model. Part 5 of adding auth_user as a foreign key.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.11.0"
+__version__ = "5.11.1"

--- a/enterprise/api_client/braze.py
+++ b/enterprise/api_client/braze.py
@@ -10,7 +10,6 @@ logger = logging.getLogger(__name__)
 try:
     from braze.client import BrazeClient
 except ImportError:
-    logger.warning('Cannot import BrazeClient, calls to Braze will not work')
     BrazeClient = None
 
 ENTERPRISE_BRAZE_ALIAS_LABEL = 'Enterprise'  # Do Not change this, this is consistent with other uses across edX repos.
@@ -38,6 +37,8 @@ class BrazeAPIClient(BrazeClient or object):
                 api_url=braze_api_url,
                 app_id='',
             )
+        else:
+            logger.warning('BrazeClient could not be imported, calls to Braze will not work')
 
     def generate_mailto_link(self, emails):
         """

--- a/enterprise/tasks.py
+++ b/enterprise/tasks.py
@@ -23,7 +23,6 @@ LOGGER = getLogger(__name__)
 try:
     from braze.exceptions import BrazeClientError
 except ImportError:
-    LOGGER.warning('Cannot import BrazeClientError')
     BrazeClientError = Exception
 
 


### PR DESCRIPTION
We don't want to raise a warning about braze when code is loaded, only when a caller attempts to _use_ `BrazeClient`.  See explanation in https://github.com/openedx/edx-enterprise/pull/2364.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
