### PR TITLE
fix: assign_learners use case insensitive lookup with received email addresses

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[5.12.1]
+--------
+* fix: assign_learners use case insensitive lookup with received email addresses
+
 [5.12.0]
 --------
 * feat. updated the _get_course_run_url to pass external_identifier as a parameter

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "5.12.0"
+__version__ = "5.12.1"

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -18,7 +18,7 @@ from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseReadWriteModelViewSet
 from enterprise.logging import getEnterpriseLogger
 from enterprise.tasks import send_group_membership_invitation_notification, send_group_membership_removal_notification
-from enterprise.utils import get_idiff_list, localized_utcnow
+from enterprise.utils import filter_in_case_insensitive, get_idiff_list, localized_utcnow
 
 LOGGER = getEnterpriseLogger(__name__)
 
@@ -310,7 +310,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
         memberships_to_create = []
         for user_email_batch in utils.batch(learner_emails[: 1000], batch_size=200):
             # Gather all existing User objects associated with the email batch
-            existing_users = User.objects.filter(email__in=user_email_batch)
+            existing_users = User.objects.filter(filter_in_case_insensitive('email', user_email_batch))
 
             # Revive any previously deleted membership records connected to ECUs containing related emails
             previously_removed_ecu_learners = models.EnterpriseGroupMembership.all_objects.filter(

--- a/enterprise/api/v1/views/enterprise_group.py
+++ b/enterprise/api/v1/views/enterprise_group.py
@@ -18,7 +18,7 @@ from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseReadWriteModelViewSet
 from enterprise.logging import getEnterpriseLogger
 from enterprise.tasks import send_group_membership_invitation_notification, send_group_membership_removal_notification
-from enterprise.utils import localized_utcnow
+from enterprise.utils import get_idiff_list, localized_utcnow
 
 LOGGER = getEnterpriseLogger(__name__)
 
@@ -345,7 +345,7 @@ class EnterpriseGroupViewSet(EnterpriseReadWriteModelViewSet):
 
             # Extend the list of emails that don't have User objects associated and need to be turned into
             # new PendingEnterpriseCustomerUser objects
-            user_emails_to_create.extend(set(user_email_batch).difference(set(ecu_by_email.keys())))
+            user_emails_to_create.extend(get_idiff_list(user_email_batch, ecu_by_email.keys()))
 
             # Extend the list of memberships that need to be created associated with existing Users
             # All existing users will have the status automatically set to accepted

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -2629,7 +2629,7 @@ def filter_in_case_insensitive(fieldname, values):
         fieldname (str): Name of the field to query
         values (list): Values to filter by
     Returns:
-        list: a list of integrations.
+        dict: queryset filter parameters
     """
     # MySQL IN query is case insensitive by default
     case_insensitive_filter = dict([(f"{fieldname}__in", values)])

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -7,6 +7,7 @@ import json
 import os
 import re
 from collections import OrderedDict
+from functools import reduce
 from itertools import islice
 from urllib.parse import parse_qs, quote, urlencode, urljoin, urlparse, urlsplit, urlunsplit
 from uuid import UUID, uuid4
@@ -24,6 +25,7 @@ from django.core import mail
 from django.core.exceptions import ObjectDoesNotExist, ValidationError
 from django.core.validators import validate_email
 from django.db import utils
+from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
 from django.http import Http404
@@ -2611,3 +2613,29 @@ def get_pending_enterprise_customer_users(user_email, enterprise_customer_uuid):
         'is_pending_learner': True,
         'user_email': user_email,
     }
+
+
+def is_sqlite():
+    """
+    Helper method to determine if the current default database is SQLite
+    """
+    return 'sqlite' in settings.DATABASES['default']['ENGINE']
+
+
+def filter_in_case_insensitive(fieldname, values):
+    """
+    Helper method to generate a case insensitive IN query, accounting for different database engines
+    Arguments:
+        fieldname (str): Name of the field to query
+        values (list): Values to filter by
+    Returns:
+        list: a list of integrations.
+    """
+    # MySQL IN query is case insensitive by default
+    case_insensitive_filter = dict([(f"{fieldname}__in", values)])
+    if is_sqlite():
+        # SQLite IN query is not case insensitive, so we need to use a less efficient way
+        q_list = map(lambda n: Q(**{fieldname + '__iexact': n}), values)
+        case_insensitive_filter = reduce(lambda a, b: a | b, q_list)
+
+    return case_insensitive_filter

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -8809,6 +8809,31 @@ class TestEnterpriseGroupViewSet(APITest):
         assert pending_membership.status == GROUP_MEMBERSHIP_PENDING_STATUS
         assert membership.status == GROUP_MEMBERSHIP_ACCEPTED_STATUS
 
+    # TODO: Figure out how to make sqlite mirror MySQL case-insensitivity for IN queries
+    # def test_assign_learners_case_insensitive_emails(self):
+    #     """
+    #     Test assigning learners to a group with emails whose case differs from their registered user emails
+    #     """
+    #     new_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+    #     user_1 = UserFactory(email='testuser1@example.com')
+    #     user_2 = UserFactory(email='TestUser2@example.com')
+    #     ecu_1 = EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_1.id)
+    #     ecu_2 = EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_2.id)
+
+    #     assign_url = settings.TEST_SERVER + reverse(
+    #         'enterprise-group-assign-learners',
+    #         kwargs={'group_uuid': new_group.uuid},
+    #     )
+    #     request_data = {
+    #         'learner_emails': ['TestUser1@example.com', 'testuser2@example.com'],
+    #     }
+    #     self.client.post(assign_url, data=request_data)
+
+    #     # Verify both group memberships in place
+    #     assert len(EnterpriseGroupMembership.objects.filter(group=new_group, pending_enterprise_customer_user__isnull=True)) == 2
+    #     # Verify no pending group memberships
+    #     assert len(EnterpriseGroupMembership.objects.filter(group=new_group, pending_enterprise_customer_user__isnull=False)) == 0
+
     @mock.patch('enterprise.tasks.send_group_membership_invitation_notification.delay', return_value=mock.MagicMock())
     def test_successful_assign_learners_to_group(self, mock_send_group_membership_invitation_notification):
         """

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -8809,36 +8809,35 @@ class TestEnterpriseGroupViewSet(APITest):
         assert pending_membership.status == GROUP_MEMBERSHIP_PENDING_STATUS
         assert membership.status == GROUP_MEMBERSHIP_ACCEPTED_STATUS
 
-    # TODO: Figure out how to make sqlite mirror MySQL case-insensitivity for IN queries
-    # def test_assign_learners_case_insensitive_emails(self):
-    #     """
-    #     Test assigning learners to a group with emails whose case differs from their registered user emails
-    #     """
-    #     new_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
-    #     user_1 = UserFactory(email='testuser1@example.com')
-    #     user_2 = UserFactory(email='TestUser2@example.com')
-    #     EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_1.id)
-    #     EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_2.id)
+    def test_assign_learners_case_insensitive_emails(self):
+        """
+        Test assigning learners to a group with emails whose case differs from their registered user emails
+        """
+        new_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+        user_1 = UserFactory(email='testuser1@example.com')
+        user_2 = UserFactory(email='TestUser2@example.com')
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_1.id)
+        EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_2.id)
 
-    #     assign_url = settings.TEST_SERVER + reverse(
-    #         'enterprise-group-assign-learners',
-    #         kwargs={'group_uuid': new_group.uuid},
-    #     )
-    #     request_data = {
-    #         'learner_emails': ['TestUser1@example.com', 'testuser2@example.com'],
-    #     }
-    #     self.client.post(assign_url, data=request_data)
+        assign_url = settings.TEST_SERVER + reverse(
+            'enterprise-group-assign-learners',
+            kwargs={'group_uuid': new_group.uuid},
+        )
+        request_data = {
+            'learner_emails': ['TestUser1@example.com', 'testuser2@example.com'],
+        }
+        self.client.post(assign_url, data=request_data)
 
-    #     # Verify both group memberships in place
-    #     assert len(EnterpriseGroupMembership.objects.filter(
-    #         group=new_group,
-    #         pending_enterprise_customer_user__isnull=True)
-    #         ) == 2
-    #     # Verify no pending group memberships
-    #     assert len(EnterpriseGroupMembership.objects.filter(
-    #         group=new_group,
-    #         pending_enterprise_customer_user__isnull=False)
-    #         ) == 0
+        # Verify both group memberships in place
+        assert len(EnterpriseGroupMembership.objects.filter(
+            group=new_group,
+            pending_enterprise_customer_user__isnull=True)
+        ) == 2
+        # Verify no pending group memberships
+        assert len(EnterpriseGroupMembership.objects.filter(
+            group=new_group,
+            pending_enterprise_customer_user__isnull=False)
+        ) == 0
 
     @mock.patch('enterprise.tasks.send_group_membership_invitation_notification.delay', return_value=mock.MagicMock())
     def test_successful_assign_learners_to_group(self, mock_send_group_membership_invitation_notification):

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -8817,8 +8817,8 @@ class TestEnterpriseGroupViewSet(APITest):
     #     new_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
     #     user_1 = UserFactory(email='testuser1@example.com')
     #     user_2 = UserFactory(email='TestUser2@example.com')
-    #     ecu_1 = EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_1.id)
-    #     ecu_2 = EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_2.id)
+    #     EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_1.id)
+    #     EnterpriseCustomerUserFactory(enterprise_customer=self.enterprise_customer, user_id=user_2.id)
 
     #     assign_url = settings.TEST_SERVER + reverse(
     #         'enterprise-group-assign-learners',
@@ -8830,9 +8830,15 @@ class TestEnterpriseGroupViewSet(APITest):
     #     self.client.post(assign_url, data=request_data)
 
     #     # Verify both group memberships in place
-    #     assert len(EnterpriseGroupMembership.objects.filter(group=new_group, pending_enterprise_customer_user__isnull=True)) == 2
+    #     assert len(EnterpriseGroupMembership.objects.filter(
+    #         group=new_group,
+    #         pending_enterprise_customer_user__isnull=True)
+    #         ) == 2
     #     # Verify no pending group memberships
-    #     assert len(EnterpriseGroupMembership.objects.filter(group=new_group, pending_enterprise_customer_user__isnull=False)) == 0
+    #     assert len(EnterpriseGroupMembership.objects.filter(
+    #         group=new_group,
+    #         pending_enterprise_customer_user__isnull=False)
+    #         ) == 0
 
     @mock.patch('enterprise.tasks.send_group_membership_invitation_notification.delay', return_value=mock.MagicMock())
     def test_successful_assign_learners_to_group(self, mock_send_group_membership_invitation_notification):


### PR DESCRIPTION
[Jira Ticket](https://2u-internal.atlassian.net/browse/ENT-10246)

Currently we allow learner emails to be entered via csv file, and do not restrict them to the email casing they registered with.  As such, we need to support looking up existing `User` records in a case-insensitive manner.

## Testing Instructions
- Deploy this change locally
- Using Admin Portal, invite a learner to a group via csv, where their email in the csv does *not* match the casing their email was originally registered with
- Verify the learner is invited to the group successfully, and no duplicate `PendingEnterpriseCustomerUser` records are created in the process

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
