### PR TITLE
fix: adding enterprisegroup delete signal

### DIFF
--- a/enterprise/api_client/enterprise_access.py
+++ b/enterprise/api_client/enterprise_access.py
@@ -1,0 +1,51 @@
+"""
+Client for communicating with the enterprise-access api
+"""
+from logging import getLogger
+from urllib.parse import urljoin
+
+from requests.exceptions import RequestException, Timeout
+
+from django.conf import settings
+
+from enterprise import utils
+from enterprise.api_client.client import UserAPIClient
+
+LOGGER = getLogger(__name__)
+
+
+class EnterpriseAccessClientError(RequestException):
+    """
+    Indicate a problem when interacting with an enterprise access api client.
+    """
+
+
+class EnterpriseAccessApiClient(UserAPIClient):
+    """
+    The API client to make calls to the enterprise-access API.
+    """
+
+    API_BASE_URL = urljoin(f"{settings.ENTERPRISE_ACCESS_INTERNAL_ROOT_URL}/", "api/v1/")
+    DELETE_ASSOCIATION_ENDPOINT = '{}/delete-group-association/{}/'
+
+    def __init__(self, user=None):
+        user = user if user else utils.get_enterprise_worker_user()
+        super().__init__(user)
+
+    @UserAPIClient.refresh_token
+    def delete_policy_group_association(self, enterprise_uuid, group_uuid):
+        """
+        Endpoint to connect to enterprise-access so we can delete any PolicyGroupAssocations after the
+        deletion of an EnterpriseGroup
+        """
+        api_url = self.API_BASE_URL + self.DELETE_ASSOCIATION_ENDPOINT.format(enterprise_uuid, group_uuid)
+        try:
+            response = self.client.delete(api_url)
+            response.raise_for_status()
+            return 204 == response.status_code
+        except (RequestException, Timeout) as exc:
+            LOGGER.exception(
+                'Failed to fetch any PolicyGroupAssoication from group %s due to [%s]',
+                group_uuid, str(exc)
+            )
+            return {}

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -311,6 +311,11 @@ class Command(BaseCommand):
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
+            self._create_enterprise_user(
+                username='enterprise_access_worker',
+                role=ENTERPRISE_OPERATOR_ROLE,
+                applies_to_all_contexts=True,
+            ),
         ]
         # Add a couple more learners!
         for i in range(2):

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -144,6 +144,7 @@ LMS_INTERNAL_ROOT_URL = "http://localhost:8000"
 LMS_ENROLLMENT_API_PATH = "/api/enrollment/v1/"
 ECOMMERCE_PUBLIC_URL_ROOT = "http://localhost:18130"
 ENTERPRISE_CATALOG_INTERNAL_ROOT_URL = "http://localhost:18160"
+ENTERPRISE_ACCESS_INTERNAL_ROOT_URL = "http://localhost:18270"
 
 ENTERPRISE_ENROLLMENT_API_URL = LMS_INTERNAL_ROOT_URL + LMS_ENROLLMENT_API_PATH
 
@@ -194,6 +195,7 @@ ENTERPRISE_ALL_SERVICE_USERNAMES = [
     'license_manager_worker',
     'enterprise_catalog_worker',
     'enterprise_subsidy_worker',
+    'enterprise_access_worker',
 ]
 
 ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'

--- a/enterprise/signals.py
+++ b/enterprise/signals.py
@@ -11,6 +11,7 @@ from django.dispatch import receiver
 
 from enterprise import models, roles_api
 from enterprise.api import activate_admin_permissions
+from enterprise.api_client.enterprise_access import EnterpriseAccessApiClient, EnterpriseAccessClientError
 from enterprise.api_client.enterprise_catalog import EnterpriseCatalogApiClient
 from enterprise.decorators import disable_for_loaddata
 from enterprise.tasks import create_enterprise_enrollment
@@ -439,6 +440,23 @@ def generate_default_orchestration_record_display_name(sender, instance, **kwarg
                 enterprise_customer=instance.enterprise_customer,
             ).count()
             instance.display_name = f'SSO-config-{instance.identity_provider}-{num_records_for_customer + 1}'
+
+
+@receiver(post_delete, sender=models.EnterpriseGroup)
+def delete_associations_with_removed_group(sender, instance, **kwargs):     # pylint: disable=unused-argument
+    """
+    Delete the associated enterprise admin role assignment record when deleting an EnterpriseCustomerUser record.
+    """
+    enterprise_uuid = instance.enterprise_customer.uuid
+    group_uuid = instance.uuid
+    try:
+        access_client = EnterpriseAccessApiClient()
+        access_client.delete_policy_group_association(enterprise_uuid, group_uuid)
+    except EnterpriseAccessClientError as exc:
+        logger.exception(
+            'Unable to delete PolicyGroupAssociations with group uuid {}'.format(str(group_uuid)),
+            exc_info=exc
+        )
 
 
 # Don't connect this receiver if we dont have access to CourseEnrollment model

--- a/tests/test_enterprise/api_client/test_enterprise_access.py
+++ b/tests/test_enterprise/api_client/test_enterprise_access.py
@@ -1,0 +1,57 @@
+"""
+Tests for enterprise.api_client.enterprise_access.py
+"""
+
+import unittest
+from unittest import mock
+
+import ddt
+import responses
+from pytest import mark
+
+from django.conf import settings
+
+from enterprise.api_client import enterprise_access
+from test_utils.factories import EnterpriseCustomerFactory, EnterpriseGroupFactory, UserFactory
+
+
+@ddt.ddt
+@mark.django_db
+class TestEnterpriseAccessApiClient(unittest.TestCase):
+    """
+    Test enterprise-access API client methods.
+    """
+
+    def setUp(self):
+        """
+        DRY method for TestEnterpriseAccessApiClient.
+        """
+        self.user = UserFactory()
+        self.enterprise_customer = EnterpriseCustomerFactory(
+            name='Lumon',
+        )
+        self.test_group = EnterpriseGroupFactory(enterprise_customer=self.enterprise_customer)
+        self.url_base = settings.ENTERPRISE_ACCESS_INTERNAL_ROOT_URL
+        self.delete_associations_url = \
+            "{base}/api/v1/{enterprise_uuid}/delete-group-association/{group_uuid}/".format(
+                base=self.url_base,
+                enterprise_uuid=self.enterprise_customer.uuid,
+                group_uuid=self.test_group.uuid,
+            )
+
+        super().setUp()
+
+    @mock.patch('enterprise.api_client.client.JwtBuilder', mock.Mock())
+    @responses.activate
+    def test_delete_policy_group_association(self):
+        """
+        Verify that the client method `delete_policy_group_association` works as expected.
+        """
+        responses.add(
+            responses.DELETE,
+            url=self.delete_associations_url,
+            status=204,
+        )
+        client = enterprise_access.EnterpriseAccessApiClient(self.user)
+        response = client.delete_policy_group_association(self.enterprise_customer.uuid, self.test_group.uuid)
+        assert response is True


### PR DESCRIPTION
When we delete an EnterpriseGroup, we want to send a post_delete signal that deletes the PolicyGroupAsscoiation from enterprise-access using the endpoint from [this PR](https://github.com/openedx/enterprise-access/pull/677). 

[Jira ticket 
](https://2u-internal.atlassian.net/browse/ENT-9904)


**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
