### PR TITLE
chore: upgrading `django-simple-history` to latest version.

### DIFF
--- a/requirements/constraints.txt
+++ b/requirements/constraints.txt
@@ -30,5 +30,3 @@ pytest<7.0
 # pinning it to latest release.
 celery>=5.2.2,<6.0.0
 
-# upgrading django-simple-history
-django-simple-history<=3.1.1


### PR DESCRIPTION
Upgrading `django-simple-history` to latest version. 

It will bring **django52** compatibility.