### PR TITLE
fix: fix unit tests that broke due to path() returning UUID objects

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.1.2]
+--------
+* fix: fix unit tests that broke due to ``path()`` returning UUID objects
+
 [6.1.1]
 --------
 * chore: upgrades python requirements

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.1.1"
+__version__ = "6.1.2"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -926,8 +926,11 @@ def get_enterprise_customer_or_404(enterprise_uuid):
     """
     EnterpriseCustomer = enterprise_customer_model()
     try:
-        enterprise_uuid = UUID(enterprise_uuid)
-        return EnterpriseCustomer.objects.get(uuid=enterprise_uuid)
+        if isinstance(enterprise_uuid, str):
+            enterprise_uuid_obj = UUID(enterprise_uuid)
+        else:
+            enterprise_uuid_obj = enterprise_uuid
+        return EnterpriseCustomer.objects.get(uuid=enterprise_uuid_obj)
     except (TypeError, ValueError, EnterpriseCustomer.DoesNotExist) as no_customer_error:
         LOGGER.error('Unable to find enterprise customer for UUID: [%s]', enterprise_uuid)
         raise Http404 from no_customer_error

--- a/enterprise/views.py
+++ b/enterprise/views.py
@@ -2343,7 +2343,7 @@ class RouterView(NonAtomicView):
         resource_id = course_key or course_run_id or program_uuid
         # Replace enterprise UUID and resource ID with '{}', to easily match with a path in RouterView.VIEWS. Example:
         # /enterprise/fake-uuid/course/course-v1:cool+course+2017/enroll/ -> /enterprise/{}/course/{}/enroll/
-        path = re.sub('{}|{}'.format(enterprise_customer_uuid, re.escape(resource_id)), '{}', request.path)
+        path = re.sub('{}|{}'.format(enterprise_customer_uuid, re.escape(str(resource_id))), '{}', request.path)
 
         # Remove course_key from kwargs if it exists because delegate views are not expecting it.
         kwargs.pop('course_key', None)

--- a/tests/test_enterprise/views/test_program_enrollment_view.py
+++ b/tests/test_enterprise/views/test_program_enrollment_view.py
@@ -5,6 +5,7 @@ Tests for the ``ProgramEnrollmentView`` view of the Enterprise app.
 import copy
 from unittest import mock
 from urllib.parse import urlencode
+from uuid import uuid4
 
 import ddt
 from faker import Factory as FakerFactory
@@ -749,7 +750,7 @@ class TestProgramEnrollmentView(EmbargoAPIMixin, MessagesMixin, TestCase):
         """
         program_enrollment_page_url = reverse(
             'enterprise_program_enrollment_page',
-            args=['some-fake-enterprise-customer-uuid', self.dummy_program_uuid],
+            args=[uuid4(), self.dummy_program_uuid],
         )
 
         self._login()


### PR DESCRIPTION
**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
