### PR TITLE
Group delete event

### DIFF
--- a/enterprise/event_bus.py
+++ b/enterprise/event_bus.py
@@ -5,8 +5,10 @@ from openedx_events.enterprise.data import (
     EnterpriseCourseEnrollment,
     EnterpriseCustomerUser,
     LearnerCreditEnterpriseCourseEnrollment,
+    EnterpriseGroup,
 )
-from openedx_events.enterprise.signals import LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED
+from openedx_events.enterprise.signals import LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED, ENTERPRISE_GROUP_DELETED
+from uuid import uuid4
 
 
 def serialize_learner_credit_course_enrollment(learner_credit_course_enrollment):
@@ -67,4 +69,18 @@ def send_learner_credit_course_enrollment_revoked_event(learner_credit_course_en
     """
     LEARNER_CREDIT_COURSE_ENROLLMENT_REVOKED.send_event(
         learner_credit_course_enrollment=serialize_learner_credit_course_enrollment(learner_credit_course_enrollment),
+    )
+
+
+def send_enterprise_group_deleted_event():
+    """
+    Sends the ENTERPRISE_GROUP_DELETED openedx event.
+
+    Args:
+        enterprise_group (enterprise.models.EnterpriseGroup):
+            An enterprise group that was deleted.
+    """
+    data = EnterpriseGroup(uuid=uuid4())
+    ENTERPRISE_GROUP_DELETED.send_event(
+        enterprise_group=data
     )

--- a/enterprise/management/commands/produce_enterprise_ping_event.py
+++ b/enterprise/management/commands/produce_enterprise_ping_event.py
@@ -1,0 +1,95 @@
+"""
+Produce a single event for enterprise-specific testing or health checks.
+
+Implements required ``APP.management.commands.*.Command`` structure.
+"""
+import logging
+import uuid
+
+import attr
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from edx_event_bus_kafka.internal.producer import create_producer
+from openedx_events.data import EventsMetadata
+from openedx_events.tooling import OpenEdxPublicSignal
+
+logger = logging.getLogger(__name__)
+
+
+# First define the topic that our consumer will subscribe to.
+ENTERPRISE_CORE_TOPIC = getattr(settings, 'EVENT_BUS_ENTERPRISE_CORE_TOPIC', 'enterprise-core')
+
+
+# Define the shape/schema of the data that our consumer will process.
+# It should be identical to the schema used to *produce* the event.
+@attr.s(frozen=True)
+class PingData:
+    """
+    Attributes of a ping record.
+    """
+    ping_uuid = attr.ib(type=str)
+    ping_message = attr.ib(type=str)
+
+
+ENTERPRISE_PING_DATA_SCHEMA = {
+    "ping": PingData,
+}
+
+# Define the key field used to serialize and de-serialize the event data.
+ENTERPRISE_PING_KEY_FIELD = 'ping.ping_uuid'
+
+# Define a Signal with the type (unique name) of the event to process,
+# and tell it about the expected schema of event data. The producer of our ping events
+# should emit an identical signal (same event_type and data schema).
+ENTERPRISE_PING_SIGNAL = OpenEdxPublicSignal(
+    event_type="org.openedx.enterprise.core.ping.v1",
+    data=ENTERPRISE_PING_DATA_SCHEMA
+)
+
+
+def ping_event_data():
+    """
+    Helper to produce a dictionary of ping event data
+    that fits the schema defined above by ``PingData`` and the
+    ``data`` expected by our Ping Signal.
+    """
+    return {
+        'ping': {
+            'ping_uuid': str(uuid.uuid4()),
+            'ping_message': 'hello, world',
+        }
+    }
+
+
+class Command(BaseCommand):
+    """
+    Management command to produce a test event to the event bus.
+    """
+    help = """
+    Produce a single ping event to the configured test topic.
+
+    example:
+        ./manage.py produce_enterprise_ping_event
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--topic', nargs=1, required=False,
+            help="Optional topic to produce to (without environment prefix)",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            producer = create_producer()
+            producer.send(
+                signal=ENTERPRISE_PING_SIGNAL,
+                topic=ENTERPRISE_CORE_TOPIC,
+                event_key_field=ENTERPRISE_PING_KEY_FIELD,
+                event_data=ping_event_data(),
+                event_metadata=EventsMetadata(
+                    event_type=ENTERPRISE_PING_SIGNAL.event_type,
+                ),
+            )
+            producer.prepare_for_shutdown()  # otherwise command may exit before delivery is complete
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Error producing Kafka event")

--- a/enterprise/management/commands/produce_event_bus_group_delete_test_event.py
+++ b/enterprise/management/commands/produce_event_bus_group_delete_test_event.py
@@ -1,0 +1,44 @@
+"""
+Produce a single event for enterprise-specific testing or health checks.
+
+Implements required ``APP.management.commands.*.Command`` structure.
+"""
+import logging
+import uuid
+
+import attr
+from django.conf import settings
+from django.core.management.base import BaseCommand
+from edx_event_bus_kafka.internal.producer import create_producer
+from openedx_events.data import EventsMetadata
+from openedx_events.tooling import OpenEdxPublicSignal
+from enterprise.event_bus import send_enterprise_group_deleted_event
+
+logger = logging.getLogger(__name__)
+
+
+# First define the topic that our consumer will subscribe to.
+ENTERPRISE_CORE_TOPIC = getattr(settings, 'EVENT_BUS_ENTERPRISE_CORE_TOPIC', 'enterprise-core')
+
+class Command(BaseCommand):
+    """
+    Management command to produce a test event to the event bus.
+    """
+    help = """
+    Produce a single ping event to the configured test topic.
+
+    example:
+        ./manage.py produce_enterprise_ping_event
+    """
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--topic', nargs=1, required=False,
+            help="Optional topic to produce to (without environment prefix)",
+        )
+
+    def handle(self, *args, **options):
+        try:
+            send_enterprise_group_deleted_event()
+        except Exception:  # pylint: disable=broad-exception-caught
+            logger.exception("Error producing Kafka event")


### PR DESCRIPTION
Not working yet, for unknown reasons.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
