### PR TITLE
fix: adding OnboardingFlow to django

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,11 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.2.5]
+--------
+* feat: adds OnboardingFlow model to django
+
+
 [6.2.4]
 --------
 * feat: creates EnterpriseCustomerAdmin records for EnterpriseCustomerUsers with admin roles

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.2.4"
+__version__ = "6.2.5"

--- a/enterprise/admin/__init__.py
+++ b/enterprise/admin/__init__.py
@@ -1411,3 +1411,16 @@ class DefaultEnterpriseEnrollmentIntentionAdmin(admin.ModelAdmin):
                 'are not used but may be re-enabled if needed.'
 
         return formfield
+
+
+@admin.register(models.OnboardingFlow)
+class OnboardingFlowAdmin(admin.ModelAdmin):
+    """
+    Django admin model for OnboardingFlow.
+    """
+
+    list_display = ('uuid', 'title', 'active')
+
+    class Meta:
+        fields = '__all__'
+        model = models.OnboardingFlow


### PR DESCRIPTION
Making the OnboardingFlow available in django admin 

<img width="538" alt="Screenshot 2025-06-16 at 11 21 12 AM" src="https://github.com/user-attachments/assets/9f614a5f-6c32-4891-bc5b-0c82fda90d8e" />

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [x] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [x] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
