### PR TITLE
fix: upgrade djangorestframework and skip automatic validators

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[6.3.2]
+--------
+* fix: upgrade djangorestframework and skip automatic validators
+
 [6.3.1]
 --------
 * feat: Add django admin interface for EnterpriseCustomerAdmin

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "6.3.1"
+__version__ = "6.3.2"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -1032,6 +1032,11 @@ class PendingEnterpriseCustomerUserSerializer(serializers.ModelSerializer):
         fields = (
             'enterprise_customer', 'user_email'
         )
+        # [ENT-10865] Explicitly set the validators attribute to prevent ModelSerializer
+        # from automatically generating uniqueness validators based on unique constraints
+        # on the underlying model. While this new feature is nice, it breaks assumptions
+        # in existing logic within this serializer.
+        validators = []
 
     def to_representation(self, instance):
         '''
@@ -1860,6 +1865,11 @@ class PendingEnterpriseCustomerAdminUserSerializer(serializers.ModelSerializer):
         fields = (
             'id', 'enterprise_customer', 'user_email'
         )
+        # [ENT-10865] Explicitly set the validators attribute to prevent ModelSerializer
+        # from automatically generating uniqueness validators based on unique constraints
+        # on the underlying model. While this new feature is nice, it breaks assumptions
+        # in existing logic within this serializer.
+        validators = []
 
     def validate(self, attrs):
         """

--- a/requirements/celery53.txt
+++ b/requirements/celery53.txt
@@ -5,5 +5,5 @@ click==8.2.1
 click-didyoumean==0.3.1
 click-repl==0.3.0
 kombu==5.5.4
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
 vine==5.1.0

--- a/requirements/ci.txt
+++ b/requirements/ci.txt
@@ -4,7 +4,7 @@
 #
 #    make upgrade
 #
-cachetools==6.1.0
+cachetools==6.2.0
     # via tox
 chardet==5.2.0
     # via tox
@@ -12,7 +12,7 @@ colorama==0.4.6
     # via tox
 distlib==0.4.0
     # via virtualenv
-filelock==3.18.0
+filelock==3.19.1
     # via
     #   tox
     #   virtualenv
@@ -20,7 +20,7 @@ packaging==25.0
     # via
     #   pyproject-api
     #   tox
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via
     #   tox
     #   virtualenv
@@ -30,5 +30,5 @@ pyproject-api==1.9.1
     # via tox
 tox==4.28.4
     # via -r requirements/ci.in
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via tox

--- a/requirements/common_constraints.txt
+++ b/requirements/common_constraints.txt
@@ -1,4 +1,5 @@
 
+
 # A central location for most common version constraints
 # (across edx repos) for pip-installation.
 #

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,60 +6,60 @@
 #
 accessible-pygments==0.0.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
 aiohttp==3.12.15
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openai
 aiosignal==1.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
 alabaster==1.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 amqp==5.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   kombu
 aniso8601==10.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-tincan-py35
-anyio==4.9.0
+anyio==4.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   httpx
 asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
 astroid==3.3.11
     # via
@@ -67,50 +67,50 @@ astroid==3.3.11
     #   pylint-celery
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   edx-ace
     #   openedx-events
     #   pytest
 babel==2.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
     #   sphinx
 bcrypt==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   paramiko
-beautifulsoup4==4.13.4
+beautifulsoup4==4.13.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
 billiard==4.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 bleach==6.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-boto3==1.39.16
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+boto3==1.40.20
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
-botocore==1.39.16
+botocore==1.40.20
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
@@ -118,57 +118,57 @@ build==1.3.0
     # via pip-tools
 cachecontrol==0.14.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   firebase-admin
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-auth
     #   tox
 celery==5.5.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-certifi==2025.7.14
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   httpcore
     #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/test.txt
     #   diff-cover
     #   tox
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   requests
     #   snowflake-connector-python
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
     #   click-didyoumean
     #   click-log
@@ -180,42 +180,42 @@ click==8.2.1
     #   pip-tools
 click-didyoumean==0.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 click-log==0.4.0
     # via edx-lint
 click-plugins==1.1.1.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-lint
     #   edx-toggles
 colorama==0.4.6
     # via tox
-coverage[toml]==7.10.3
+coverage[toml]==7.10.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/test.txt
     #   pytest-cov
-cryptography==45.0.5
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -224,25 +224,25 @@ cryptography==45.0.5
     #   pyopenssl
     #   snowflake-connector-python
 ddt==1.3.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   djangorestframework-xml
 diff-cover==9.6.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 dill==0.4.0
     # via pylint
 distlib==0.4.0
     # via virtualenv
 django==4.2.23
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -251,6 +251,7 @@ django==4.2.23
     #   django-multi-email-field
     #   django-oauth-toolkit
     #   django-push-notifications
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -267,87 +268,87 @@ django==4.2.23
     #   openedx-events
 django-cache-memoize==0.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-config-models==2.9.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-countries==7.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-filter==25.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-ipware==7.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-rbac
 django-multi-email-field==0.8.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-oauth-toolkit==1.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-object-actions==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-push-notifications==3.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ace
 django-simple-history==3.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
@@ -355,20 +356,20 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pymongo
 doc8==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    # via -r requirements/doc.txt
 docutils==0.21.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   doc8
     #   pydata-sphinx-theme
     #   readme-renderer
@@ -376,44 +377,44 @@ docutils==0.21.2
     #   sphinx
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-braze-client
 edx-api-doc-tools==2.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-braze-client==1.1.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
     #   -r requirements/dev.in
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openedx-events
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-config-models
     #   edx-ace
     #   edx-braze-client
@@ -423,9 +424,9 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-drf-extensions==10.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-rbac
 edx-i18n-tools==1.9.0
     # via -r requirements/dev.in
@@ -433,184 +434,184 @@ edx-lint==5.6.0
     # via -r requirements/dev.in
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==2.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-rest-api-client==6.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-tincan-py35==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 edx-toggles==5.4.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 factory-boy==3.3.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-faker==37.5.3
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
+faker==37.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
     #   tox
     #   virtualenv
-firebase-admin==7.0.0
+firebase-admin==7.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ace
 freezegun==0.3.14
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 frozenlist==1.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   aiosignal
 google-api-core[grpc]==2.25.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-auth==2.40.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-core==2.4.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-firestore==2.21.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   firebase-admin
-google-cloud-storage==3.2.0
+google-cloud-storage==3.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   firebase-admin
 google-crc32c==1.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-cloud-storage
     #   google-resumable-media
 google-resumable-media==2.7.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-cloud-storage
 googleapis-common-protos==1.70.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-api-core
     #   grpcio-status
 grpcio==1.74.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-api-core
     #   grpcio-status
 grpcio-status==1.74.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-api-core
 h11==0.16.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   httpcore
-h2==4.2.0
+h2==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   httpx
 hpack==4.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   h2
 httpcore==1.0.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   httpx
 httpx[http2]==0.28.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   firebase-admin
 hyperframe==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   h2
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   anyio
     #   httpx
     #   requests
@@ -618,61 +619,67 @@ idna==3.10
     #   yarl
 imagesize==1.4.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest
+invoke==2.2.0
+    # via
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+    #   paramiko
 isort==6.0.1
     # via
     #   -r requirements/dev.in
     #   pylint
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   diff-cover
     #   sphinx
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   boto3
     #   botocore
 jsondiff==2.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 jsonfield==3.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 jwcrypto==1.5.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-oauth-toolkit
 kombu==5.5.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   celery
-lxml[html-clean,html_clean]==6.0.0
+lxml[html-clean]==6.0.1
     # via
     #   edx-i18n-tools
     #   lxml-html-clean
@@ -680,54 +687,54 @@ lxml-html-clean==0.4.2
     # via lxml
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   jinja2
 mccabe==0.7.0
     # via pylint
 mock==3.0.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 msgpack==1.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   cachecontrol
-multidict==6.6.3
+multidict==6.6.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 nh3==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   readme-renderer
 oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-oauth-toolkit
 openai==0.28.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-openedx-events==10.4.0
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
+openedx-events==10.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   build
     #   drf-yasg
     #   kombu
@@ -737,87 +744,81 @@ packaging==25.0
     #   snowflake-connector-python
     #   sphinx
     #   tox
-paramiko==3.5.1
+paramiko==4.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 path==16.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-i18n-tools
     #   path-py
 path-py==12.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-pbr==6.1.1
-    # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-    #   stevedore
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 pgpy==0.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 pillow==11.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 pip-tools==7.5.0
     # via -r requirements/dev.in
 pkginfo==1.12.1.2
     # via twine
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pylint
     #   snowflake-connector-python
     #   tox
     #   virtualenv
 pluggy==1.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   diff-cover
     #   pytest
     #   pytest-cov
     #   tox
 polib==1.2.0
     # via edx-i18n-tools
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   click-repl
 propcache==0.3.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
     #   yarl
 proto-plus==1.26.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.31.1
+protobuf==6.32.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
@@ -825,47 +826,47 @@ protobuf==6.31.1
     #   proto-plus
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
 py==1.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pgpy
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-auth
 pycodestyle==2.14.0
     # via -r requirements/dev.in
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   cffi
 pydata-sphinx-theme==0.15.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx-book-theme
 pydocstyle==6.3.0
     # via -r requirements/dev.in
 pygments==2.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   accessible-pygments
     #   diff-cover
     #   doc8
@@ -874,9 +875,9 @@ pygments==2.19.2
     #   sphinx
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -898,22 +899,22 @@ pylint-plugin-utils==0.9.0
     #   pylint-django
 pymongo==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
 pyproject-api==1.9.1
     # via tox
@@ -923,61 +924,60 @@ pyproject-hooks==1.2.0
     #   pip-tools
 pytest==6.2.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==6.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 pytest-django==4.5.2
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    # via -r requirements/test.txt
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   botocore
     #   celery
     #   edx-ace
     #   freezegun
 python-ipware==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
-    #   djangorestframework
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   drf-yasg
     #   edx-i18n-tools
     #   jsondiff
 readme-renderer==44.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-requests==2.32.4
+    # via -r requirements/doc.txt
+requests==2.32.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   cachecontrol
     #   django-oauth-toolkit
     #   edx-braze-client
@@ -997,56 +997,56 @@ requests-toolbelt==1.0.0
     # via twine
 responses==0.10.15
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -c requirements/constraints.txt
+    #   -r requirements/test.txt
 restructuredtext-lint==1.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   doc8
 roman-numerals-py==3.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   google-auth
 rules==3.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   boto3
 sailthru-client==2.2.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ace
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   sailthru-client
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   edx-ace
     #   edx-ccx-keys
     #   edx-lint
@@ -1057,77 +1057,77 @@ six==1.17.0
     #   responses
 slumber==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 sniffio==1.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   anyio
 snowballstemmer==3.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydocstyle
     #   sphinx
-snowflake-connector-python==3.16.0
+snowflake-connector-python==3.17.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 sortedcontainers==2.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   snowflake-connector-python
-soupsieve==2.7
+soupsieve==2.8
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   beautifulsoup4
 sphinx==8.2.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   pydata-sphinx-theme
     #   sphinx-book-theme
 sphinx-book-theme==1.1.4
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    # via -r requirements/doc.txt
 sphinxcontrib-applehelp==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-devhelp==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-htmlhelp==2.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-jsmath==1.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-qthelp==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sphinxcontrib-serializinghtml==2.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
+    #   -r requirements/doc.txt
     #   sphinx
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   code-annotations
     #   doc8
     #   edx-ace
@@ -1135,44 +1135,44 @@ stevedore==5.4.1
     #   edx-opaque-keys
 testfixtures==9.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
     #   -r requirements/dev.in
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   python-slugify
 toml==0.10.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test.txt
     #   pytest
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   pylint
     #   snowflake-connector-python
 tox==4.27.0
     # via -r requirements/dev.in
 tqdm==4.67.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   openai
     #   twine
 twine==1.11.0
     # via -r requirements/dev.in
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiosignal
     #   anyio
     #   beautifulsoup4
@@ -1184,50 +1184,50 @@ typing-extensions==4.14.1
     #   snowflake-connector-python
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   faker
     #   kombu
 unicodecsv==0.14.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   drf-yasg
 urllib3==2.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   botocore
     #   requests
 vine==5.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   amqp
     #   celery
     #   kombu
-virtualenv==20.33.1
+virtualenv==20.34.0
     # via tox
 wcwidth==0.2.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   bleach
 wheel==0.45.1
     # via
@@ -1235,9 +1235,9 @@ wheel==0.45.1
     #   pip-tools
 yarl==1.20.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/doc.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test.txt
+    #   -r requirements/doc.txt
+    #   -r requirements/test-master.txt
+    #   -r requirements/test.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -8,42 +8,42 @@ accessible-pygments==0.0.5
     # via pydata-sphinx-theme
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 aiohttp==3.12.15
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
 aiosignal==1.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 alabaster==1.0.0
     # via sphinx
 amqp==5.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   kombu
 aniso8601==10.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-tincan-py35
-anyio==4.9.0
+anyio==4.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpx
 asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   edx-ace
     #   openedx-events
@@ -54,59 +54,59 @@ babel==2.17.0
     #   sphinx
 bcrypt==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   paramiko
-beautifulsoup4==4.13.4
+beautifulsoup4==4.13.5
     # via pydata-sphinx-theme
 billiard==4.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 bleach==6.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-boto3==1.39.16
+    # via -r requirements/test-master.txt
+boto3==1.40.20
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
-botocore==1.39.16
+botocore==1.40.20
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
 cachecontrol==0.14.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-auth
 celery==5.5.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-certifi==2025.7.14
+    #   -c requirements/constraints.txt
+    #   -r requirements/test-master.txt
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpcore
     #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
 click==8.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -115,23 +115,23 @@ click==8.2.1
     #   edx-django-utils
 click-didyoumean==0.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 click-plugins==1.1.1.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 click-repl==0.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-toggles
-cryptography==45.0.5
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -141,12 +141,12 @@ cryptography==45.0.5
     #   snowflake-connector-python
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   djangorestframework-xml
 django==4.2.23
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -155,6 +155,7 @@ django==4.2.23
     #   django-multi-email-field
     #   django-oauth-toolkit
     #   django-push-notifications
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -169,59 +170,58 @@ django==4.2.23
     #   jsonfield
     #   openedx-events
 django-cache-memoize==0.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-config-models==2.9.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-countries==7.6.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-filter==25.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-ipware==7.0.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-rbac
 django-multi-email-field==0.8.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-oauth-toolkit==1.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-object-actions==5.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-push-notifications==3.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
 django-simple-history==3.10.1
-    # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pymongo
 doc8==2.0.0
     # via -r requirements/doc.in
@@ -235,29 +235,29 @@ docutils==0.21.2
     #   sphinx
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-braze-client
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-braze-client==1.1.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
     #   -r requirements/doc.in
+    #   -r requirements/test-master.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   edx-ace
     #   edx-braze-client
@@ -267,122 +267,122 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-drf-extensions==10.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-rbac
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==2.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-tincan-py35==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-toggles==5.4.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 factory-boy==3.3.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
-faker==37.5.3
+faker==37.6.0
     # via factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
-firebase-admin==7.0.0
+firebase-admin==7.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
 frozenlist==1.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   aiosignal
 google-api-core[grpc]==2.25.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-auth==2.40.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-core==2.4.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-firestore==2.21.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
-google-cloud-storage==3.2.0
+google-cloud-storage==3.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
 google-crc32c==1.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-cloud-storage
     #   google-resumable-media
 google-resumable-media==2.7.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-cloud-storage
 googleapis-common-protos==1.70.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   grpcio-status
 grpcio==1.74.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   grpcio-status
 grpcio-status==1.74.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
 h11==0.16.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpcore
-h2==4.2.0
+h2==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpx
 hpack==4.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   h2
 httpcore==1.0.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpx
 httpx[http2]==0.28.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
 hyperframe==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   h2
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   anyio
     #   httpx
     #   requests
@@ -392,103 +392,103 @@ imagesize==1.4.1
     # via sphinx
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via pytest
+invoke==2.2.0
+    # via
+    #   -r requirements/test-master.txt
+    #   paramiko
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   sphinx
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   boto3
     #   botocore
 jsondiff==2.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jsonfield==3.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jwcrypto==1.5.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
 kombu==5.5.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   jinja2
 msgpack==1.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cachecontrol
-multidict==6.6.3
+multidict==6.6.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 nh3==0.3.0
     # via readme-renderer
 oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
 openai==0.28.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-openedx-events==10.4.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
+openedx-events==10.5.0
+    # via -r requirements/test-master.txt
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
     #   kombu
     #   pydata-sphinx-theme
     #   pytest
     #   snowflake-connector-python
     #   sphinx
-paramiko==3.5.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+paramiko==4.0.0
+    # via -r requirements/test-master.txt
 path==16.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   path-py
 path-py==12.5.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-pbr==6.1.1
-    # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   stevedore
+    # via -r requirements/test-master.txt
 pgpy==0.6.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 pillow==11.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-platformdirs==4.3.8
+    # via -r requirements/test-master.txt
+platformdirs==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pluggy==1.6.0
     # via pytest
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   click-repl
 propcache==0.3.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 proto-plus==1.26.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.31.1
+protobuf==6.32.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
@@ -496,23 +496,23 @@ protobuf==6.31.1
     #   proto-plus
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
 py==1.11.0
     # via pytest
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pgpy
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-auth
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cffi
 pydata-sphinx-theme==0.15.4
     # via sphinx-book-theme
@@ -525,7 +525,7 @@ pygments==2.19.2
     #   sphinx
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -533,53 +533,52 @@ pyjwt[crypto]==2.10.1
     #   snowflake-connector-python
 pymongo==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pytest==6.2.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/doc.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   botocore
     #   celery
     #   edx-ace
 python-ipware==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   djangorestframework
+    #   -r requirements/test-master.txt
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   drf-yasg
     #   jsondiff
 readme-renderer==44.0
     # via -r requirements/doc.in
-requests==2.32.4
+requests==2.32.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cachecontrol
     #   django-oauth-toolkit
     #   edx-braze-client
@@ -598,48 +597,48 @@ roman-numerals-py==3.1.0
     # via sphinx
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-auth
 rules==3.5
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   boto3
 sailthru-client==2.2.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   sailthru-client
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
     #   edx-ccx-keys
     #   edx-rbac
     #   python-dateutil
 slumber==0.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 sniffio==1.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   anyio
 snowballstemmer==3.0.1
     # via sphinx
-snowflake-connector-python==3.16.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+snowflake-connector-python==3.17.2
+    # via -r requirements/test-master.txt
 sortedcontainers==2.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
-soupsieve==2.7
+soupsieve==2.8
     # via beautifulsoup4
 sphinx==8.2.3
     # via
@@ -662,35 +661,35 @@ sphinxcontrib-serializinghtml==2.0.0
     # via sphinx
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   doc8
     #   edx-ace
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==9.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   python-slugify
 toml==0.10.2
     # via pytest
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 tqdm==4.67.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiosignal
     #   anyio
     #   beautifulsoup4
@@ -702,37 +701,37 @@ typing-extensions==4.14.1
     #   snowflake-connector-python
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   faker
     #   kombu
 unicodecsv==0.14.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 urllib3==2.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   botocore
     #   requests
 vine==5.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   bleach
 yarl==1.20.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -23,7 +23,7 @@ aniso8601==10.0.1
     # via edx-tincan-py35
 annotated-types==0.7.0
     # via pydantic
-anyio==4.9.0
+anyio==4.10.0
     # via httpx
 appdirs==1.4.4
     # via fs
@@ -53,7 +53,7 @@ backoff==1.10.0
     # via analytics-python
 bcrypt==4.3.0
     # via paramiko
-beautifulsoup4==4.13.4
+beautifulsoup4==4.13.5
     # via
     #   openedx-forum
     #   pynliner
@@ -68,14 +68,14 @@ bleach[css]==6.2.0
     #   xblock-poll
 boto==2.49.0
     # via -r requirements/edx/kernel.in
-boto3==1.39.16
+boto3==1.40.20
     # via
     #   -r requirements/edx/kernel.in
     #   django-ses
     #   fs-s3fs
     #   ora2
     #   snowflake-connector-python
-botocore==1.39.16
+botocore==1.40.20
     # via
     #   -r requirements/edx/kernel.in
     #   boto3
@@ -101,7 +101,7 @@ camel-converter[pydantic]==4.0.1
     #   enterprise-integrated-channels
     #   event-tracking
     #   openedx-learning
-certifi==2025.7.14
+certifi==2025.8.3
     # via
     #   elasticsearch
     #   httpcore
@@ -115,7 +115,7 @@ cffi==1.17.1
     #   snowflake-connector-python
 chardet==5.2.0
     # via pysrt
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
     #   requests
     #   snowflake-connector-python
@@ -142,7 +142,7 @@ codejail-includes==2.0.0
     # via -r requirements/edx/kernel.in
 crowdsourcehinter-xblock==0.8
     # via -r requirements/edx/bundled.in
-cryptography==45.0.5
+cryptography==45.0.6
     # via
     #   -r requirements/edx/kernel.in
     #   django-fernet-fields-v2
@@ -185,6 +185,7 @@ django==4.2.23
     #   django-push-notifications
     #   django-sekizai
     #   django-ses
+    #   django-simple-history
     #   django-statici18n
     #   django-storages
     #   django-user-tasks
@@ -304,7 +305,7 @@ django-model-utils==5.0.0
     #   enterprise-integrated-channels
     #   ora2
     #   super-csv
-django-mptt==0.17.0
+django-mptt==0.18.0
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-wiki
@@ -352,7 +353,7 @@ django-storages==1.14.6
     # via
     #   -r requirements/edx/kernel.in
     #   edxval
-django-user-tasks==3.4.2
+django-user-tasks==3.4.3
     # via -r requirements/edx/kernel.in
 django-waffle==5.0.0
     # via
@@ -367,9 +368,8 @@ django-webpack-loader==0.7.0
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   edx-proctoring
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
     #   django-config-models
     #   django-user-tasks
@@ -466,7 +466,7 @@ edx-drf-extensions==10.6.0
     #   edxval
     #   enterprise-integrated-channels
     #   openedx-learning
-edx-enterprise==6.2.15
+edx-enterprise==6.3.0
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -481,7 +481,7 @@ edx-i18n-tools==1.9.0
     #   xblocks-contrib
 edx-milestones==1.1.0
     # via -r requirements/edx/kernel.in
-edx-name-affirmation==3.0.1
+edx-name-affirmation==3.0.2
     # via -r requirements/edx/kernel.in
 edx-opaque-keys[django]==3.0.0
     # via
@@ -501,7 +501,7 @@ edx-opaque-keys[django]==3.0.0
     #   openedx-filters
     #   ora2
     #   xblocks-contrib
-edx-organizations==7.1.0
+edx-organizations==7.3.0
     # via -r requirements/edx/kernel.in
 edx-proctoring==5.2.0
     # via
@@ -560,7 +560,7 @@ enmerkar==0.7.1
     # via enmerkar-underscore
 enmerkar-underscore==2.4.0
     # via -r requirements/edx/kernel.in
-enterprise-integrated-channels==0.1.13
+enterprise-integrated-channels==0.1.14
     # via -r requirements/edx/bundled.in
 event-tracking==3.3.0
     # via
@@ -568,23 +568,23 @@ event-tracking==3.3.0
     #   edx-completion
     #   edx-proctoring
     #   edx-search
-fastavro==1.11.1
+fastavro==1.12.0
     # via openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via snowflake-connector-python
-firebase-admin==7.0.0
+firebase-admin==7.1.0
     # via edx-ace
 frozenlist==1.7.0
     # via
     #   aiohttp
     #   aiosignal
-fs==2.0.27
+fs==2.4.16
     # via
     #   -r requirements/edx/kernel.in
     #   fs-s3fs
     #   openedx-django-pyfs
     #   xblock
-fs-s3fs==0.1.8
+fs-s3fs==1.1.1
     # via
     #   -r requirements/edx/kernel.in
     #   openedx-django-pyfs
@@ -612,7 +612,7 @@ google-cloud-core==2.4.3
     #   google-cloud-storage
 google-cloud-firestore==2.21.0
     # via firebase-admin
-google-cloud-storage==3.2.0
+google-cloud-storage==3.3.0
     # via firebase-admin
 google-crc32c==1.7.1
     # via
@@ -634,7 +634,7 @@ gunicorn==23.0.0
     # via -r requirements/edx/kernel.in
 h11==0.16.0
     # via httpcore
-h2==4.2.0
+h2==4.3.0
     # via httpx
 help-tokens==3.2.0
     # via -r requirements/edx/kernel.in
@@ -666,6 +666,8 @@ inflection==0.5.1
     # via
     #   drf-spectacular
     #   drf-yasg
+invoke==2.2.0
+    # via paramiko
 ipaddress==1.0.23
     # via -r requirements/edx/kernel.in
 isodate==0.7.2
@@ -676,7 +678,7 @@ jmespath==1.0.1
     # via
     #   boto3
     #   botocore
-joblib==1.5.1
+joblib==1.5.2
     # via nltk
 jsondiff==2.2.1
 jsonfield==3.2.0
@@ -689,7 +691,7 @@ jsonfield==3.2.0
     #   enterprise-integrated-channels
     #   lti-consumer-xblock
     #   ora2
-jsonschema==4.25.0
+jsonschema==4.25.1
     # via
     #   drf-spectacular
     #   optimizely-sdk
@@ -710,7 +712,7 @@ lazy==1.6
     #   xblock
 loremipsum==1.0.5
     # via ora2
-lti-consumer-xblock==9.14.0
+lti-consumer-xblock==9.14.2
     # via -r requirements/edx/kernel.in
 lxml[html-clean,html_clean]==5.3.2
     # via
@@ -752,7 +754,7 @@ markupsafe==3.0.2
     #   xblock
 maxminddb==2.8.2
     # via geoip2
-meilisearch==0.36.0
+meilisearch==0.37.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-search
@@ -766,7 +768,7 @@ mpmath==1.3.0
     # via sympy
 msgpack==1.1.1
     # via cachecontrol
-multidict==6.6.3
+multidict==6.6.4
     # via
     #   aiohttp
     #   yarl
@@ -819,7 +821,7 @@ openedx-django-require==3.0.0
     # via -r requirements/edx/kernel.in
 openedx-django-wiki==3.1.1
     # via -r requirements/edx/kernel.in
-openedx-events==10.4.0
+openedx-events==10.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise
@@ -833,9 +835,9 @@ openedx-filters==2.1.0
     #   -r requirements/edx/kernel.in
     #   lti-consumer-xblock
     #   ora2
-openedx-forum==0.3.2
+openedx-forum==0.3.4
     # via -r requirements/edx/kernel.in
-openedx-learning==0.27.0
+openedx-learning==0.27.1
     # via
     #   -c requirements/edx/../constraints.txt
     #   -r requirements/edx/kernel.in
@@ -849,7 +851,7 @@ packaging==25.0
     #   gunicorn
     #   kombu
     #   snowflake-connector-python
-paramiko==3.5.1
+paramiko==4.0.0
 path==16.11.0
     # via
     #   -c requirements/edx/../constraints.txt
@@ -861,8 +863,6 @@ path-py==12.5.0
     #   edx-enterprise
     #   ora2
     #   staff-graded-xblock
-pbr==6.1.1
-    # via stevedore
 pgpy==0.6.0
 piexif==1.1.3
     # via -r requirements/edx/kernel.in
@@ -872,7 +872,7 @@ pillow==11.3.0
     #   edx-enterprise
     #   edx-organizations
     #   edxval
-platformdirs==4.3.8
+platformdirs==4.4.0
     # via snowflake-connector-python
 polib==1.2.0
     # via edx-i18n-tools
@@ -885,7 +885,7 @@ proto-plus==1.26.1
     # via
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.31.1
+protobuf==6.32.0
     # via
     #   google-api-core
     #   google-cloud-firestore
@@ -918,9 +918,7 @@ pydantic==2.11.7
 pydantic-core==2.33.2
     # via pydantic
 pyjwkest==1.4.2
-    # via
-    #   -r requirements/edx/kernel.in
-    #   lti-consumer-xblock
+    # via -r requirements/edx/kernel.in
 pyjwt[crypto]==2.10.1
     # via
     #   -r requirements/edx/kernel.in
@@ -994,7 +992,6 @@ python3-saml==1.16.0
 pytz==2025.2
     # via
     #   -r requirements/edx/kernel.in
-    #   djangorestframework
     #   drf-yasg
     #   edx-completion
     #   edx-enterprise
@@ -1003,7 +1000,6 @@ pytz==2025.2
     #   edx-tincan-py35
     #   enterprise-integrated-channels
     #   event-tracking
-    #   fs
     #   olxcleaner
     #   ora2
     #   snowflake-connector-python
@@ -1024,7 +1020,7 @@ random2==1.0.2
     # via -r requirements/edx/kernel.in
 recommender-xblock==3.1.0
     # via -r requirements/edx/bundled.in
-redis==6.2.0
+redis==6.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   walrus
@@ -1032,9 +1028,9 @@ referencing==0.36.2
     # via
     #   jsonschema
     #   jsonschema-specifications
-regex==2025.7.31
+regex==2025.7.34
     # via nltk
-requests==2.32.4
+requests==2.32.5
     # via
     #   analytics-python
     #   cachecontrol
@@ -1065,7 +1061,7 @@ requests-oauthlib==2.0.0
     # via
     #   -r requirements/edx/kernel.in
     #   social-auth-core
-rpds-py==0.26.0
+rpds-py==0.27.1
     # via
     #   jsonschema
     #   referencing
@@ -1120,7 +1116,7 @@ slumber==0.7.1
     #   enterprise-integrated-channels
 sniffio==1.3.1
     # via anyio
-snowflake-connector-python==3.16.0
+snowflake-connector-python==3.17.2
 social-auth-app-django==5.4.1
     # via
     #   -c requirements/edx/../constraints.txt
@@ -1140,13 +1136,13 @@ sortedcontainers==2.4.0
     # via
     #   -r requirements/edx/kernel.in
     #   snowflake-connector-python
-soupsieve==2.7
+soupsieve==2.8
     # via beautifulsoup4
 sqlparse==0.5.3
     # via django
 staff-graded-xblock==3.1.0
     # via -r requirements/edx/bundled.in
-stevedore==5.4.1
+stevedore==5.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   code-annotations
@@ -1171,7 +1167,7 @@ tqdm==4.67.1
     # via
     #   nltk
     #   openai
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
     #   aiosignal
     #   anyio
@@ -1239,7 +1235,7 @@ webob==1.8.9
     #   xblock
 wheel==0.45.1
     # via django-pipeline
-wrapt==1.17.2
+wrapt==1.17.3
     # via -r requirements/edx/kernel.in
 xblock[django]==5.2.0
     # via
@@ -1267,7 +1263,7 @@ xblock-utils==4.0.0
     # via
     #   edx-sga
     #   xblock-poll
-xblocks-contrib==0.5.0
+xblocks-contrib==0.6.0
     # via -r requirements/edx/bundled.in
 xmlsec==1.3.14
     # via

--- a/requirements/js_test.txt
+++ b/requirements/js_test.txt
@@ -32,7 +32,7 @@ jaraco-collections==5.2.1
     #   cherrypy
 jaraco-context==6.0.1
     # via jaraco-text
-jaraco-functools==4.2.1
+jaraco-functools==4.3.0
     # via
     #   -r requirements/js_test.in
     #   cheroot
@@ -69,7 +69,7 @@ python-dateutil==2.9.0.post0
     # via tempora
 pyyaml==6.0.2
     # via jasmine
-selenium==4.34.2
+selenium==4.35.0
     # via jasmine
 six==1.17.0
     # via python-dateutil

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -6,89 +6,89 @@
 #
 aiohappyeyeballs==2.6.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
 aiohttp==3.12.15
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openai
 aiosignal==1.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
 amqp==5.3.1
     # via kombu
 aniso8601==10.0.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-tincan-py35
-anyio==4.9.0
+anyio==4.10.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   httpx
 asgiref==3.9.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 attrs==25.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   edx-ace
     #   openedx-events
 bcrypt==4.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   paramiko
 billiard==4.2.1
     # via celery
 bleach==6.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-boto3==1.39.16
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
+boto3==1.40.20
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
-botocore==1.39.16
+botocore==1.40.20
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
 cachecontrol==0.14.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   firebase-admin
 cachetools==5.5.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-auth
 celery==5.5.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-certifi==2025.7.14
+    #   -c requirements/constraints.txt
+    #   -r requirements/base.in
+certifi==2025.8.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   httpcore
     #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   requests
     #   snowflake-connector-python
 click==8.2.1
@@ -103,19 +103,19 @@ click-didyoumean==0.3.1
     # via celery
 click-plugins==1.1.1.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   celery
 click-repl==0.3.0
     # via celery
 code-annotations==2.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-toggles
-cryptography==45.0.5
+cryptography==45.0.6
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -125,13 +125,13 @@ cryptography==45.0.5
     #   snowflake-connector-python
 defusedxml==0.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   djangorestframework-xml
 django==4.2.23
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/common_constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -140,6 +140,7 @@ django==4.2.23
     #   django-multi-email-field
     #   django-oauth-toolkit
     #   django-push-notifications
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -155,70 +156,69 @@ django==4.2.23
     #   openedx-events
 django-cache-memoize==0.2.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-config-models==2.9.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-countries==7.6.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-crum==0.7.9
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-filter==25.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-ipware==7.0.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-model-utils==5.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-rbac
 django-multi-email-field==0.8.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-oauth-toolkit==1.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-object-actions==5.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 django-push-notifications==3.2.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-ace
 django-simple-history==3.10.1
-    # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    # via -r requirements/base.in
 django-waffle==5.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
@@ -226,38 +226,38 @@ djangorestframework==3.14.0
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 dnspython==2.7.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-braze-client
 edx-api-doc-tools==2.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/test-master.in
 edx-braze-client==1.1.2
     # via -r requirements/test-master.in
 edx-ccx-keys==2.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openedx-events
 edx-django-utils==8.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   django-config-models
     #   edx-ace
     #   edx-braze-client
@@ -267,126 +267,126 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-drf-extensions==10.6.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-rbac
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==2.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 edx-rest-api-client==6.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 edx-tincan-py35==2.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 edx-toggles==5.4.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-fastavro==1.11.1
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
+fastavro==1.12.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
-firebase-admin==7.0.0
+firebase-admin==7.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-ace
 frozenlist==1.7.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   aiosignal
 google-api-core[grpc]==2.25.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-auth==2.40.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-core==2.4.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-firestore==2.21.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   firebase-admin
-google-cloud-storage==3.2.0
+google-cloud-storage==3.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   firebase-admin
 google-crc32c==1.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-cloud-storage
     #   google-resumable-media
 google-resumable-media==2.7.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-cloud-storage
 googleapis-common-protos==1.70.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-api-core
     #   grpcio-status
 grpcio==1.74.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-api-core
     #   grpcio-status
 grpcio-status==1.74.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-api-core
 h11==0.16.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   httpcore
-h2==4.2.0
+h2==4.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   httpx
 hpack==4.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   h2
 httpcore==1.0.9
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   httpx
 httpx[http2]==0.28.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   firebase-admin
 hyperframe==6.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   h2
 idna==3.10
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   anyio
     #   httpx
     #   requests
@@ -394,105 +394,105 @@ idna==3.10
     #   yarl
 inflection==0.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-yasg
+invoke==2.2.0
+    # via
+    #   -c requirements/edx-platform-constraints.txt
+    #   paramiko
 jinja2==3.1.6
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
 jmespath==1.0.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   boto3
     #   botocore
 jsondiff==2.2.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 jsonfield==3.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 jwcrypto==1.5.6
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-oauth-toolkit
 kombu==5.5.4
     # via celery
 markupsafe==3.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   jinja2
 msgpack==1.1.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   cachecontrol
-multidict==6.6.3
+multidict==6.6.4
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   yarl
 oauthlib==3.3.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-oauth-toolkit
 openai==0.28.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-openedx-events==10.4.0
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
+openedx-events==10.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 packaging==25.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-yasg
     #   kombu
     #   snowflake-connector-python
-paramiko==3.5.1
+paramiko==4.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 path==16.11.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   path-py
 path-py==12.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-pbr==6.1.1
-    # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   stevedore
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 pgpy==0.6.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 pillow==11.3.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-platformdirs==4.3.8
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
+platformdirs==4.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
-prompt-toolkit==3.0.51
+prompt-toolkit==3.0.52
     # via click-repl
 propcache==0.3.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
     #   yarl
 proto-plus==1.26.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.31.1
+protobuf==6.32.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
@@ -500,25 +500,25 @@ protobuf==6.31.1
     #   proto-plus
 psutil==7.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-django-utils
 pyasn1==0.6.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   pgpy
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-auth
 pycparser==2.22
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   cffi
 pyjwt[crypto]==2.10.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -526,50 +526,49 @@ pyjwt[crypto]==2.10.1
     #   snowflake-connector-python
 pymongo==4.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 python-dateutil==2.9.0.post0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   botocore
     #   celery
     #   edx-ace
 python-ipware==3.0.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
 pytz==2025.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
-    #   djangorestframework
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   code-annotations
     #   drf-yasg
     #   jsondiff
-requests==2.32.4
+requests==2.32.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   cachecontrol
     #   django-oauth-toolkit
     #   edx-braze-client
@@ -583,82 +582,82 @@ requests==2.32.4
     #   snowflake-connector-python
 rsa==4.9.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   google-auth
 rules==3.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 s3transfer==0.13.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   boto3
 sailthru-client==2.2.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-ace
 semantic-version==2.10.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   sailthru-client
 six==1.17.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   edx-ace
     #   edx-ccx-keys
     #   edx-rbac
     #   python-dateutil
 slumber==0.7.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 sniffio==1.3.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   anyio
-snowflake-connector-python==3.16.0
+snowflake-connector-python==3.17.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 sortedcontainers==2.4.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 sqlparse==0.5.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
     #   code-annotations
     #   edx-ace
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==9.1.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 text-unidecode==1.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   python-slugify
 tomlkit==0.13.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   snowflake-connector-python
 tqdm==4.67.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   openai
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiosignal
     #   anyio
     #   django-countries
@@ -668,19 +667,19 @@ typing-extensions==4.14.1
     #   snowflake-connector-python
 tzdata==2025.2
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   kombu
 unicodecsv==0.14.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/base.in
+    #   -c requirements/edx-platform-constraints.txt
+    #   -r requirements/base.in
 uritemplate==4.2.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   drf-yasg
 urllib3==2.5.0
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   botocore
     #   requests
 vine==5.1.0
@@ -690,15 +689,15 @@ vine==5.1.0
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   bleach
 yarl==1.20.1
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/edx-platform-constraints.txt
+    #   -c requirements/edx-platform-constraints.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -6,95 +6,95 @@
 #
 aiohappyeyeballs==2.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 aiohttp==3.12.15
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
 aiosignal==1.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   kombu
 aniso8601==10.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-tincan-py35
-anyio==4.9.0
+anyio==4.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpx
 asgiref==3.9.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
     #   django-countries
 asn1crypto==1.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 attrs==25.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   edx-ace
     #   openedx-events
     #   pytest
 bcrypt==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   paramiko
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 bleach==6.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-boto3==1.39.16
+    # via -r requirements/test-master.txt
+boto3==1.40.20
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
-botocore==1.39.16
+botocore==1.40.20
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   boto3
     #   s3transfer
     #   snowflake-connector-python
 cachecontrol==0.14.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
 cachetools==5.5.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-auth
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-certifi==2025.7.14
+    #   -c requirements/constraints.txt
+    #   -r requirements/test-master.txt
+certifi==2025.8.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpcore
     #   httpx
     #   requests
     #   snowflake-connector-python
 cffi==1.17.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cryptography
     #   pynacl
     #   snowflake-connector-python
 chardet==5.2.0
     # via diff-cover
-charset-normalizer==3.4.2
+charset-normalizer==3.4.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   requests
     #   snowflake-connector-python
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     #   click-didyoumean
     #   click-plugins
@@ -102,24 +102,24 @@ charset-normalizer==3.4.2
     #   code-annotations
     #   edx-django-utils
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 click-plugins==1.1.1.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 code-annotations==2.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-toggles
-coverage[toml]==7.10.3
+coverage[toml]==7.10.6
     # via pytest-cov
-cryptography==45.0.5
+cryptography==45.0.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-fernet-fields-v2
     #   jwcrypto
     #   paramiko
@@ -131,13 +131,13 @@ ddt==1.3.1
     # via -r requirements/test.in
 defusedxml==0.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   djangorestframework-xml
 diff-cover==9.6.0
     # via -r requirements/test.in
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/common_constraints.txt
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -c requirements/common_constraints.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   django-crum
     #   django-fernet-fields-v2
@@ -146,6 +146,7 @@ diff-cover==9.6.0
     #   django-multi-email-field
     #   django-oauth-toolkit
     #   django-push-notifications
+    #   django-simple-history
     #   django-waffle
     #   djangorestframework
     #   drf-jwt
@@ -160,84 +161,83 @@ diff-cover==9.6.0
     #   jsonfield
     #   openedx-events
 django-cache-memoize==0.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-config-models==2.9.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-countries==7.6.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-crum==0.7.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-rbac
     #   edx-toggles
 django-fernet-fields-v2==0.9
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-filter==25.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-ipware==7.0.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-model-utils==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   -r requirements/test.in
     #   edx-rbac
 django-multi-email-field==0.8.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-oauth-toolkit==1.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-object-actions==5.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-push-notifications==3.2.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
 django-simple-history==3.10.1
-    # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 django-waffle==5.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   edx-drf-extensions
     #   edx-toggles
-djangorestframework==3.14.0
+djangorestframework==3.16.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   drf-jwt
     #   drf-yasg
     #   edx-api-doc-tools
     #   edx-drf-extensions
 djangorestframework-xml==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 dnspython==2.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pymongo
 drf-jwt==1.19.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 drf-yasg==1.21.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-api-doc-tools
 edx-ace==1.15.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-braze-client
 edx-api-doc-tools==2.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-braze-client==1.1.2
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-ccx-keys==2.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
 edx-django-utils==8.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-config-models
     #   edx-ace
     #   edx-braze-client
@@ -247,126 +247,126 @@ edx-django-utils==8.0.0
     #   openedx-events
 edx-drf-extensions==10.6.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-rbac
 edx-opaque-keys[django]==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ccx-keys
     #   edx-drf-extensions
     #   openedx-events
 edx-rbac==2.1.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-rest-api-client==6.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-tincan-py35==2.0.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 edx-toggles==5.4.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 factory-boy==3.3.3
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
-faker==37.5.3
+faker==37.6.0
     # via factory-boy
-fastavro==1.11.1
+fastavro==1.12.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openedx-events
-filelock==3.18.0
+filelock==3.19.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
-firebase-admin==7.0.0
+firebase-admin==7.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
 freezegun==0.3.14
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 frozenlist==1.7.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   aiosignal
 google-api-core[grpc]==2.25.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-auth==2.40.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   google-cloud-core
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-core==2.4.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-cloud-firestore
     #   google-cloud-storage
 google-cloud-firestore==2.21.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
-google-cloud-storage==3.2.0
+google-cloud-storage==3.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
 google-crc32c==1.7.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-cloud-storage
     #   google-resumable-media
 google-resumable-media==2.7.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-cloud-storage
 googleapis-common-protos==1.70.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   grpcio-status
 grpcio==1.74.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   grpcio-status
 grpcio-status==1.74.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
 h11==0.16.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpcore
-h2==4.2.0
+h2==4.3.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpx
 hpack==4.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   h2
 httpcore==1.0.9
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   httpx
 httpx[http2]==0.28.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   firebase-admin
 hyperframe==6.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   h2
 idna==3.10
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   anyio
     #   httpx
     #   requests
@@ -374,82 +374,82 @@ idna==3.10
     #   yarl
 inflection==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 iniconfig==2.1.0
     # via pytest
+invoke==2.2.0
+    # via
+    #   -r requirements/test-master.txt
+    #   paramiko
 jinja2==3.1.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   diff-cover
 jmespath==1.0.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   boto3
     #   botocore
 jsondiff==2.2.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jsonfield==3.2.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 jwcrypto==1.5.6
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   celery
 markupsafe==3.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   jinja2
 mock==3.0.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 msgpack==1.1.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cachecontrol
-multidict==6.6.3
+multidict==6.6.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 oauthlib==3.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-oauth-toolkit
 openai==0.28.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-openedx-events==10.4.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
+openedx-events==10.5.0
+    # via -r requirements/test-master.txt
 packaging==25.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
     #   kombu
     #   pytest
     #   snowflake-connector-python
-paramiko==3.5.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+paramiko==4.0.0
+    # via -r requirements/test-master.txt
 path==16.11.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   path-py
 path-py==12.5.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-pbr==6.1.1
-    # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   stevedore
+    # via -r requirements/test-master.txt
 pgpy==0.6.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 pillow==11.3.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-platformdirs==4.3.8
+    # via -r requirements/test-master.txt
+platformdirs==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pluggy==1.6.0
     # via
@@ -457,21 +457,21 @@ pluggy==1.6.0
     #   pytest
     #   pytest-cov
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   click-repl
 propcache==0.3.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
     #   yarl
 proto-plus==1.26.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   google-cloud-firestore
-protobuf==6.31.1
+protobuf==6.32.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-api-core
     #   google-cloud-firestore
     #   googleapis-common-protos
@@ -479,29 +479,29 @@ protobuf==6.31.1
     #   proto-plus
 psutil==7.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
 py==1.11.0
     # via pytest
 pyasn1==0.6.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   pgpy
     #   pyasn1-modules
     #   rsa
 pyasn1-modules==0.4.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-auth
 pycparser==2.22
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cffi
 pygments==2.19.2
     # via diff-cover
 pyjwt[crypto]==2.10.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-jwt
     #   edx-drf-extensions
     #   edx-rest-api-client
@@ -509,20 +509,20 @@ pyjwt[crypto]==2.10.1
     #   snowflake-connector-python
 pymongo==4.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-opaque-keys
 pynacl==1.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-django-utils
     #   paramiko
 pyopenssl==25.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 pytest==6.2.5
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   pytest-cov
     #   pytest-django
 pytest-cov==6.2.1
@@ -531,35 +531,34 @@ pytest-django==4.5.2
     # via -r requirements/test.in
 python-dateutil==2.9.0.post0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   botocore
     #   celery
     #   edx-ace
     #   freezegun
 python-ipware==3.0.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django-ipware
 python-slugify==8.0.4
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
 pytz==2025.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
-    #   djangorestframework
+    #   -r requirements/test-master.txt
     #   drf-yasg
     #   edx-tincan-py35
     #   snowflake-connector-python
 pyyaml==6.0.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   drf-yasg
     #   jsondiff
-requests==2.32.4
+requests==2.32.5
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   cachecontrol
     #   django-oauth-toolkit
     #   edx-braze-client
@@ -574,33 +573,33 @@ requests==2.32.4
     #   snowflake-connector-python
 responses==0.10.15
     # via
-    #   -c /home/runner/work/edx-enterprise/edx-enterprise/requirements/constraints.txt
+    #   -c requirements/constraints.txt
     #   -r requirements/test.in
 rsa==4.9.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   google-auth
 rules==3.5
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 s3transfer==0.13.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   boto3
 sailthru-client==2.2.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
 semantic-version==2.10.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-drf-extensions
 simplejson==3.20.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   sailthru-client
 six==1.17.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   edx-ace
     #   edx-ccx-keys
     #   edx-rbac
@@ -609,49 +608,49 @@ six==1.17.0
     #   python-dateutil
     #   responses
 slumber==0.7.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 sniffio==1.3.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   anyio
-snowflake-connector-python==3.16.0
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+snowflake-connector-python==3.17.2
+    # via -r requirements/test-master.txt
 sortedcontainers==2.4.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 sqlparse==0.5.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   django
-stevedore==5.4.1
+stevedore==5.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   code-annotations
     #   edx-ace
     #   edx-django-utils
     #   edx-opaque-keys
 testfixtures==9.1.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   -r requirements/test.in
 text-unidecode==1.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   python-slugify
 toml==0.10.2
     # via pytest
 tomlkit==0.13.3
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   snowflake-connector-python
 tqdm==4.67.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   openai
-typing-extensions==4.14.1
+typing-extensions==4.15.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiosignal
     #   anyio
     #   django-countries
@@ -661,36 +660,36 @@ typing-extensions==4.14.1
     #   snowflake-connector-python
 tzdata==2025.2
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   faker
     #   kombu
 unicodecsv==0.14.1
-    # via -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    # via -r requirements/test-master.txt
 uritemplate==4.2.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   drf-yasg
 urllib3==2.5.0
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   botocore
     #   requests
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   amqp
     #   celery
     #   kombu
 wcwidth==0.2.13
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   prompt-toolkit
 webencodings==0.5.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   bleach
 yarl==1.20.1
     # via
-    #   -r /home/runner/work/edx-enterprise/edx-enterprise/requirements/test-master.txt
+    #   -r requirements/test-master.txt
     #   aiohttp
 
 # The following packages are considered to be unsafe in a requirements file:

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -54,7 +54,7 @@ class TestUserFilterBackend(APITest):
         assert len(data['results']) == expected_data_length
 
     @ddt.data(
-        (False, False, {'detail': 'Not found.'}),
+        (False, False, {'detail': 'No EnterpriseCustomer matches the given query.'}),
         (False, True, {'uuid': FAKE_UUIDS[0], 'active': True}),
         (True, False, {'uuid': FAKE_UUIDS[0], 'active': True}),
         (True, True, {'uuid': FAKE_UUIDS[0], 'active': True}),

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -2876,7 +2876,7 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
         {
             'is_staff': False,
             'is_linked_to_enterprise': False,
-            'expected_result': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'No EnterpriseCustomerCatalog matches the given query.'},
         },
         {
             'is_staff': False,
@@ -3324,50 +3324,92 @@ class TestEnterpriseCustomerCatalogs(BaseTestEnterpriseAPIViews):
         assert response == expected_result
 
     @ddt.data(
-        (False, False, False, False, {}, {'detail': 'Not found.'}),
-        (False, True, False, False, {'detail': 'Not found.'}, {'detail': 'Not found.'}),
-        (False, True, True, False, {'detail': 'Not found.'}, {'detail': 'Not found.'}),
-        (
-            False,
-            True,
-            True,
-            True,
-            fake_catalog_api.FAKE_PROGRAM_RESPONSE1,
-            update_program_with_enterprise_context(
+        {
+            'is_staff': False,
+            'is_linked_to_enterprise': False,
+            'has_existing_catalog': False,
+            'is_program_in_catalog': False,
+            'mocked_program': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'No EnterpriseCustomerCatalog matches the given query.'},
+        },
+        {
+            'is_staff': False,
+            'is_linked_to_enterprise': True,
+            'has_existing_catalog': False,
+            'is_program_in_catalog': False,
+            'mocked_program': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'No EnterpriseCustomerCatalog matches the given query.'},
+        },
+        {
+            'is_staff': False,
+            'is_linked_to_enterprise': True,
+            'has_existing_catalog': True,
+            'is_program_in_catalog': False,
+            'mocked_program': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'Not found.'},
+        },
+        {
+            'is_staff': False,
+            'is_linked_to_enterprise': True,
+            'has_existing_catalog': True,
+            'is_program_in_catalog': True,
+            'mocked_program': fake_catalog_api.FAKE_PROGRAM_RESPONSE1,
+            'expected_result': update_program_with_enterprise_context(
                 fake_catalog_api.FAKE_PROGRAM_RESPONSE1,
                 add_utm_info=True,
                 enterprise_catalog_uuid=FAKE_UUIDS[1]
             ),
-        ),
-        (True, False, False, False, {}, {'detail': 'Not found.'}),
-        (True, True, False, False, {'detail': 'Not found.'}, {'detail': 'Not found.'}),
-        (True, True, True, False, {'detail': 'Not found.'}, {'detail': 'Not found.'}),
-        (
-            True,
-            True,
-            True,
-            True,
-            fake_catalog_api.FAKE_PROGRAM_RESPONSE1,
-            update_program_with_enterprise_context(
+        },
+        {
+            'is_staff': True,
+            'is_linked_to_enterprise': False,
+            'has_existing_catalog': False,
+            'is_program_in_catalog': False,
+            'mocked_program': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'No EnterpriseCustomerCatalog matches the given query.'},
+        },
+        {
+            'is_staff': True,
+            'is_linked_to_enterprise': True,
+            'has_existing_catalog': False,
+            'is_program_in_catalog': False,
+            'mocked_program': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'No EnterpriseCustomerCatalog matches the given query.'},
+        },
+        {
+            'is_staff': True,
+            'is_linked_to_enterprise': True,
+            'has_existing_catalog': True,
+            'is_program_in_catalog': False,
+            'mocked_program': {'detail': 'Not found.'},
+            'expected_result': {'detail': 'Not found.'},
+        },
+        {
+            'is_staff': True,
+            'is_linked_to_enterprise': True,
+            'has_existing_catalog': True,
+            'is_program_in_catalog': True,
+            'mocked_program': fake_catalog_api.FAKE_PROGRAM_RESPONSE1,
+            'expected_result': update_program_with_enterprise_context(
                 fake_catalog_api.FAKE_PROGRAM_RESPONSE1,
                 add_utm_info=True,
                 enterprise_catalog_uuid=FAKE_UUIDS[1]
             ),
-        ),
+        },
     )
     @ddt.unpack
     @mock.patch('enterprise.models.EnterpriseCatalogApiClient')
     @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
     def test_enterprise_catalog_program_detail(
             self,
+            mock_catalog_api_client,
+            mock_ent_catalog_api_client,
             is_staff,
             is_linked_to_enterprise,
             has_existing_catalog,
             is_program_in_catalog,
             mocked_program,
             expected_result,
-            mock_catalog_api_client,
-            mock_ent_catalog_api_client
     ):
         """
         The ``programs`` detail endpoint should return correct results from course discovery,

--- a/tests/test_enterprise_learner_portal/api/test_views.py
+++ b/tests/test_enterprise_learner_portal/api/test_views.py
@@ -185,7 +185,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
             )
         )
         assert resp.status_code == 404
-        assert resp.json() == {'detail': 'Not found.'}
+        assert resp.json() == {'detail': 'No EnterpriseCustomerUser matches the given query.'}
 
     @mock.patch('enterprise_learner_portal.api.v1.views.get_resume_urls_for_course_enrollments')
     @mock.patch('enterprise_learner_portal.api.v1.serializers.get_certificate_for_user', mock.MagicMock())
@@ -358,7 +358,7 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
             )
         )
         assert resp.status_code == 404
-        assert resp.json() == {'detail': 'Not found.'}
+        assert resp.json() == {'detail': 'No EnterpriseCustomerUser matches the given query.'}
 
     @mock.patch('enterprise_learner_portal.api.v1.views.EnterpriseCourseEnrollmentSerializer')
     @mock.patch('enterprise_learner_portal.api.v1.views.get_course_overviews')
@@ -382,4 +382,4 @@ class TestEnterpriseCourseEnrollmentView(TestCase):
             )
         )
         assert resp.status_code == 404
-        assert resp.json() == {'detail': 'Not found.'}
+        assert resp.json() == {'detail': 'No EnterpriseCourseEnrollment matches the given query.'}


### PR DESCRIPTION
Background:
---

About two weeks ago edx-platform upgraded DRF from 3.14->3.16.1 and enterprise team started noticing the `POST /api/v1/pending-enterprise-learner` endpoint stopped being idempotent. It would return 400 errors instead of 204 No Content on duplicate requests.

Root Cause:
---

DRF 3.15 introduced a feature to automatically add uniqueness validators to a model serializer if any are found on the underlying model. While this feature is nice, it broke assumptions in the logic for many of our serializers.

Solution:
---
Disable the new feature for affected model serializers by overriding the `Meta.validators` attribute.

ENT-10865