### PR TITLE
feat: add GradeEventContextEnricher pipeline step for grade analytics

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * nothing unreleased
 
+[8.0.13] - 2026-05-14
+---------------------
+* feat: add GradeEventContextEnricher pipeline step for grade analytics (ENT-11563)
+
 [8.0.12] - 2026-05-13
 ---------------------
 * fix: dashboard filter step now fetches the live request via crum instead of expecting it in the filter context (ENT-11569)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.12"
+__version__ = "8.0.13"

--- a/enterprise/filters/__init__.py
+++ b/enterprise/filters/__init__.py
@@ -1,0 +1,3 @@
+"""
+Filter pipeline step implementations for edx-enterprise openedx-filters integrations.
+"""

--- a/enterprise/filters/grades.py
+++ b/enterprise/filters/grades.py
@@ -2,11 +2,14 @@
 Pipeline step for enriching grade analytics event context.
 """
 import copy
+import logging
 from typing import Any
 
 from openedx_filters.filters import PipelineStep
 
 from enterprise.models import EnterpriseCourseEnrollment
+
+log = logging.getLogger(__name__)
 
 
 class GradeEventContextEnricher(PipelineStep):
@@ -39,6 +42,11 @@ class GradeEventContextEnricher(PipelineStep):
                     "course_id": <unchanged>,
                 }
         """
+        log.info(
+            "GradeEventContextEnricher running: user_id=%s, course_id=%s",
+            str(user_id),
+            str(course_id),
+        )
         uuids = EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course(user_id, course_id)
         if uuids:
             context = copy.deepcopy(context)  # create a copy to avoid altering the passed-in value.

--- a/enterprise/filters/grades.py
+++ b/enterprise/filters/grades.py
@@ -1,0 +1,47 @@
+"""
+Pipeline step for enriching grade analytics event context.
+"""
+import copy
+from typing import Any
+
+from openedx_filters.filters import PipelineStep
+
+from enterprise.models import EnterpriseCourseEnrollment
+
+
+class GradeEventContextEnricher(PipelineStep):
+    """
+    Enriches a grade analytics event context dict with the learner's enterprise UUID.
+
+    This step is intended to be registered as a pipeline step for the
+    ``org.openedx.learning.grade.context.requested.v1`` filter.
+
+    If the user is enrolled in the given course through an enterprise, the enterprise
+    UUID is added to the context under the key ``"enterprise_uuid"``. If the user has
+    no enterprise course enrollment, the context is returned unchanged.
+    """
+
+    def run_filter(self, context: dict, user_id: int, course_id: str) -> dict[str, Any]:  # pylint: disable=arguments-differ
+        """
+        Add enterprise UUID to the event context if the user has an enterprise enrollment.
+
+        Arguments:
+            context (dict): the event tracking context dict.
+            user_id (int): the ID of the user whose grade event is being emitted.
+            course_id (str): the course key for the grade event.
+
+        Returns:
+            dict: updated pipeline data with the enriched ``context`` dict::
+
+                {
+                    "context": <enriched context>,
+                    "user_id": <unchanged>,
+                    "course_id": <unchanged>,
+                }
+        """
+        uuids = EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course(user_id, course_id)
+        if uuids:
+            context = copy.deepcopy(context)  # create a copy to avoid altering the passed-in value.
+            # Warning: Selecting the first element is not likely deterministic!
+            context["enterprise_uuid"] = str(uuids[0])
+        return {"context": context, "user_id": user_id, "course_id": course_id}

--- a/tests/filters/__init__.py
+++ b/tests/filters/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for enterprise filter pipeline steps."""

--- a/tests/filters/test_grades.py
+++ b/tests/filters/test_grades.py
@@ -1,0 +1,73 @@
+"""
+Tests for enterprise.filters.grades pipeline step.
+"""
+import uuid
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from enterprise.filters.grades import GradeEventContextEnricher
+
+
+class TestGradeEventContextEnricher(TestCase):
+    """
+    Tests for GradeEventContextEnricher pipeline step.
+    """
+
+    def _make_step(self):
+        return GradeEventContextEnricher(
+            filter_type="org.openedx.learning.grade.context.requested.v1",
+            running_pipeline=[],
+        )
+
+    @patch("enterprise.models.EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course")
+    def test_enriches_context_when_enterprise_enrollment_found(self, mock_get_uuids):
+        """
+        When an enterprise course enrollment exists, enterprise_uuid is added to context.
+        """
+        enterprise_uuid = uuid.uuid4()
+        mock_get_uuids.return_value = [enterprise_uuid]
+
+        step = self._make_step()
+        context = {"org": "TestOrg", "course_id": "course-v1:org+course+run"}
+        result = step.run_filter(context=context, user_id=7, course_id="course-v1:org+course+run")
+
+        assert result == {
+            "context": {**context, "enterprise_uuid": str(enterprise_uuid)},
+            "user_id": 7,
+            "course_id": "course-v1:org+course+run",
+        }
+        mock_get_uuids.assert_called_once_with(7, "course-v1:org+course+run")
+
+    @patch("enterprise.models.EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course")
+    def test_returns_unchanged_context_when_no_enterprise_enrollment(self, mock_get_uuids):
+        """
+        When no enterprise course enrollment exists, context is returned unchanged.
+        """
+        mock_get_uuids.return_value = []
+
+        step = self._make_step()
+        context = {"org": "TestOrg"}
+        result = step.run_filter(context=context, user_id=99, course_id="course-v1:org+course+run")
+
+        assert result == {
+            "context": context,
+            "user_id": 99,
+            "course_id": "course-v1:org+course+run",
+        }
+        assert "enterprise_uuid" not in result["context"]
+
+    @patch("enterprise.models.EnterpriseCourseEnrollment.get_enterprise_uuids_with_user_and_course")
+    def test_uses_first_uuid_when_multiple_enrollments(self, mock_get_uuids):
+        """
+        When multiple enterprise enrollments exist, only the first UUID is used.
+        """
+        first_uuid = uuid.uuid4()
+        second_uuid = uuid.uuid4()
+        mock_get_uuids.return_value = [first_uuid, second_uuid]
+
+        step = self._make_step()
+        context = {}
+        result = step.run_filter(context=context, user_id=1, course_id="course-v1:x+y+z")
+
+        assert result["context"]["enterprise_uuid"] == str(first_uuid)


### PR DESCRIPTION
Introduces enterprise/filters/grades.py with GradeEventContextEnricher, a PipelineStep for the org.openedx.learning.grade.context.requested.v1 filter that enriches grade analytics event context with the learner's enterprise UUID. Adds openedx-filters as a dependency and unit tests covering both enrichment and no-op branches.

ENT-11563

You can see it enriching the payload with the enterprise uuid correctly when fired directly 
<img width="1007" height="243" alt="Screenshot 2026-05-18 at 8 29 18 PM" src="https://github.com/user-attachments/assets/7c539256-6d5f-498c-97d0-149438119f78" />

And in the COURSE_GRADE_PASSED_FIRST_TIME event sender also has the enterprise uuid information 
<img width="1045" height="199" alt="Screenshot 2026-05-18 at 8 31 56 PM" src="https://github.com/user-attachments/assets/b42a36a9-aa91-4d7d-ac14-fc1acd67b08d" />

Also tested with a user that doesn't have any enterprise associations, just prints enterprise uuid empty 
<img width="1042" height="85" alt="Screenshot 2026-05-18 at 8 33 45 PM" src="https://github.com/user-attachments/assets/f1a9e19d-073a-4eda-9bdf-5827e21a6a81" />

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

---

Blocked by:
* https://github.com/openedx/openedx-filters/pull/333

Blocks:
* https://github.com/openedx/openedx-platform/pull/38097