### PR TITLE
feat: add several courseware access related pipeline steps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.1.0] - 2026-06-17
+---------------------
+* feat: add courseware-access pipeline steps
+
 [8.0.19] - 2026-06-16
 ---------------------
 * feat: Add the ``enable_credit_and_industry_pathways`` field for EnterpriseCustomer

--- a/consent/filters/__init__.py
+++ b/consent/filters/__init__.py
@@ -1,0 +1,1 @@
+"""Pipeline steps registered against openedx-filters by the Consent app."""

--- a/consent/filters/courseware.py
+++ b/consent/filters/courseware.py
@@ -1,0 +1,105 @@
+"""
+Pipeline steps for courseware filters, contributed by the Consent app.
+
+DataSharingConsentRedirectStep and DataSharingConsentCourseAccessStep both enforce the
+same consent requirement but are registered against different platform hooks that fire
+at different points in the courseware experience. The two hooks may sometimes run in
+the same request, but not always — so both registrations are necessary to ensure
+consent is enforced across all entry points.
+"""
+import logging
+from typing import Any
+
+from crum import get_current_request
+from opaque_keys.edx.keys import CourseKey
+from openedx_filters.filters import PipelineStep
+from openedx_filters.learning.filters import CoursewareAccessChecksRequested, CoursewareViewStarted
+
+from consent.helpers import get_enterprise_consent_url
+
+log = logging.getLogger(__name__)
+
+
+class DataSharingConsentRedirectStep(PipelineStep):
+    """
+    Redirects the user to the consent page when data sharing consent is required.
+
+    Registered against ``org.openedx.learning.courseware.view.started.v1``.
+    Raises ``CoursewareViewStarted.RedirectToUrl`` to redirect when consent is needed.
+    If consent is not required, the step is a no-op.
+    """
+
+    def run_filter(self, course_key: CourseKey, view_name: str) -> dict:  # pylint: disable=arguments-differ
+        request = get_current_request()
+        log.info(
+            "DataSharingConsentRedirectStep running: course_key=%s, view_name=%s, user_id=%s",
+            course_key,
+            view_name,
+            request.user.id if request else None,
+        )
+        if request is None:
+            return {"course_key": course_key, "view_name": view_name}
+        consent_url = get_enterprise_consent_url(
+            request=request,
+            course_id=str(course_key),
+            # An enrollment is assumed to exist if a courseware view has started, so just hard-code the value here.
+            enrollment_exists=True,
+            # `source` is tracked in consent DB records so we can audit which view initiated the consent redirect.
+            source=view_name,
+            # Omitted kwargs:
+            # - user: Defaults to request.user, which matches original decorator behavior.
+            # - return_to: Defaults to request.path, which should already be the courseware view.
+        )
+        # Redirect to the consent page if consent is required.
+        if consent_url:
+            raise CoursewareViewStarted.RedirectToUrl(
+                message="Data sharing consent required",
+                redirect_to=consent_url,
+            )
+        # No consent required — pass through.
+        return {"course_key": course_key, "view_name": view_name}
+
+
+class DataSharingConsentCourseAccessStep(PipelineStep):
+    """
+    Deny courseware access when data sharing consent is required but not granted.
+
+    Registered against ``org.openedx.learning.courseware.access_checks.requested.v1``.
+    Raises ``CoursewareAccessChecksRequested.PreventCoursewareAccess`` to deny
+    access when ``get_enterprise_consent_url`` returns a URL.
+    """
+
+    def run_filter(self, user: Any, course_key: CourseKey) -> dict:  # pylint: disable=arguments-differ
+        log.info(
+            "DataSharingConsentCourseAccessStep running: user_id=%s, course_key=%s",
+            user.id,
+            course_key,
+        )
+        request = get_current_request()
+        if request is None:
+            return {"user": user, "course_key": course_key}
+        consent_url = get_enterprise_consent_url(
+            request=request,
+            course_id=str(course_key),
+            # We must pass the given user even though the request already has a user attached. They could differ.
+            user=user,
+            # This is always True since the step only runs in course access checks that require an existing enrollment.
+            enrollment_exists=True,
+            # After granting consent, make sure to redirect to the courseware view regardless of where they came from.
+            return_to="courseware",
+            # Identify as originating from the access check context.
+            source="CoursewareAccess",
+        )
+        # Deny courseware access if consent is required.
+        if consent_url:
+            raise CoursewareAccessChecksRequested.PreventCoursewareAccess(
+                message="Data sharing consent required",
+                error_code="data_sharing_access_required",
+                # developer_message carries the consent redirect URL by convention: the Learning MFE treats this message
+                # as a URL when error_code is "data_sharing_access_required" and performs a client-side redirect.
+                # See frontend-app-learning/src/shared/access.js.
+                developer_message=consent_url,
+                user_message="You must give Data Sharing Consent for the course",
+            )
+        # No consent required — pass through.
+        return {"user": user, "course_key": course_key}

--- a/consent/helpers.py
+++ b/consent/helpers.py
@@ -2,11 +2,162 @@
 Helper functions for the Consent application.
 """
 
+import logging
+from urllib.parse import urlencode
+
+from edx_django_utils.cache import TieredCache
+
 from django.apps import apps
+from django.conf import settings
+from django.contrib.sites.models import Site
+from django.urls import reverse
 
 from consent.models import ProxyDataSharingConsent
 from enterprise.api_client.discovery import get_course_catalog_api_service_client
-from enterprise.utils import get_enterprise_customer
+from enterprise.utils import get_active_enterprise_customer_user, get_enterprise_customer
+
+# ENT-11576: CONSENT_FAILED_PARAMETER, ConsentApiClient, enterprise_customer_uuid_for_request,
+# and get_data_consent_share_cache_key will be migrated from the platform's enterprise_support
+# module into edx-enterprise, eliminating these cross-boundary imports.
+try:
+    from openedx.features.enterprise_support.api import (
+        CONSENT_FAILED_PARAMETER,
+        ConsentApiClient,
+        enterprise_customer_uuid_for_request,
+    )
+    from openedx.features.enterprise_support.utils import get_data_consent_share_cache_key
+except ImportError:
+    CONSENT_FAILED_PARAMETER = 'consent_failed'
+    ConsentApiClient = None
+    enterprise_customer_uuid_for_request = None
+    get_data_consent_share_cache_key = None
+
+LOGGER = logging.getLogger(__name__)
+
+
+def consent_needed_for_course(request, user, course_id, enrollment_exists=False):
+    """
+    Determine whether ``user`` must grant data-sharing consent before accessing ``course_id``.
+    """
+    # Consent is never required if the enterprise feature is disabled.
+    if not getattr(settings, 'ENABLE_ENTERPRISE_INTEGRATION', False):
+        return False
+
+    LOGGER.info(
+        "[ENTERPRISE DSC] Determining if user [%s] must consent to data sharing for course [%s]",
+        user.username, course_id,
+    )
+
+    active_enterprise_learner_info = get_active_enterprise_customer_user(user)
+    if not active_enterprise_learner_info:
+        LOGGER.info(
+            "[ENTERPRISE DSC] Consent from user [%s] is not needed for course [%s]. "
+            "The user is not linked to an enterprise.",
+            user.username, course_id,
+        )
+        return False
+
+    active_enterprise_customer = active_enterprise_learner_info.enterprise_customer
+
+    consent_cache_key = get_data_consent_share_cache_key(
+        user.id, course_id, str(active_enterprise_customer.uuid),
+    )
+    cached = TieredCache.get_cached_response(consent_cache_key)
+    if cached.is_found and cached.value == 0:
+        LOGGER.info(
+            "[ENTERPRISE DSC] Consent from user [%s] is not needed for course [%s]. "
+            "The DSC cache was checked and the value was 0.",
+            user.username, course_id,
+        )
+        return False
+
+    if not active_enterprise_customer.enable_data_sharing_consent:
+        LOGGER.info(
+            "[ENTERPRISE DSC] DSC is disabled for enterprise customer [%s]. "
+            "Consent from user [%s] is not needed for course [%s]",
+            active_enterprise_customer.slug, user.username, course_id,
+        )
+        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
+        return False
+
+    current_enterprise_uuid = enterprise_customer_uuid_for_request(request)
+    if str(current_enterprise_uuid) != str(active_enterprise_customer.uuid):
+        LOGGER.info(
+            '[ENTERPRISE DSC] Enterprise mismatch. USER: [%s], RequestEnterprise: [%s], '
+            'LearnerEnterprise: [%s]',
+            user.username, current_enterprise_uuid, active_enterprise_customer.uuid,
+        )
+        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
+        return False
+
+    enterprise_domain = Site.objects.get(domain=active_enterprise_customer.site.domain)
+    if enterprise_domain != request.site:
+        LOGGER.info(
+            '[ENTERPRISE DSC] Site mismatch. USER: [%s], RequestSite: [%s], '
+            'LearnerEnterpriseDomain: [%s]',
+            user.username, request.site, enterprise_domain,
+        )
+        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
+        return False
+
+    client = ConsentApiClient(user=request.user)
+    consent_required = client.consent_required(
+        username=user.username,
+        course_id=course_id,
+        enterprise_customer_uuid=current_enterprise_uuid,
+        enrollment_exists=enrollment_exists,
+    )
+    if not consent_required:
+        LOGGER.info(
+            "[ENTERPRISE DSC] Consent from user [%s] is not needed for course [%s]. "
+            "The user's current enterprise does not require data sharing consent.",
+            user.username, course_id,
+        )
+        TieredCache.set_all_tiers(consent_cache_key, 0, settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT)
+        return False
+
+    LOGGER.info(
+        "[ENTERPRISE DSC] Consent from user [%s] is needed for course [%s]. "
+        "The user's current enterprise requires data sharing consent, and it has not been given.",
+        user.username, course_id,
+    )
+    return True
+
+
+def get_enterprise_consent_url(request, course_id, user=None, return_to=None, enrollment_exists=False, source='lms'):
+    """
+    Build a URL to redirect the user to the data-sharing consent page for a specific course.
+
+    Arguments:
+        request: Django request object.
+        course_id: Course key/identifier string.
+        user: user to check for consent. If None, uses ``request.user``.
+        return_to: url name for the page to return to after consent is granted; defaults to
+            ``request.path``.
+        enrollment_exists: forwarded to ``consent_needed_for_course``.
+        source: opaque string identifying the caller, recorded on the consent URL.
+    """
+    user = user or request.user
+    LOGGER.info(
+        'Getting enterprise consent url for user [%s] and course [%s].',
+        user.username,
+        course_id,
+    )
+    if not consent_needed_for_course(request, user, course_id, enrollment_exists=enrollment_exists):
+        return None
+    return_path = request.path if return_to is None else reverse(return_to, args=(course_id,))
+    url_params = {
+        'enterprise_customer_uuid': enterprise_customer_uuid_for_request(request),
+        'course_id': course_id,
+        'source': source,
+        'next': request.build_absolute_uri(return_path),
+        'failure_url': request.build_absolute_uri(
+            reverse('dashboard') + '?' + urlencode({CONSENT_FAILED_PARAMETER: course_id})
+        ),
+    }
+    full_url = reverse('grant_data_sharing_permissions') + '?' + urlencode(url_params)
+    LOGGER.info('Redirecting to %s to complete data sharing consent', full_url)
+    return full_url
 
 
 def get_data_sharing_consent(username, enterprise_customer_uuid, course_id=None, program_uuid=None):

--- a/consent/settings/common.py
+++ b/consent/settings/common.py
@@ -6,7 +6,16 @@ Common plugin settings for the consent app.
 # enterprise plugin's settings module.
 from enterprise.settings.common import FiltersConfig, _merge_filters_config
 
-CONSENT_FILTERS_CONFIG: FiltersConfig = {}
+CONSENT_FILTERS_CONFIG: FiltersConfig = {
+    "org.openedx.learning.courseware.view.started.v1": {
+        "fail_silently": False,
+        "pipeline": ["consent.filters.courseware.DataSharingConsentRedirectStep"],
+    },
+    "org.openedx.learning.courseware.access_checks.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["consent.filters.courseware.DataSharingConsentCourseAccessStep"],
+    },
+}
 
 
 def plugin_settings(settings):
@@ -30,3 +39,5 @@ def plugin_settings(settings):
         filters_config = {}
         settings.OPEN_EDX_FILTERS_CONFIG = filters_config
     _merge_filters_config(filters_config, CONSENT_FILTERS_CONFIG)
+
+    settings.DATA_CONSENT_SHARE_CACHE_TIMEOUT = 8 * 60 * 60  # 8 hours

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.19"
+__version__ = "8.1.0"

--- a/enterprise/filters/courseware.py
+++ b/enterprise/filters/courseware.py
@@ -1,0 +1,110 @@
+"""
+Pipeline steps for courseware-related openedx-filters contributed by the Enterprise app.
+"""
+import logging
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+from crum import get_current_request
+from opaque_keys.edx.keys import CourseKey
+from openedx_filters.filters import PipelineStep
+from openedx_filters.learning.filters import CourseStartDateValidationFailed, CoursewareAccessChecksRequested
+
+# Courses whose start date equals DEFAULT_START_DATE are considered "unscheduled" in the platform.
+# Messages for these courses omit the specific date and use a generic "has not started" wording.
+try:
+    from xmodule.course_metadata_utils import DEFAULT_START_DATE
+except ImportError:
+    DEFAULT_START_DATE = datetime(2040, 1, 1, tzinfo=ZoneInfo("UTC"))
+
+from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
+from enterprise.utils import enterprise_learner_enrolled
+
+log = logging.getLogger(__name__)
+
+# Error code (for platform AccessError exceptions) representing a start date
+# error with a hint that the enrollment is enterprise subsidized.  This hint is
+# used by the Learning MFE to trigger enterprise redirect logic.
+COURSE_NOT_STARTED_ENTERPRISE_LEARNER = "course_not_started_enterprise_learner"
+
+
+class EnterpriseStartDateAccessFailureStep(PipelineStep):
+    """
+    Substitutes a more specific start-date access-error payload for enterprise learners.
+
+    Registered against ``org.openedx.learning.course.start_date.validation_failed.v1``.
+    Raises ``CourseStartDateValidationFailed.OverrideStartDateError`` when the request
+    user is an enterprise learner enrolled via a subsidy for the given course. If the
+    user is not an enterprise learner, the step is a no-op.
+    """
+
+    def run_filter(  # pylint: disable=arguments-differ
+        self,
+        course_key: CourseKey,
+        start_date: datetime,
+    ) -> dict:
+        request = get_current_request()
+        if request is None:
+            return {"course_key": course_key, "start_date": start_date}
+        user = request.user
+        if not user.is_authenticated or not enterprise_learner_enrolled(request, course_key):
+            return {"course_key": course_key, "start_date": start_date}
+
+        # By now, all conditions have been met to warrant a custom enterprise-specific override error.
+        if start_date == DEFAULT_START_DATE:
+            developer_message = "Course has not started, and the learner is enrolled via an enterprise subsidy."
+            user_message = "Course has not started"
+        else:
+            developer_message = (
+                f"Course does not start until {start_date}, and the learner is enrolled via an enterprise subsidy."
+            )
+            user_message = f"Course does not start until {start_date:%B %d, %Y}"
+        raise CourseStartDateValidationFailed.OverrideStartDateError(
+            message="Course has not started, and this is an enterprise learner",
+            error_code=COURSE_NOT_STARTED_ENTERPRISE_LEARNER,
+            developer_message=developer_message,
+            user_message=user_message,
+        )
+
+
+class ActiveEnterpriseCheckStep(PipelineStep):
+    """
+    Deny access when the learner's active EnterpriseCustomer differs from the
+    EnterpriseCustomer attached to their EnterpriseCourseEnrollment for this course.
+
+    Registered against ``org.openedx.learning.courseware.access_checks.requested.v1``.
+    Raises ``CoursewareAccessChecksRequested.PreventCoursewareAccess`` to deny access.
+    """
+
+    def run_filter(self, user: Any, course_key: CourseKey) -> dict:  # pylint: disable=arguments-differ
+        enterprise_enrollments = EnterpriseCourseEnrollment.objects.filter(
+            course_id=course_key, enterprise_customer_user__user_id=user.id,
+        )
+        if not enterprise_enrollments.exists():
+            return {"user": user, "course_key": course_key}
+
+        try:
+            active_ecu = EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
+            if enterprise_enrollments.filter(enterprise_customer_user=active_ecu).exists():
+                return {"user": user, "course_key": course_key}
+            active_enterprise_name = active_ecu.enterprise_customer.name
+        except (EnterpriseCustomerUser.DoesNotExist, EnterpriseCustomerUser.MultipleObjectsReturned):
+            # Ideally this should not happen — there should be exactly 1 active enterprise customer.
+            log.error("Multiple or No Active Enterprise found for the user %s.", user.id)
+            active_enterprise_name = "Incorrect"
+
+        enrollment_enterprise_name = (
+            enterprise_enrollments.first().enterprise_customer_user.enterprise_customer.name
+        )
+        user_message = (
+            f"You are enrolled in this course with '{enrollment_enterprise_name}'. However, you are "
+            f"currently logged in as a '{active_enterprise_name}' user. Please log in with "
+            f"'{enrollment_enterprise_name}' to access this course."
+        )
+        raise CoursewareAccessChecksRequested.PreventCoursewareAccess(
+            message="Incorrect active enterprise",
+            error_code="incorrect_active_enterprise",
+            developer_message="User active enterprise should be same as EnterpriseCourseEnrollment enterprise.",
+            user_message=user_message,
+        )

--- a/enterprise/filters/dashboard.py
+++ b/enterprise/filters/dashboard.py
@@ -7,8 +7,8 @@ from typing import Any
 from crum import get_current_request
 from openedx_filters.filters import PipelineStep
 
-# These imports will be replaced with internal paths in epic 17 when enterprise_support is
-# migrated into edx-enterprise.
+# ENT-11576: These functions will be migrated from the platform's enterprise_support module
+# into edx-enterprise, eliminating these cross-boundary imports.
 try:
     from openedx.features.enterprise_support.api import (
         get_dashboard_consent_notification,

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -20,6 +20,20 @@ ENTERPRISE_FILTERS_CONFIG: FiltersConfig = {
         "fail_silently": False,
         "pipeline": ["enterprise.filters.grades.GradeEventContextEnricher"],
     },
+    "org.openedx.learning.course.start_date.validation_failed.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.courseware.EnterpriseStartDateAccessFailureStep"],
+    },
+    # NOTE: Pipeline ordering matters here. ActiveEnterpriseCheckStep must run before
+    # consent's DataSharingConsentCourseAccessStep to match the original platform behavior
+    # (the incorrect-enterprise redirect took priority over the DSC redirect). This ordering
+    # is guaranteed because setup.py lists "enterprise" before "consent" in entry_points,
+    # stevedore preserves intra-distribution order, and consent's plugin_settings appends
+    # its step after enterprise's via _merge_filters_config.
+    "org.openedx.learning.courseware.access_checks.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.courseware.ActiveEnterpriseCheckStep"],
+    },
 }
 
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -9,6 +9,7 @@ import re
 from collections import OrderedDict
 from functools import reduce
 from itertools import islice
+from typing import TYPE_CHECKING
 from urllib.parse import parse_qs, quote, urlencode, urljoin, urlparse, urlsplit, urlunsplit
 from uuid import UUID, uuid4
 
@@ -16,6 +17,7 @@ import bleach
 import pytz
 from edx_django_utils.cache import TieredCache
 from edx_django_utils.cache import get_cache_key as get_django_cache_key
+from opaque_keys.edx.keys import CourseKey
 from slumber.exceptions import HttpClientError
 from social_django.models import UserSocialAuth
 
@@ -30,7 +32,7 @@ from django.db import utils
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
-from django.http import Http404
+from django.http import Http404, HttpRequest
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
@@ -57,6 +59,12 @@ try:
     from openedx.features.enterprise_support.enrollments.utils import lms_update_or_create_enrollment
 except ImportError:
     lms_update_or_create_enrollment = None
+
+# In ENT-11576, enterprise_customer_from_session_or_learner_data will be migrated into this repo.
+try:
+    from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
+except ImportError:
+    enterprise_customer_from_session_or_learner_data = None
 
 try:
     from openedx.core.djangoapps.course_groups.models import CourseUserGroup
@@ -134,6 +142,9 @@ try:
     from openedx.core.djangoapps.lang_pref import LANGUAGE_KEY
 except ImportError:
     LANGUAGE_KEY = 'pref-lang'
+
+if TYPE_CHECKING:
+    from enterprise.models import EnterpriseCustomerUser
 
 
 class ValidationMessages:
@@ -837,6 +848,76 @@ def get_enterprise_customer_user(user_id, enterprise_uuid):
         )
     except EnterpriseCustomerUser.DoesNotExist:
         return None
+
+
+def get_active_enterprise_customer_user(user: AbstractUser) -> 'EnterpriseCustomerUser | None':
+    """
+    Return the active EnterpriseCustomerUser model instance for ``user``, or None.
+
+    There is at most one active EnterpriseCustomerUser per user.
+    """
+    if not getattr(settings, 'ENABLE_ENTERPRISE_INTEGRATION', False) or not user.is_authenticated:
+        return None
+    EnterpriseCustomerUser = apps.get_model('enterprise', 'EnterpriseCustomerUser')
+    try:
+        return EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
+    except EnterpriseCustomerUser.DoesNotExist:
+        LOGGER.info(
+            "Active EnterpriseCustomerUser for user [%s] does not exist", user.username,
+        )
+        return None
+
+
+def enterprise_learner_enrolled(request: HttpRequest, course_key: CourseKey) -> bool:
+    """
+    Return True if the request user is an enterprise learner enrolled via a subsidy for ``course_key``.
+
+    Returns True only when all of the following conditions hold:
+
+    1. The request user has an active linked EnterpriseCustomer.
+    2. The linked customer has the learner portal enabled.
+    3. The user has an EnterpriseCourseEnrollment for ``course_key`` under that customer.
+
+    Intended use: determining whether the learner should be subject to enterprise-specific
+    courseware gating (e.g. data-sharing consent enforcement or start-date error overrides)
+    and redirected to the enterprise learner portal when access is denied.
+
+    ``enterprise_customer_from_session_or_learner_data`` is used in lieu of direct model access
+    because it caches the customer data on the request session, making it safe to call on
+    frequently-hit views without incurring repeated database queries.
+    """
+    # enterprise_customer is either None (learner not linked to any customer) or a serialized
+    # EnterpriseCustomer representing the learner's active linked customer.
+    enterprise_customer = enterprise_customer_from_session_or_learner_data(request)
+
+    enterprise_enrollment_exists = False
+
+    # 1. Check that the request user has an active linked EnterpriseCustomer.
+    if enterprise_customer:
+        # 2. Check that the linked customer has the learner portal enabled.
+        if enterprise_customer.get('enable_learner_portal'):
+            # 3. Make sure the enterprise learner is actually enrolled in the requested course,
+            #    subsidized via the discovered customer.
+            EnterpriseCourseEnrollment = apps.get_model('enterprise', 'EnterpriseCourseEnrollment')
+            enterprise_enrollment_exists = EnterpriseCourseEnrollment.objects.filter(
+                course_id=course_key,
+                enterprise_customer_user__user_id=request.user.id,
+                enterprise_customer_user__enterprise_customer__uuid=enterprise_customer['uuid'],
+            ).exists()
+
+    LOGGER.info(
+        (
+            "[enterprise_learner_enrolled] Checking for an enterprise enrollment for "
+            "lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s (enable_learner_portal=%s). "
+            "Exists: %s"
+        ),
+        request.user.id,
+        course_key,
+        enterprise_customer['uuid'] if enterprise_customer else None,
+        enterprise_customer.get('enable_learner_portal') if enterprise_customer else None,
+        enterprise_enrollment_exists,
+    )
+    return enterprise_enrollment_exists
 
 
 def get_course_track_selection_url(course_run, query_parameters):

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -673,7 +673,7 @@ openedx-events==11.2.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -402,7 +402,7 @@ openedx-atlas==0.7.0
     # via -r requirements/test-master.txt
 openedx-events==11.2.0
     # via -r requirements/test-master.txt
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via -r requirements/test-master.txt
 packaging==26.2
     # via

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -858,7 +858,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -420,7 +420,7 @@ openedx-events==11.2.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -395,7 +395,7 @@ openedx-atlas==0.7.0
     # via -r requirements/test-master.txt
 openedx-events==11.2.0
     # via -r requirements/test-master.txt
-openedx-filters==3.4.1
+openedx-filters==3.5.0
     # via -r requirements/test-master.txt
 packaging==26.2
     # via

--- a/tests/filters/test_courseware.py
+++ b/tests/filters/test_courseware.py
@@ -1,0 +1,168 @@
+"""
+Tests for enterprise.filters.courseware pipeline steps.
+"""
+from datetime import datetime
+from unittest.mock import patch
+from zoneinfo import ZoneInfo
+
+import ddt
+import pytest
+from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CourseStartDateValidationFailed, CoursewareAccessChecksRequested
+
+from django.contrib.auth.models import AnonymousUser
+from django.test import RequestFactory, TestCase
+
+from enterprise.filters.courseware import ActiveEnterpriseCheckStep, EnterpriseStartDateAccessFailureStep
+from test_utils.factories import (
+    EnterpriseCourseEnrollmentFactory,
+    EnterpriseCustomerFactory,
+    EnterpriseCustomerUserFactory,
+    UserFactory,
+)
+
+
+@ddt.ddt
+class TestEnterpriseStartDateAccessFailureStep(TestCase):
+    """Tests for EnterpriseStartDateAccessFailureStep."""
+
+    def _make_step(self):
+        return EnterpriseStartDateAccessFailureStep(
+            "org.openedx.learning.course.start_date.validation_failed.v1", []
+        )
+
+    @ddt.data(
+        # Enterprise learner with a specific start date: raises with formatted date in messages.
+        {
+            "is_authenticated": True,
+            "has_request": True,
+            "enterprise_learner_enrolled": True,
+            "start_date": datetime(2026, 9, 1, tzinfo=ZoneInfo("UTC")),
+            "expected_raises_error_code": "course_not_started_enterprise_learner",
+            "expected_raises_developer_message": "2026-09-01",
+            "expected_raises_user_message": "Course does not start until September 01, 2026",
+        },
+        # Enterprise learner with the default/unscheduled start date: raises with generic "has not started" messages.
+        {
+            "is_authenticated": True,
+            "has_request": True,
+            "enterprise_learner_enrolled": True,
+            "start_date": datetime(2040, 1, 1, tzinfo=ZoneInfo("UTC")),
+            "expected_raises_error_code": "course_not_started_enterprise_learner",
+            "expected_raises_developer_message": (
+                "Course has not started, and the learner is enrolled via an enterprise subsidy."
+            ),
+            "expected_raises_user_message": "Course has not started",
+        },
+        # Authenticated user who is not an enterprise learner: passes through.
+        {
+            "is_authenticated": True,
+            "has_request": True,
+            "enterprise_learner_enrolled": False,
+            "start_date": datetime(2026, 9, 1, tzinfo=ZoneInfo("UTC")),
+            "expected_raises_error_code": None,
+            "expected_raises_developer_message": None,
+            "expected_raises_user_message": None,
+        },
+        # Unauthenticated user: passes through without calling enterprise_learner_enrolled.
+        {
+            "is_authenticated": False,
+            "has_request": True,
+            "enterprise_learner_enrolled": False,
+            "start_date": datetime(2026, 9, 1, tzinfo=ZoneInfo("UTC")),
+            "expected_raises_error_code": None,
+            "expected_raises_developer_message": None,
+            "expected_raises_user_message": None,
+        },
+        # No CRUM request available: passes through without calling enterprise_learner_enrolled.
+        {
+            "is_authenticated": True,
+            "has_request": False,
+            "enterprise_learner_enrolled": False,
+            "start_date": datetime(2026, 9, 1, tzinfo=ZoneInfo("UTC")),
+            "expected_raises_error_code": None,
+            "expected_raises_developer_message": None,
+            "expected_raises_user_message": None,
+        },
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.courseware.enterprise_learner_enrolled')
+    @patch('enterprise.filters.courseware.get_current_request')
+    def test_run_filter(
+        self,
+        mock_get_request,
+        mock_enrolled,
+        is_authenticated,
+        has_request,
+        enterprise_learner_enrolled,
+        start_date,
+        expected_raises_error_code,
+        expected_raises_developer_message,
+        expected_raises_user_message,
+    ):
+        """Raises OverrideStartDateError for enterprise learners; passes through otherwise."""
+        if has_request:
+            request = RequestFactory().get('/')
+            request.user = UserFactory.create() if is_authenticated else AnonymousUser()
+            mock_get_request.return_value = request
+        else:
+            mock_get_request.return_value = None
+        mock_enrolled.return_value = enterprise_learner_enrolled
+
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        step = self._make_step()
+        if expected_raises_error_code:
+            with pytest.raises(CourseStartDateValidationFailed.OverrideStartDateError) as exc_info:
+                step.run_filter(course_key=course_key, start_date=start_date)
+            assert exc_info.value.error_code == expected_raises_error_code
+            assert expected_raises_developer_message in exc_info.value.developer_message
+            assert exc_info.value.user_message == expected_raises_user_message
+        else:
+            result = step.run_filter(course_key=course_key, start_date=start_date)
+            assert result == {"course_key": course_key, "start_date": start_date}
+
+
+class TestActiveEnterpriseCheckStep(TestCase):
+    """Tests for ActiveEnterpriseCheckStep."""
+
+    def _make_step(self):
+        return ActiveEnterpriseCheckStep(
+            "org.openedx.learning.courseware.access_checks.requested.v1", [],
+        )
+
+    def test_no_enterprise_enrollments_passthrough(self):
+        """When the user has no enterprise enrollments, the step is a no-op."""
+        user = UserFactory.create()
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        step = self._make_step()
+        result = step.run_filter(user=user, course_key=course_key)
+        assert result == {"user": user, "course_key": course_key}
+
+    def test_matching_active_customer_passthrough(self):
+        """When the active EnterpriseCustomerUser matches the enrollment's customer, no exception."""
+        user = UserFactory.create()
+        ec = EnterpriseCustomerFactory()
+        ecu = EnterpriseCustomerUserFactory(enterprise_customer=ec, user_id=user.id, active=True)
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        EnterpriseCourseEnrollmentFactory(enterprise_customer_user=ecu, course_id=str(course_key))
+        step = self._make_step()
+        result = step.run_filter(user=user, course_key=course_key)
+        assert result == {"user": user, "course_key": course_key}
+
+    def test_mismatched_active_customer_raises(self):
+        """When the active EnterpriseCustomerUser does not match, PreventCoursewareAccess is raised."""
+        user = UserFactory.create()
+        enrolled_ec = EnterpriseCustomerFactory(name="EnrolledCo")
+        active_ec = EnterpriseCustomerFactory(name="ActiveCo")
+        enrolled_ecu = EnterpriseCustomerUserFactory(
+            enterprise_customer=enrolled_ec, user_id=user.id, active=False,
+        )
+        EnterpriseCustomerUserFactory(enterprise_customer=active_ec, user_id=user.id, active=True)
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        EnterpriseCourseEnrollmentFactory(enterprise_customer_user=enrolled_ecu, course_id=str(course_key))
+        step = self._make_step()
+        with pytest.raises(CoursewareAccessChecksRequested.PreventCoursewareAccess) as exc_info:
+            step.run_filter(user=user, course_key=course_key)
+        assert exc_info.value.error_code == "incorrect_active_enterprise"
+        assert "EnrolledCo" in exc_info.value.user_message
+        assert "ActiveCo" in exc_info.value.user_message

--- a/tests/test_consent/test_filters_courseware.py
+++ b/tests/test_consent/test_filters_courseware.py
@@ -1,0 +1,146 @@
+"""
+Tests for consent.filters.courseware pipeline steps.
+"""
+from unittest.mock import patch
+
+import ddt
+import pytest
+from opaque_keys.edx.keys import CourseKey
+from openedx_filters.learning.filters import CoursewareAccessChecksRequested, CoursewareViewStarted
+
+from django.test import RequestFactory, TestCase
+
+from consent.filters.courseware import DataSharingConsentCourseAccessStep, DataSharingConsentRedirectStep
+from test_utils.factories import UserFactory
+
+
+@ddt.ddt
+class TestDataSharingConsentRedirectStep(TestCase):
+    """Tests for DataSharingConsentRedirectStep."""
+
+    def _make_step(self):
+        return DataSharingConsentRedirectStep(
+            "org.openedx.learning.courseware.view.started.v1", []
+        )
+
+    @ddt.data(
+        {
+            "consent_url_return_value": "/consent/",
+            "expected_raises": CoursewareViewStarted.RedirectToUrl,
+            "expected_redirect_url": "/consent/",
+        },
+        {
+            "consent_url_return_value": None,
+            "expected_raises": None,
+            "expected_redirect_url": None,
+        },
+    )
+    @ddt.unpack
+    @patch('consent.filters.courseware.get_enterprise_consent_url')
+    @patch('consent.filters.courseware.get_current_request')
+    def test_run_filter(
+        self,
+        mock_get_request,
+        mock_get_url,
+        consent_url_return_value,
+        expected_raises,
+        expected_redirect_url,
+    ):
+        """Raises RedirectToUrl when consent is required, otherwise returns passthrough."""
+        user = UserFactory.create()
+        request = RequestFactory().get('/')
+        request.user = user
+        mock_get_request.return_value = request
+        mock_get_url.return_value = consent_url_return_value
+        step = self._make_step()
+        course_key = CourseKey.from_string("course-v1:org+course+run")
+        view_name = "test_view"
+        if expected_raises is not None:
+            with pytest.raises(expected_raises) as exc_info:
+                step.run_filter(course_key=course_key, view_name=view_name)
+            assert exc_info.value.redirect_to == expected_redirect_url
+        else:
+            result = step.run_filter(course_key=course_key, view_name=view_name)
+            assert result == {"course_key": course_key, "view_name": view_name}
+        mock_get_url.assert_called_once_with(
+            request=request,
+            course_id='course-v1:org+course+run',
+            enrollment_exists=True,
+            source=view_name,
+        )
+
+    @patch('consent.filters.courseware.get_current_request', return_value=None)
+    def test_passthrough_when_no_request(self, _mock_get_request):
+        """No exception and passthrough dict when there is no current request available."""
+        step = self._make_step()
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        view_name = "test_view"
+        result = step.run_filter(course_key=course_key, view_name=view_name)
+        assert result == {"course_key": course_key, "view_name": view_name}
+
+
+@ddt.ddt
+class TestDataSharingConsentCourseAccessStep(TestCase):
+    """Tests for DataSharingConsentCourseAccessStep."""
+
+    def _make_step(self):
+        return DataSharingConsentCourseAccessStep(
+            "org.openedx.learning.courseware.access_checks.requested.v1", [],
+        )
+
+    @ddt.data(
+        {
+            "consent_url_return_value": "/consent/",
+            "expected_raises": CoursewareAccessChecksRequested.PreventCoursewareAccess,
+            "expected_developer_message": "/consent/",
+        },
+        {
+            "consent_url_return_value": None,
+            "expected_raises": None,
+            "expected_developer_message": None,
+        },
+    )
+    @ddt.unpack
+    @patch('consent.filters.courseware.get_enterprise_consent_url')
+    @patch('consent.filters.courseware.get_current_request')
+    def test_run_filter(
+        self,
+        mock_get_request,
+        mock_get_url,
+        consent_url_return_value,
+        expected_raises,
+        expected_developer_message,
+    ):
+        """Raises PreventCoursewareAccess when consent is required, otherwise returns passthrough."""
+        user = UserFactory.create()
+        request = RequestFactory().get('/')
+        request.user = user
+        mock_get_request.return_value = request
+        mock_get_url.return_value = consent_url_return_value
+        step = self._make_step()
+        course_key = CourseKey.from_string("course-v1:org+course+run")
+        if expected_raises is not None:
+            with pytest.raises(expected_raises) as exc_info:
+                step.run_filter(user=user, course_key=course_key)
+            assert exc_info.value.error_code == 'data_sharing_access_required'
+            assert exc_info.value.developer_message == expected_developer_message
+        else:
+            result = step.run_filter(user=user, course_key=course_key)
+            assert result == {"user": user, "course_key": course_key}
+        mock_get_url.assert_called_once_with(
+            request=request,
+            course_id='course-v1:org+course+run',
+            user=user,
+            return_to="courseware",
+            enrollment_exists=True,
+            source="CoursewareAccess",
+        )
+
+    @patch('consent.filters.courseware.get_current_request', return_value=None)
+    def test_passthrough_when_no_request(self, _mock_get_request):
+        """No exception when there is no current request available."""
+        step = self._make_step()
+        user = UserFactory.create()
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        result = step.run_filter(user=user, course_key=course_key)
+        assert result == {"user": user, "course_key": course_key}

--- a/tests/test_consent/test_helpers.py
+++ b/tests/test_consent/test_helpers.py
@@ -3,14 +3,32 @@ Tests for helper functions in the Consent application.
 """
 
 from unittest import mock
+from urllib.parse import parse_qs, urlparse
 
 import ddt
 from pytest import mark
 
-from django.test import testcases
+from django.contrib.sites.models import Site
+from django.test import override_settings, testcases
 
 from consent import helpers
 from test_utils import TEST_UUID
+from test_utils.factories import UserFactory
+
+
+def _mock_active_enterprise_learner_details(
+        enterprise_customer_uuid=TEST_UUID,
+        enable_data_sharing_consent=True,
+        slug='test-slug',
+        site_domain='example.com',
+):
+    """Return a mock mirroring the shape returned by get_active_enterprise_customer_user."""
+    mock_ecu = mock.MagicMock()
+    mock_ecu.enterprise_customer.uuid = enterprise_customer_uuid
+    mock_ecu.enterprise_customer.slug = slug
+    mock_ecu.enterprise_customer.enable_data_sharing_consent = enable_data_sharing_consent
+    mock_ecu.enterprise_customer.site.domain = site_domain
+    return mock_ecu
 
 
 @mark.django_db
@@ -31,3 +49,173 @@ class ConsentHelpersTest(testcases.TestCase):
         mock_catalog_api_class = mock_catalog_api_class.return_value
         mock_catalog_api_class.get_course_id.return_value = self.fake_course_id
         assert helpers.get_data_sharing_consent('bob', TEST_UUID, course_id=self.fake_course_id) is None
+
+
+@mark.django_db
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True, DATA_CONSENT_SHARE_CACHE_TIMEOUT=60)
+class ConsentNeededForCourseTest(testcases.TestCase):
+    """Tests for ``consent.helpers.consent_needed_for_course``."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory(username='janedoe')
+        self.course_id = 'fake-course'
+        self.site = Site.objects.get_or_create(domain='example.com', defaults={'name': 'example.com'})[0]
+        self.request = mock.MagicMock(user=self.user, site=self.site)
+
+    def _patch_platform_deps(self, **overrides):
+        """Patch the lazy-imported platform symbols on consent.helpers with sensible defaults."""
+        defaults = {
+            'ConsentApiClient': mock.MagicMock(),
+            'enterprise_customer_uuid_for_request': mock.MagicMock(return_value=TEST_UUID),
+            'get_data_consent_share_cache_key': mock.MagicMock(return_value='cache-key'),
+        }
+        defaults.update(overrides)
+        return mock.patch.multiple('consent.helpers', **defaults)
+
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user', return_value=None)
+    def test_returns_false_when_user_has_no_active_enterprise(self, _mock_active):
+        with self._patch_platform_deps():
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+    @mock.patch('consent.helpers.TieredCache')
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user')
+    def test_returns_false_when_dsc_cache_indicates_not_needed(self, mock_active, mock_cache):
+        mock_active.return_value = _mock_active_enterprise_learner_details()
+        cached = mock.MagicMock(is_found=True, value=0)
+        mock_cache.get_cached_response.return_value = cached
+        with self._patch_platform_deps():
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+    @mock.patch('consent.helpers.TieredCache')
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user')
+    def test_returns_false_when_dsc_disabled_for_customer(self, mock_active, mock_cache):
+        mock_active.return_value = _mock_active_enterprise_learner_details(enable_data_sharing_consent=False)
+        mock_cache.get_cached_response.return_value = mock.MagicMock(is_found=False)
+        with self._patch_platform_deps():
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+        mock_cache.set_all_tiers.assert_called_once()
+
+    @mock.patch('consent.helpers.TieredCache')
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user')
+    def test_returns_false_when_request_enterprise_does_not_match_learner(self, mock_active, mock_cache):
+        mock_active.return_value = _mock_active_enterprise_learner_details(enterprise_customer_uuid=TEST_UUID)
+        mock_cache.get_cached_response.return_value = mock.MagicMock(is_found=False)
+        with self._patch_platform_deps(
+            enterprise_customer_uuid_for_request=mock.MagicMock(return_value='other-uuid'),
+        ):
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+    @mock.patch('consent.helpers.TieredCache')
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user')
+    def test_returns_false_when_site_does_not_match_learner(self, mock_active, mock_cache):
+        Site.objects.get_or_create(domain='other.example.com', defaults={'name': 'other'})
+        mock_active.return_value = _mock_active_enterprise_learner_details(site_domain='other.example.com')
+        mock_cache.get_cached_response.return_value = mock.MagicMock(is_found=False)
+        with self._patch_platform_deps():
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+    @mock.patch('consent.helpers.TieredCache')
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user')
+    def test_returns_false_when_consent_api_says_no_consent_required(self, mock_active, mock_cache):
+        mock_active.return_value = _mock_active_enterprise_learner_details()
+        mock_cache.get_cached_response.return_value = mock.MagicMock(is_found=False)
+        consent_client = mock.MagicMock()
+        consent_client.return_value.consent_required.return_value = False
+        with self._patch_platform_deps(ConsentApiClient=consent_client):
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+    @mock.patch('consent.helpers.TieredCache')
+    @mock.patch('consent.helpers.get_active_enterprise_customer_user')
+    def test_returns_true_when_consent_api_says_consent_required(self, mock_active, mock_cache):
+        mock_active.return_value = _mock_active_enterprise_learner_details()
+        mock_cache.get_cached_response.return_value = mock.MagicMock(is_found=False)
+        consent_client = mock.MagicMock()
+        consent_client.return_value.consent_required.return_value = True
+        with self._patch_platform_deps(ConsentApiClient=consent_client):
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is True
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
+    def test_returns_false_when_integration_disabled(self):
+        assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+    def test_returns_false_when_platform_imports_unavailable(self):
+        with mock.patch.multiple(
+            'consent.helpers',
+            ConsentApiClient=None,
+            enterprise_customer_uuid_for_request=None,
+            get_data_consent_share_cache_key=None,
+        ):
+            assert helpers.consent_needed_for_course(self.request, self.user, self.course_id) is False
+
+
+@mark.django_db
+@override_settings(ENABLE_ENTERPRISE_INTEGRATION=True, DATA_CONSENT_SHARE_CACHE_TIMEOUT=60)
+@mock.patch('consent.helpers.reverse', side_effect=lambda name, *args, **kwargs: f'/reversed/{name}/')
+@mock.patch('consent.helpers.enterprise_customer_uuid_for_request', return_value=TEST_UUID)
+class GetEnterpriseConsentUrlTest(testcases.TestCase):
+    """Tests for ``consent.helpers.get_enterprise_consent_url``."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = UserFactory(username='janedoe')
+        self.course_id = 'course-v1:edX+DemoX+T1'
+        self.site = Site.objects.get_or_create(domain='example.com', defaults={'name': 'example.com'})[0]
+        self.request = mock.MagicMock(
+            user=self.user,
+            site=self.site,
+            path='/courses/course-v1:edX+DemoX+T1/courseware',
+        )
+        self.request.build_absolute_uri = lambda path: f'http://example.com{path}'
+
+    def _parse_consent_url(self, url):
+        """Parse a consent URL into (path, query_params_dict)."""
+        parsed = urlparse(url)
+        params = {k: v[0] for k, v in parse_qs(parsed.query).items()}
+        return parsed.path, params
+
+    @mock.patch('consent.helpers.consent_needed_for_course', return_value=False)
+    def test_returns_none_when_consent_not_needed(self, _mock_consent, _mock_uuid_fn, _mock_reverse):
+        """Returns None when consent_needed_for_course says no."""
+        result = helpers.get_enterprise_consent_url(self.request, self.course_id)
+        assert result is None
+
+    @mock.patch('consent.helpers.consent_needed_for_course', return_value=True)
+    def test_returns_url_using_request_path_when_return_to_is_none(self, _mock_consent, _mock_uuid_fn, _mock_reverse):
+        """Uses request.path as the return path when return_to is not specified."""
+        result = helpers.get_enterprise_consent_url(self.request, self.course_id)
+        path, params = self._parse_consent_url(result)
+        assert path == '/reversed/grant_data_sharing_permissions/'
+        assert params['next'] == 'http://example.com/courses/course-v1:edX+DemoX+T1/courseware'
+
+    @mock.patch('consent.helpers.consent_needed_for_course', return_value=True)
+    def test_returns_url_using_reverse_when_return_to_specified(self, _mock_consent, _mock_uuid_fn, _mock_reverse):
+        """Uses reverse(return_to, args=(course_id,)) when return_to is given."""
+        result = helpers.get_enterprise_consent_url(
+            self.request, self.course_id, return_to='course_root',
+        )
+        path, params = self._parse_consent_url(result)
+        assert path == '/reversed/grant_data_sharing_permissions/'
+        assert params['next'] == 'http://example.com/reversed/course_root/'
+
+    @mock.patch('consent.helpers.consent_needed_for_course', return_value=True)
+    def test_uses_explicit_user_when_provided(self, mock_consent, _mock_uuid_fn, _mock_reverse):
+        """Passes the explicit user arg to consent_needed_for_course."""
+        other_user = UserFactory(username='other_user')
+        result = helpers.get_enterprise_consent_url(self.request, self.course_id, user=other_user)
+        path, _ = self._parse_consent_url(result)
+        assert path == '/reversed/grant_data_sharing_permissions/'
+        mock_consent.assert_called_once_with(
+            self.request, other_user, self.course_id, enrollment_exists=False,
+        )
+
+    @mock.patch('consent.helpers.CONSENT_FAILED_PARAMETER', 'consent_failed')
+    @mock.patch('consent.helpers.consent_needed_for_course', return_value=True)
+    def test_includes_failure_url_with_consent_failed_param(self, _mock_consent, _mock_uuid_fn, _mock_reverse):
+        """The returned URL includes a failure_url pointing to the dashboard."""
+        result = helpers.get_enterprise_consent_url(self.request, self.course_id)
+        path, params = self._parse_consent_url(result)
+        assert path == '/reversed/grant_data_sharing_permissions/'
+        assert params['failure_url'] == (
+            'http://example.com/reversed/dashboard/?consent_failed=course-v1%3AedX%2BDemoX%2BT1'
+        )

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -13,13 +13,14 @@ from urllib.parse import quote, urlencode
 # Third-party imports
 import ddt
 import pytest
+from opaque_keys.edx.keys import CourseKey
 from pytest import mark
 
 # Django imports
 from django.conf import settings
 from django.db import DatabaseError, transaction
 from django.forms.models import model_to_dict
-from django.test import TestCase
+from django.test import RequestFactory, TestCase, override_settings
 
 # First-party imports
 from enterprise.api import utils as api_utils
@@ -41,6 +42,8 @@ from enterprise.models import (
 from enterprise.utils import (
     batch_dict,
     enroll_subsidy_users_in_courses,
+    enterprise_learner_enrolled,
+    get_active_enterprise_customer_user,
     get_default_invite_key_expiration_date,
     get_idiff_list,
     get_platform_logo_url,
@@ -1129,3 +1132,72 @@ class TestAdminInviteUtils(TestCase):
                             ]
                         )
                 assert mock_logger_exception.called
+
+
+@mark.django_db
+class GetActiveEnterpriseCustomerUserTest(TestCase):
+    """Tests for ``enterprise.utils.get_active_enterprise_customer_user``."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = factories.UserFactory()
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
+    def test_returns_none_when_integration_disabled(self):
+        factories.EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
+        assert get_active_enterprise_customer_user(self.user) is None
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
+    def test_returns_active_customer_user(self):
+        factories.EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
+        data = get_active_enterprise_customer_user(self.user)
+        assert data.user.username == self.user.username
+        assert data.active
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
+    def test_returns_none_when_no_active_user_found(self):
+        assert get_active_enterprise_customer_user(self.user) is None
+
+
+@mark.django_db
+@ddt.ddt
+class EnterpriseLearnerEnrolledTest(TestCase):
+    """Tests for ``enterprise.utils.enterprise_learner_enrolled``."""
+
+    def _make_request(self, user):
+        request = RequestFactory().get('/')
+        request.user = user
+        return request
+
+    @ddt.data(
+        # Linked customer with portal enabled and matching enrollment: returns True.
+        {"has_customer": True, "enable_learner_portal": True, "has_enrollment": True, "expected_result": True},
+        # No linked enterprise customer: returns False.
+        {"has_customer": False, "enable_learner_portal": None, "has_enrollment": False, "expected_result": False},
+        # Linked customer but learner portal disabled: returns False.
+        {"has_customer": True, "enable_learner_portal": False, "has_enrollment": False, "expected_result": False},
+        # Linked customer with portal enabled but no EnterpriseCourseEnrollment: returns False.
+        {"has_customer": True, "enable_learner_portal": True, "has_enrollment": False, "expected_result": False},
+    )
+    @ddt.unpack
+    @patch('enterprise.utils.enterprise_customer_from_session_or_learner_data')
+    def test_returns_enrolled(
+        self,
+        mock_customer,
+        has_customer: bool,
+        enable_learner_portal: bool | None,
+        has_enrollment: bool,
+        expected_result: bool,
+    ):
+        """Returns True only when the user has an active linked customer with portal enabled and an enrollment."""
+        user = factories.UserFactory()
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        if has_customer:
+            ec = factories.EnterpriseCustomerFactory()
+            mock_customer.return_value = {'uuid': str(ec.uuid), 'enable_learner_portal': enable_learner_portal}
+            if has_enrollment:
+                ecu = factories.EnterpriseCustomerUserFactory(enterprise_customer=ec, user_id=user.id)
+                factories.EnterpriseCourseEnrollmentFactory(enterprise_customer_user=ecu, course_id=str(course_key))
+        else:
+            mock_customer.return_value = None
+        assert enterprise_learner_enrolled(self._make_request(user), course_key) is expected_result


### PR DESCRIPTION
This commit replaces most enterprise-specific logic serving the purpose of conditionally blocking courseware access, often redirecting to a DSC page.

Enterprise steps added:
- EnterpriseStartDateAccessFailureStep supplies an enterprise-specific start-date error for enterprise learners.
- ActiveEnterpriseCheckStep denies access when the learner's active EnterpriseCustomer differs from the enrollment's customer.

Consent steps added:
- DataSharingConsentRedirectStep supplies a redirect URL to collect data sharing consent when it is required.
- DataSharingConsentCourseAccessStep denies access when consent is required.

ENT-11544

---

Blocked by:
* https://github.com/openedx/openedx-filters/pull/336

Blocks:
* https://github.com/edx/edx-platform/pull/338
* https://github.com/edx/edx-platform/pull/339
* https://github.com/edx/edx-platform/pull/340
* https://github.com/openedx/openedx-platform/pull/38102