### PR TITLE
feat: add pipeline steps for logistration filters

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.8.0] - 2026-08-07
+---------------------
+* feat: add pipeline steps for logistration filters
+
 [8.7.3] - 2026-07-27
 ---------------------
 * feat: add multiple SSO tenants during devstack provisioning

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,7 +32,14 @@ extensions = [
     'sphinx.ext.ifconfig',
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
+    'sphinxcontrib.mermaid',
+    'myst_parser',
 ]
+
+# Render fenced ```mermaid code blocks in Markdown (MyST) sources through the
+# sphinxcontrib.mermaid directive, so the same fences render both on GitHub and
+# in the Sphinx-built docs.
+myst_fence_as_directive = ["mermaid"]
 
 import enterprise
 
@@ -65,8 +72,8 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 #
-# source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+# Markdown sources (e.g. docs/decisions/*.md) are parsed by myst_parser.
+source_suffix = ['.rst', '.md']
 
 # The encoding of source files.
 #

--- a/docs/decisions/0016-logistration-filters.md
+++ b/docs/decisions/0016-logistration-filters.md
@@ -1,0 +1,138 @@
+# 0016. Centralize enterprise logistration logic behind openedx-filters
+
+## Status
+
+Accepted
+
+## Context
+
+The `user_authn` module in openedx-platform
+(`openedx/core/djangoapps/user_authn/`) includes several direct imports of
+enterprise functions from `enterprise_support` and `enterprise` to customize
+login and registration behavior for enterprise learners.  The
+enterprise-specific business logic includes:
+
+- Enriching the legacy logistration page context and the authentication MFE
+  context with enterprise customer branding and sidebar data.
+- Setting/deleting enterprise cookies on the rendered logistration response.
+- Pre-filling and locking the email field on the login form during an enterprise
+  SSO (third-party auth) pipeline.
+- Hiding provider-prefilled registration fields when an enterprise SSO provider
+  skips the registration form.
+- Redirecting learners linked to multiple enterprise customers to the enterprise
+  selection page after login.
+
+These imports make edx-enterprise a hard dependency of core authentication code.
+As part of the broader initiative to convert edx-enterprise into an optional
+Open edX plugin, all `enterprise` / `enterprise_support` imports must be removed
+from openedx-platform and replaced with generic hooks whose enterprise-specific
+implementations live in this repository (edx-enterprise).
+
+## Decision
+
+We will replace the enterprise-specific logic in `user_authn` with six new
+enterprise-agnostic openedx filters, and reimplement the enterprise behavior as
+filter pipeline steps within edx-enterprise:
+
+| openedx-filter (triggered by platform)   | edx-enterprise pipeline step                | Business Logic                                            |
+| ---------------------------------------- | ------------------------------------------- | --------------------------------------------------------- |
+| `LogistrationViewContextGenerated`       | `LogistrationViewEnterpriseContextEnricher` | add enterprise branding, sidebar, slug login URL (legacy) |
+| `AuthnMFEContextGenerated`               | `AuthnMFEEnterpriseContextEnricher`         | add enterprise branding to the authentication MFE context |
+| `LogistrationViewRenderCompleted`        | `LogistrationViewEnterpriseCookieSetter`    | set experiment cookie, delete enterprise customer cookie  |
+| `LoginFormGenerated`                     | `LoginFormEnterpriseOverrides`              | pre-fill and lock email from SSO identity                 |
+| `RegistrationFormGenerated`              | `RegistrationFormEnterpriseOverrides`       | hide prefilled fields when provider skips registration    |
+| `LoginAltRedirectURLRequested`           | `PostLoginEnterpriseRedirect`               | send multi-enterprise learners to selection page          |
+
+These six filters live in the new `authentication` architecture subdomain in openedx-filters.
+
+### Logistration flow (high level)
+
+Each block is a page, an endpoint, or a filter paired with the enterprise
+pipeline step that implements it (shaded).
+
+```mermaid
+%%{init: {"flowchart": {"rankSpacing": 30}}}%%
+flowchart TD
+    classDef ent fill:#d4e6f9,stroke:#1f6feb,color:#0a3069
+
+    LogistrationViewContextGenerated["<b>LogistrationViewContextGenerated</b><br/>→&nbsp;<b>LogistrationViewEnterpriseContextEnricher</b><br/><i>add enterprise branding, sidebar, slug login URL</i>"]:::ent
+    AuthnMFEContextGenerated["<b>AuthnMFEContextGenerated</b><br/>→&nbsp;<b>AuthnMFEEnterpriseContextEnricher</b><br/><i>add enterprise branding to the authn MFE context</i>"]:::ent
+    LogistrationViewRenderCompleted["<b>LogistrationViewRenderCompleted</b><br/>→&nbsp;<b>LogistrationViewEnterpriseCookieSetter</b><br/><i>set experiment cookie, delete enterprise customer cookie</i>"]:::ent
+    LoginFormGenerated["<b>LoginFormGenerated</b><br/>→&nbsp;<b>LoginFormEnterpriseOverrides</b><br/><i>pre-fill and lock email from SSO identity</i>"]:::ent
+    RegistrationFormGenerated["<b>RegistrationFormGenerated</b><br/>→&nbsp;<b>RegistrationFormEnterpriseOverrides</b><br/><i>hide prefilled fields when provider skips registration</i>"]:::ent
+    LoginAltRedirectURLRequested["<b>LoginAltRedirectURLRequested</b><br/>→&nbsp;<b>PostLoginEnterpriseRedirect</b><br/><i>send multi-enterprise learners to selection page</i>"]:::ent
+
+    LP["/login and /register routes<br/>"]
+    MFE["Authn MFE page<br/>(frontend-app-authn)"]
+    FORMS["Login/registration<br/>FormDescription generation"]
+    LOGINPOST["Login session POST endpoint"]
+    REGPOST["Registration POST endpoint"]
+    RENDERED["Legacy /login or /register<br/>template rendered"]
+    SEL["Enterprise selection page"]
+    DEST["Post-login destination"]
+
+    LP -- "else,<br/>use AuthN MFE" --> MFE
+    LP -- "TPA hint or running SAML pipeline:<br/>stay on legacy page" --> LogistrationViewContextGenerated
+    LogistrationViewContextGenerated --> RENDERED
+    RENDERED --> LogistrationViewRenderCompleted
+    LogistrationViewRenderCompleted -- "Get FormDescription<br/>from python API" --> FORMS
+    MFE --> AuthnMFEContextGenerated
+    AuthnMFEContextGenerated -- "Get FormDescription<br/>from REST API" --> FORMS
+    %% invisible edge: pin AuthnMFEContextGenerated to the same rank as
+    %% LogistrationViewContextGenerated so both *ContextGenerated filters render on the same level
+    AuthnMFEContextGenerated ~~~ RENDERED
+    FORMS -- "is /login route" --> LoginFormGenerated
+    FORMS -- "is /register route" --> RegistrationFormGenerated
+    %% invisible edge: pin LoginFormGenerated to the same rank as
+    %% RegistrationFormGenerated so both *FormGenerated filters render on the same level
+    LoginFormGenerated ~~~ REGPOST
+    LoginFormGenerated -- "user submits credentials" --> LOGINPOST
+    RegistrationFormGenerated -- "user submits registration" --> REGPOST
+    LOGINPOST -- "MFE enabled and the request is for first-party auth" --> LoginAltRedirectURLRequested
+    LOGINPOST -- "otherwise" --> DEST
+    LoginAltRedirectURLRequested -- "multiple linked enterprises" --> SEL
+    LoginAltRedirectURLRequested -- "single/no enterprise,<br/>or direct-enrollment" --> DEST
+    SEL -- "continue to original next URL" --> DEST
+    REGPOST -- "account created and logged in" --> DEST
+```
+
+### Integration Testing
+
+As part of this work, the SAML provisioning suite within edx-enterprise (`make
+dev.provision.keycloak`) will be significantly enhanced to support the many
+test scenarios, especially multi-IdP test scenarios.
+
+Additionally, a new integration test script
+`scripts/provision-integration-test-ENT-11568.sh` will facilitate in rendering
+the exact test scenario setup and expected outcomes.
+
+## Consequences
+
+- The entire `user_authn` platform module (`openedx/core/djangoapps/user_authn/`)
+  no longer imports `enterprise_support` or `enterprise`, bringing us one step
+  closer to removing edx-enterprise as a hard platform dependency.
+- Enterprise-specific logistration behavior is now centrally discoverable in one
+  module (`enterprise/filters/logistration.py`) instead of being spread across
+  platform views and `enterprise_support` helpers.
+- The added filters created in service of this ticket can also serve as
+  general-purpose hooks for other logistration-altering plugins.
+
+## Rejected Alternatives
+
+- **Pluggable overrides** — As the primary plugin hook alternative to
+  openedx-filters, pluggable overrides would have been a poor choice
+  semantically because all the hook locations are reasonably general purpose.
+- **Django signals** — rejected: every hook here must return data to the caller
+  (context, form description, redirect URL), which signals do not support well.
+- **Middleware** — rejected: logistration customization is view-specific;
+  middleware would run on every request for logic that applies to a handful of
+  endpoints.  This approach could have significant performance impact.
+
+## References
+
+- JIRA: ENT-11568
+- openedx-filters PR: https://github.com/openedx/openedx-filters/pull/337
+- edx-enterprise PR: https://github.com/openedx/edx-enterprise/pull/2662
+- edx-enterprise PR: https://github.com/openedx/edx-enterprise/pull/2551
+- openedx/openedx-platform PR: https://github.com/openedx/openedx-platform/pull/38105
+- edx/edx-platform PR (2U fork): https://github.com/edx/edx-platform/pull/407

--- a/docs/saml_testing.rst
+++ b/docs/saml_testing.rst
@@ -12,10 +12,16 @@ Prerequisites
 -------------
 
 * A running `devstack <https://github.com/openedx/devstack>`_ environment with
-  the LMS container up.
+  the following containers up and running:
+
+  * ``make dev.up.lms+enterprise-catalog+frontend-app-account+frontend-app-authn``
+
 * The edx-enterprise branch you want to test installed as an editable package
-  inside the LMS container (``/edx/src/edx-enterprise``).
-* Docker Compose (the ``docker compose`` CLI plugin).
+  inside the LMS container (``pip install -e /edx/src/edx-enterprise``).
+
+* The following line added to ``/etc/hosts`` on your host machine:
+
+  * ``127.0.0.1 edx.devstack.keycloak``
 
 Starting Keycloak
 -----------------
@@ -26,10 +32,8 @@ From the **edx-enterprise** repository root:
 
    $ make dev.up.keycloak
 
-This starts a Keycloak 26.x container (``edx.devstack.keycloak``) on the
-devstack Docker network, exposed at ``http://localhost:8080``.  Keycloak data is
-persisted in a Docker volume (``keycloak_data``) so the container can be stopped
-and restarted without losing state.
+This starts a Keycloak container (``edx.devstack.keycloak``) on the
+devstack Docker network, exposed at ``http://localhost:8080``.
 
 Provisioning
 ------------
@@ -40,45 +44,20 @@ Provisioning configures **both** Keycloak and the LMS in a single step:
 
    $ make dev.provision.keycloak
 
-Under the hood this runs two commands:
+Under the hood this accomplishes the following:
 
-1. ``keycloak-config-cli`` imports every realm definition in
-   ``keycloak-realms/`` into Keycloak.  Each file is one tenant realm (currently
-   ``gryffindor`` and ``slytherin``), each with a SAML client and two test users.
-2. ``provision-tpa.py`` runs inside the LMS container and, for each tenant,
-   creates the matching ``SAMLProviderConfig``, the ``EnterpriseCustomer`` link,
-   branding (logo + colors), and a login-flow LMS learner account.  A single
-   shared ``SAMLConfiguration`` (the LMS service-provider config) is created once.
+* [Keycloak] Provisions two "realms" within Keycloak, ``gryffindor`` and ``slytherin``, each representing an IdP.
 
-A "tenant" is one Keycloak realm plus one enterprise customer.  The realm name,
-the SAML slug, the ``provider_id`` (``saml-<name>``), and the enterprise slug are
-all the same arbitrary token (e.g. ``gryffindor``), so one memorable name
-identifies everything about the tenant.  Adding a tenant means dropping a new
-``keycloak-realms/<name>.json`` and adding a matching entry to the ``TENANTS``
-list in ``provision-tpa.py``.
+* [Keycloak] Provisions several Keycloak users within those realms.
 
-Shared configuration (the Keycloak URL, the LMS entity ID, the ACS URL, and the
-attribute OIDs) plus each tenant's SSO usernames live in
-``keycloak-devstack.env``.  The usernames are the single source of truth: the
-realm JSON substitutes them via ``$(env:...)`` and ``provision-tpa.py`` reads the
-same variables, so a username is defined in exactly one place.
+* [LMS] provisions a SAMLConfiguration record to globally enable SAML auth.
 
-The examples below use the ``gryffindor`` tenant; ``slytherin`` behaves
-identically -- substitute its name to test tenant isolation.
+* [LMS] provisions matching LMS records for each of the Keycloak realms:
 
-Host setup
-----------
-
-The LMS redirects to Keycloak using the Docker hostname
-``edx.devstack.keycloak``.  Your browser needs to resolve that name to
-localhost.
-
-Add this line to ``/etc/hosts`` on the machine where your browser runs (your
-laptop, **not** a remote codespace):
-
-.. code-block:: text
-
-   127.0.0.1 edx.devstack.keycloak
+  * EnterpriseCustomer
+  * SAMLProviderConfig + EnterpriseCustomerIdentityProvider (to link the enterprise customer with the Keycloak IdP)
+  * EnterpriseCustomerBrandingConfiguration (to give the login/registration pages a distinctive look)
+  * User + EnterpriseCustomerUser (to provide LMS-side users corresponding to the IdP side users).
 
 Testing the SAML login flow
 ----------------------------
@@ -92,10 +71,10 @@ Testing the SAML login flow
 
 3. Log in with the test credentials:
 
-   =========  =============================
+   =========  ======================
    Username   ``gryffindor_learner``
    Password   ``testpass``
-   =========  =============================
+   =========  ======================
 
 4. Validate that you were **not** prompted to log into the existing LMS user.
    The ``enterprise_associate_by_email`` pipeline step should discover that the
@@ -111,64 +90,25 @@ Testing the SAML login flow
 Testing the SAML disconnect flow
 --------------------------------
 
-Triggering the disconnect via the Account MFE
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-1. Bring up the Account MFE container (devstack runs it on port 1997):
-
-   .. code-block:: bash
-
-      $ make dev.up.frontend-app-account
-
-2. In the same browser session where you completed the SAML login, navigate to
-   the Linked Accounts section:
+1. In the same browser session where you completed the SAML login, navigate to
+   the Linked Accounts section within the Account MFE:
 
    http://localhost:1997/#linked-accounts
 
-3. Find the Gryffindor IdP entry (matches
-   SAMLProviderConfig.name) and click **Unlink Gryffindor IdP
-   account**.
+2. Find the Gryffindor IdP entry and click **Unlink Gryffindor IdP account**.
 
-4. The button should settle into the "unconnected" state with a "Sign in with
+3. The button should settle into the "unconnected" state with a "Sign in with
    Gryffindor IdP" link. indicating the MFE received a successful
    disconnect response.
 
-Verifying the disconnect
-~~~~~~~~~~~~~~~~~~~~~~~~
+Resetting state to repeat tests
+-------------------------------
 
-1. **LMS logs** -- tail the LMS container and grep for the new debug lines:
-
-   .. code-block:: bash
-
-      $ docker logs --tail 500 edx.devstack.lms 2>&1 | grep -E 'SAMLAccountDisconnected|_unlink_enterprise_user_from_idp|successfully unlinked'
-
-   You should see all three lines, in order::
-
-      [THIRD_PARTY_AUTH] Emitting SAMLAccountDisconnected signal for user_id=<id>, backend=tpa-saml
-      [ENTERPRISE] _unlink_enterprise_user_from_idp called for user_id=<id>, backend=tpa-saml
-      Enterprise learner {gryffindor_learner@example.com} successfully unlinked from Enterprise Customer {<name>}
-
-Resetting state to repeat the test
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-The simplest reset is to re-run provisioning:
+The simplest reset is to re-run idempotent provisioning:
 
 .. code-block:: bash
 
    $ make dev.provision.keycloak
-
-Then navigate to the SAML login URL again to re-link:
-
-   http://localhost:18000/auth/login/tpa-saml/?auth_entry=login&idp=gryffindor
-
-Note: re-running provisioning is necessary because when you clicked the
-**Unlink Gryffindor IdP account** button, the SAML disconnect handler
-did more than just disconnect from the IdP, it also unlinked the
-EnterpriseCustomerUser.  This is only recoverable by an admin or system
-operator, hence the need to use the provision script.  Yes, that means in prod
-if a learner accidentally clicks the unlink-from-IdP button, they ALSO get
-unlinked from the enterprise itself and need to reach out to their admin to get
-re-linked to the enterprise.
 
 Stopping Keycloak
 -----------------
@@ -197,9 +137,5 @@ Troubleshooting
 
 **Keycloak admin console**
    The Keycloak admin console is available at
-   ``http://localhost:8080/admin/master/console/`` with credentials
+   ``http://edx.devstack.keycloak:8080/admin/master/console/`` with credentials
    ``admin`` / ``admin``.
-
-**Account MFE shows no linked providers**
-    UserSocialAuth likely has no row for this user -- complete the SAML
-    login first.

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.7.3"
+__version__ = "8.8.0"

--- a/enterprise/filters/logistration.py
+++ b/enterprise/filters/logistration.py
@@ -1,0 +1,302 @@
+"""
+Pipeline steps for the logistration (login/registration) filters.
+"""
+import logging
+import re
+import urllib.parse
+from typing import Any
+
+from crum import get_current_request
+from openedx_filters.authentication.types import FormDescriptionProtocol, ProviderConfigProtocol, RunningPipeline
+from openedx_filters.filters import PipelineStep
+
+from django.conf import settings
+from django.urls import reverse
+
+try:
+    from openedx.core.djangoapps.user_api import accounts
+except ImportError:
+    accounts = None
+
+# ENT-11576: These functions will be migrated from the platform's enterprise_support module
+# into edx-enterprise, eliminating these cross-boundary imports.
+try:
+    from openedx.features.enterprise_support.api import (
+        activate_learner_enterprise,
+        enterprise_customer_for_request,
+        enterprise_enabled,
+        get_enterprise_learner_data_from_api,
+    )
+    from openedx.features.enterprise_support.utils import (
+        build_enterprise_branding_for_authn_mfe,
+        get_enterprise_slug_login_url,
+        handle_enterprise_cookies_for_logistration,
+        update_logistration_context_for_enterprise,
+    )
+except ImportError:
+    activate_learner_enterprise = None
+    enterprise_customer_for_request = None
+    enterprise_enabled = None
+    get_enterprise_learner_data_from_api = None
+    build_enterprise_branding_for_authn_mfe = None
+    get_enterprise_slug_login_url = None
+    handle_enterprise_cookies_for_logistration = None
+    update_logistration_context_for_enterprise = None
+
+log = logging.getLogger(__name__)
+
+UUID4_REGEX = '[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+
+
+def _enterprise_enrollment_url_regex() -> str:
+    """
+    Return the regex matching enterprise direct-enrollment URLs.
+
+    Built lazily because ``settings.COURSE_KEY_REGEX`` is only defined by the platform's
+    settings, not by this package's standalone test settings.
+
+    The customer UUID is captured as ``enterprise_uuid`` so callers can read it off the
+    same match rather than applying a second regex to a different string.
+    """
+    return fr'/enterprise/(?P<enterprise_uuid>{UUID4_REGEX})/course/{settings.COURSE_KEY_REGEX}/enroll'
+
+
+class LogistrationViewEnterpriseContextEnricher(PipelineStep):
+    """
+    Enrich the logistration page context with enterprise customer data.
+
+    This step calls enterprise_customer_for_request to identify the enterprise customer
+    associated with the current SSO session, then delegates to the enterprise_support
+    utilities to update the context with enterprise-specific sidebar content and
+    third-party-auth adjustments. It also injects the enterprise slug login URL and the
+    enterprise-enabled flag consumed by the logistration page's JS.
+    """
+
+    def run_filter(self, context: dict[str, Any]) -> dict[str, Any]:  # pylint: disable=arguments-differ
+        """
+        Enrich context with enterprise customer data.
+        """
+        request = get_current_request()
+        enterprise_customer = enterprise_customer_for_request(request)
+        if enterprise_customer:
+            log.info(
+                "LogistrationViewEnterpriseContextEnricher running: enterprise_customer_uuid=%s",
+                enterprise_customer.get('uuid'),
+            )
+        # Called even without an enterprise customer: it sets
+        # context['enable_enterprise_sidebar'] = False and applies the third-party-auth
+        # error message adjustments regardless of the customer.
+        update_logistration_context_for_enterprise(request, context, enterprise_customer)
+
+        if 'data' in context:
+            context['data']['enterprise_slug_login_url'] = get_enterprise_slug_login_url()
+            context['data']['is_enterprise_enable'] = enterprise_enabled()
+
+        return {'context': context}
+
+
+class AuthnMFEEnterpriseContextEnricher(PipelineStep):
+    """
+    Enrich the authentication MFE context with enterprise branding.
+
+    This step is the authentication MFE counterpart to LogistrationViewEnterpriseContextEnricher. The MFE
+    serves a flat context (as opposed to the legacy combined login/registration page's nested
+    ``context['data']`` shape), so this step only adds the ``enterpriseBranding`` payload
+    consumed by the authentication MFE, looked up from the enterprise customer associated with
+    the current SSO session (``None`` when there is no enterprise customer).
+
+    The payload goes into ``extra_context`` rather than ``context``: the platform's MFE context
+    serializer declares no ``enterpriseBranding`` field, and drops undeclared ``context`` entries.
+    Entries in ``extra_context`` are merged into the served response as-is, so this step owns the
+    shape of its own payload.
+    """
+
+    def run_filter(  # pylint: disable=arguments-differ
+        self, context: dict[str, Any], extra_context: dict[str, Any],
+    ) -> dict[str, Any]:
+        """
+        Add enterprise branding to the authentication MFE context.
+        """
+        request = get_current_request()
+        enterprise_customer = enterprise_customer_for_request(request)
+        extra_context['enterpriseBranding'] = build_enterprise_branding_for_authn_mfe(enterprise_customer)
+        return {'context': context, 'extra_context': extra_context}
+
+
+class LogistrationViewEnterpriseCookieSetter(PipelineStep):
+    """
+    Set or delete enterprise cookies on the rendered logistration response.
+
+    This step runs on every logistration page render (not only for enterprise customers),
+    mirroring the original platform behavior: it sets the ``experiments_is_enterprise``
+    cookie from ``context['enable_enterprise_sidebar']`` and deletes the enterprise
+    customer cookie so that subsequent requests show the default login page.
+    """
+
+    def run_filter(self, response: Any, context: dict[str, Any]) -> dict[str, Any]:  # pylint: disable=arguments-differ
+        """
+        Apply enterprise cookie handling to the logistration response.
+        """
+        handle_enterprise_cookies_for_logistration(get_current_request(), response, context)
+        return {'response': response, 'context': context}
+
+
+class LoginFormEnterpriseOverrides(PipelineStep):
+    """
+    Override login form description fields for enterprise SSO users.
+
+    The filter fires for every login form build, and passes the third-party auth state of the
+    request. When the running pipeline's provider is known and the request is associated with
+    an enterprise customer, the email field is pre-filled from the provider details and made
+    read-only. Otherwise it is a no-op.
+    """
+
+    def run_filter(  # pylint: disable=arguments-differ
+        self,
+        form_desc: FormDescriptionProtocol,
+        running_pipeline: RunningPipeline | None,
+        current_provider: ProviderConfigProtocol | None,
+    ) -> dict[str, Any]:
+        """
+        Apply enterprise SSO overrides to the login form description.
+        """
+        if running_pipeline and current_provider and enterprise_customer_for_request(get_current_request()):
+            log.info(
+                "LoginFormEnterpriseOverrides running: provider=%s",
+                getattr(current_provider, 'provider_id', None),
+            )
+            email = running_pipeline['kwargs']['details'].get('email', '')
+
+            # override the email field.
+            form_desc.override_field_properties(
+                "email",
+                default=email,
+                restrictions={"readonly": "readonly"} if email else {
+                    "min_length": accounts.EMAIL_MIN_LENGTH,
+                    "max_length": accounts.EMAIL_MAX_LENGTH,
+                }
+            )
+
+        return {
+            'form_desc': form_desc,
+            'running_pipeline': running_pipeline,
+            'current_provider': current_provider,
+        }
+
+
+class RegistrationFormEnterpriseOverrides(PipelineStep):
+    """
+    Override registration form description fields for enterprise SSO users.
+
+    The filter fires for every registration form build, and passes the third-party auth state
+    of the request. When the running pipeline's provider is configured to skip the registration
+    form and we are in an enterprise context, we need to hide all fields except for terms of
+    service and ensure that the user explicitly checks that field. Otherwise it is a no-op.
+
+    The platform iterates its known registration fields and skips any without a provider
+    override; this step iterates the provider overrides directly, which is equivalent
+    because providers only return values for standard registration fields.
+    """
+
+    def run_filter(  # pylint: disable=arguments-differ
+        self,
+        form_desc: FormDescriptionProtocol,
+        running_pipeline: RunningPipeline | None,
+        current_provider: ProviderConfigProtocol | None,
+    ) -> dict[str, Any]:
+        """
+        Hide provider-prefilled registration fields (except terms of service) for
+        enterprise SSO registrations.
+        """
+        if (
+                running_pipeline
+                and current_provider
+                and current_provider.skip_registration_form
+                and enterprise_customer_for_request(get_current_request())
+        ):
+            log.info(
+                "RegistrationFormEnterpriseOverrides running: provider=%s",
+                getattr(current_provider, 'provider_id', None),
+            )
+            # Subscripted rather than ``.get()`` for the same reason as above: it preserves the
+            # declared RunningPipelineKwargs shape that get_register_form_data expects.
+            field_overrides = current_provider.get_register_form_data(running_pipeline['kwargs'])
+
+            for field_name, field_default in field_overrides.items():
+                # If SAML provider config has skip_registration_optional_checkboxes=True,
+                # don't hide the marketing_emails_opt_in field (matching the platform's
+                # guard around provider overrides for that field).
+                #
+                # NOTE: [2026-07-22] Reading this flag off current_provider is an intentional
+                # divergence from the legacy platform logic, which ignored current_provider and
+                # re-queried the database (SAMLProviderConfig.objects.current_set().get(slug=...)).
+                # Using the config the running TPA pipeline already resolved is simpler, saves a
+                # query, and reflects the config that actually drove the SSO handshake.
+                #
+                # That said, the old vs. new approach can still disagree in an unlikely corner
+                # case: the new approach leverages a cache-backed value, while the old
+                # queries the DB directly. We already take special care to invalidate the cache
+                # on ``save()``, but not ``delete()``.  This really should NOT have an impact
+                # in prod due to how slowly-changing these values are.
+                if (
+                        field_name == 'marketing_emails_opt_in'
+                        and getattr(current_provider, 'skip_registration_optional_checkboxes', False)
+                ):
+                    continue
+
+                if field_name not in ['terms_of_service', 'honor_code'] and field_default:
+                    form_desc.override_field_properties(
+                        field_name,
+                        field_type="hidden",
+                        default=field_default,
+                        label="",
+                        instructions="",
+                    )
+
+        return {
+            'form_desc': form_desc,
+            'running_pipeline': running_pipeline,
+            'current_provider': current_provider,
+        }
+
+
+class PostLoginEnterpriseRedirect(PipelineStep):
+    """
+    Updates redirect url to enterprise selection page if user is associated
+    with multiple enterprises otherwise return the next url.
+    """
+
+    def run_filter(self, redirect_url: str, user: Any) -> dict[str, Any]:  # pylint: disable=arguments-differ
+        """
+        Return enterprise selection page URL if user is associated with multiple enterprises.
+        """
+        learner_data = get_enterprise_learner_data_from_api(user)
+        if learner_data and len(learner_data) > 1:
+            log.info(
+                "PostLoginEnterpriseRedirect running: user_id=%s linked to %s enterprises",
+                user.id,
+                len(learner_data),
+            )
+            # Check to see if the destination has an enterprise in it. In this case if user is associated
+            # with that enterprise, activate that enterprise and bypass the selection page.
+            url_match = re.match(_enterprise_enrollment_url_regex(), urllib.parse.unquote(redirect_url))
+            if url_match:
+                enterprise_in_url = url_match.group('enterprise_uuid')
+                for enterprise in learner_data:
+                    if enterprise_in_url == str(enterprise['enterprise_customer']['uuid']):
+                        is_activated_successfully = activate_learner_enterprise(
+                            get_current_request(), user, enterprise_in_url,
+                        )
+                        if is_activated_successfully:
+                            # Already scoped to a single enterprise: leave the destination alone.
+                            return {'redirect_url': redirect_url, 'user': user}
+                        break
+
+            # Carry the caller's destination through the selection page as success_url, so the
+            # learner still lands there once they have chosen a customer.
+            selection_url = (
+                reverse('enterprise_select_active') + '/?success_url=' + urllib.parse.quote(redirect_url)
+            )
+            return {'redirect_url': selection_url, 'user': user}
+
+        return {'redirect_url': redirect_url, 'user': user}

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -46,6 +46,30 @@ ENTERPRISE_FILTERS_CONFIG: FiltersConfig = {
         "fail_silently": False,
         "pipeline": ["enterprise.filters.discounts.DiscountEligibilityEnterpriseStep"],
     },
+    "org.openedx.authentication.logistration_view.context.generated.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.logistration.LogistrationViewEnterpriseContextEnricher"],
+    },
+    "org.openedx.authentication.mfe.context.generated.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.logistration.AuthnMFEEnterpriseContextEnricher"],
+    },
+    "org.openedx.authentication.logistration_view.render.completed.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.logistration.LogistrationViewEnterpriseCookieSetter"],
+    },
+    "org.openedx.authentication.login.form.generated.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.logistration.LoginFormEnterpriseOverrides"],
+    },
+    "org.openedx.authentication.registration.form.generated.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.logistration.RegistrationFormEnterpriseOverrides"],
+    },
+    "org.openedx.authentication.login.alt_redirect_url.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.logistration.PostLoginEnterpriseRedirect"],
+    },
 }
 
 

--- a/enterprise/settings/test.py
+++ b/enterprise/settings/test.py
@@ -184,6 +184,7 @@ ECOMMERCE_SERVICE_WORKER_USERNAME = 'ecommerce_worker'
 # These are standard regexes for pulling out info like course_ids, usage_ids, etc.
 COURSE_KEY_PATTERN = r'(?P<course_key_string>[^/+]+(/|\+)[^/+]+(/|\+)[^/?]+)'
 COURSE_ID_PATTERN = COURSE_KEY_PATTERN.replace('course_key_string', 'course_id')
+COURSE_KEY_REGEX = COURSE_KEY_PATTERN.replace('P<course_key_string>', ':')
 
 USE_TZ = True
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -329,6 +329,7 @@ docutils==0.21.2
     # via
     #   -r requirements/doc.txt
     #   doc8
+    #   myst-parser
     #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
@@ -596,8 +597,10 @@ jinja2==3.1.6
     #   -r requirements/test.txt
     #   code-annotations
     #   diff-cover
+    #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinxcontrib-mermaid
 jsondiff==2.2.1
     # via
     #   -r requirements/doc.txt
@@ -631,6 +634,11 @@ lxml[html-clean]==5.3.2
     #   xmlsec
 lxml-html-clean==0.4.4
     # via lxml
+markdown-it-py==4.2.0
+    # via
+    #   -r requirements/doc.txt
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==3.0.3
     # via
     #   -r requirements/doc.txt
@@ -639,6 +647,14 @@ markupsafe==3.0.3
     #   jinja2
 mccabe==0.7.0
     # via pylint
+mdit-py-plugins==0.6.1
+    # via
+    #   -r requirements/doc.txt
+    #   myst-parser
+mdurl==0.1.2
+    # via
+    #   -r requirements/doc.txt
+    #   markdown-it-py
 mock==5.2.0
     # via -r requirements/test.txt
 model-bakery==1.24.0
@@ -651,6 +667,8 @@ msgpack==1.2.1
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
     #   cachecontrol
+myst-parser==5.1.0
+    # via -r requirements/doc.txt
 nh3==0.3.6
     # via
     #   -r requirements/doc.txt
@@ -673,7 +691,7 @@ openedx-events==11.2.0
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
     #   -r requirements/test.txt
-openedx-filters==3.8.0
+openedx-filters==3.9.0
     # via
     #   -r requirements/doc.txt
     #   -r requirements/test-master.txt
@@ -911,7 +929,9 @@ pyyaml==6.0.3
     #   drf-yasg
     #   edx-i18n-tools
     #   jsondiff
+    #   myst-parser
     #   responses
+    #   sphinxcontrib-mermaid
 readme-renderer==45.0
     # via -r requirements/doc.txt
 requests==2.34.2
@@ -1019,8 +1039,10 @@ sphinx==8.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.txt
+    #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx-book-theme
+    #   sphinxcontrib-mermaid
 sphinx-book-theme==1.4.0
     # via -r requirements/doc.txt
 sphinxcontrib-applehelp==2.0.0
@@ -1039,6 +1061,8 @@ sphinxcontrib-jsmath==1.0.1
     # via
     #   -r requirements/doc.txt
     #   sphinx
+sphinxcontrib-mermaid==2.1.0
+    # via -r requirements/doc.txt
 sphinxcontrib-qthelp==2.0.0
     # via
     #   -r requirements/doc.txt

--- a/requirements/doc.in
+++ b/requirements/doc.in
@@ -11,3 +11,5 @@ factory-boy
 readme_renderer           # Validates README.rst for usage on PyPI
 Sphinx                    # Documentation builder
 sphinx-book-theme         # Common theme for all Open edX projects
+sphinxcontrib-mermaid     # Renders mermaid diagrams in docs
+myst-parser               # Markdown (MyST) support for Sphinx docs

--- a/requirements/doc.txt
+++ b/requirements/doc.txt
@@ -195,6 +195,7 @@ docutils==0.21.2
     # via
     #   -r requirements/doc.in
     #   doc8
+    #   myst-parser
     #   pydata-sphinx-theme
     #   readme-renderer
     #   restructuredtext-lint
@@ -363,8 +364,10 @@ jinja2==3.1.6
     # via
     #   -r requirements/test-master.txt
     #   code-annotations
+    #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx
+    #   sphinxcontrib-mermaid
 jsondiff==2.2.1
     # via -r requirements/test-master.txt
 jsonfield==3.2.0
@@ -382,14 +385,24 @@ lxml==5.3.2
     #   -r requirements/test-master.txt
     #   python3-saml
     #   xmlsec
+markdown-it-py==4.2.0
+    # via
+    #   mdit-py-plugins
+    #   myst-parser
 markupsafe==3.0.3
     # via
     #   -r requirements/test-master.txt
     #   jinja2
+mdit-py-plugins==0.6.1
+    # via myst-parser
+mdurl==0.1.2
+    # via markdown-it-py
 msgpack==1.2.1
     # via
     #   -r requirements/test-master.txt
     #   cachecontrol
+myst-parser==5.1.0
+    # via -r requirements/doc.in
 nh3==0.3.6
     # via readme-renderer
 oauthlib==3.3.1
@@ -402,7 +415,7 @@ openedx-atlas==0.7.0
     # via -r requirements/test-master.txt
 openedx-events==11.2.0
     # via -r requirements/test-master.txt
-openedx-filters==3.8.0
+openedx-filters==3.9.0
     # via -r requirements/test-master.txt
 packaging==26.2
     # via
@@ -518,6 +531,8 @@ pyyaml==6.0.3
     #   code-annotations
     #   drf-yasg
     #   jsondiff
+    #   myst-parser
+    #   sphinxcontrib-mermaid
 readme-renderer==45.0
     # via -r requirements/doc.in
 requests==2.34.2
@@ -583,8 +598,10 @@ sphinx==8.2.3
     # via
     #   -c requirements/constraints.txt
     #   -r requirements/doc.in
+    #   myst-parser
     #   pydata-sphinx-theme
     #   sphinx-book-theme
+    #   sphinxcontrib-mermaid
 sphinx-book-theme==1.4.0
     # via -r requirements/doc.in
 sphinxcontrib-applehelp==2.0.0
@@ -595,6 +612,8 @@ sphinxcontrib-htmlhelp==2.1.0
     # via sphinx
 sphinxcontrib-jsmath==1.0.1
     # via sphinx
+sphinxcontrib-mermaid==2.1.0
+    # via -r requirements/doc.in
 sphinxcontrib-qthelp==2.0.0
     # via sphinx
 sphinxcontrib-serializinghtml==2.0.0

--- a/requirements/edx-platform-constraints.txt
+++ b/requirements/edx-platform-constraints.txt
@@ -859,7 +859,7 @@ openedx-events==11.2.0
     #   openedx-authz
     #   openedx-core
     #   ora2
-openedx-filters==3.8.0
+openedx-filters==3.9.0
     # via
     #   -r requirements/edx/kernel.in
     #   edx-enterprise

--- a/requirements/test-master.txt
+++ b/requirements/test-master.txt
@@ -419,7 +419,7 @@ openedx-events==11.2.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in
-openedx-filters==3.8.0
+openedx-filters==3.9.0
     # via
     #   -c requirements/edx-platform-constraints.txt
     #   -r requirements/base.in

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -394,7 +394,7 @@ openedx-atlas==0.7.0
     # via -r requirements/test-master.txt
 openedx-events==11.2.0
     # via -r requirements/test-master.txt
-openedx-filters==3.8.0
+openedx-filters==3.9.0
     # via -r requirements/test-master.txt
 packaging==26.2
     # via

--- a/scripts/provision-integration-test-ENT-11568.sh
+++ b/scripts/provision-integration-test-ENT-11568.sh
@@ -1,19 +1,13 @@
 #!/usr/bin/env bash
 #
-# Provision a devstack environment for integration-testing the six new
-# openedx-filter pipeline steps added in ticket ENT-11568
-# (Logistration Enterprise Context).
+# Provision devstack fixtures for integration-testing the six openedx-filter
+# pipeline steps added in ticket ENT-11568, and print a manual test plan.
 #
-# Instructions:
+# To run this script:
 #
-# 1. Start relevant devstack services:
-#
-#     make dev.up.lms+frontend-app-authn+frontend-app-learner-portal-enterprise
-#
-# 2. From the edx-enterprise directory, provision keycloak and run this script:
-#
-#     make dev.provision.keycloak
-#     ./scripts/provision-integration-test-ENT-11568.sh
+#     [devstack]       make dev.up.lms+enterprise-catalog+frontend-app-authn
+#     [edx-enterprise] make dev.provision.keycloak
+#     [edx-enterprise] ./scripts/provision-integration-test-ENT-11568.sh
 
 set -eu -o pipefail
 
@@ -29,14 +23,15 @@ source "${REPO_ROOT}/keycloak-devstack.env"
 
 set -x
 
-# Username for a learner linked to BOTH enterprises (Gryffindor + Slytherin)
-# to trigger a multi-enterprise drop-down selection interstitial during login.
+# A learner linked to BOTH enterprises, to trigger the multi-enterprise selection page.
 DUAL_LEARNER="dual_enterprise_learner"
 
 LMS_BASE="http://localhost:18000"
+# The authn micro-frontend base URL (settings.AUTHN_MICROFRONTEND_URL).
+AUTHN_MFE_BASE="http://localhost:1999"
 
 # ---------------------------------------------------------------------------
-# Helpers -- run a Django management command inside the LMS container
+# Helpers
 # ---------------------------------------------------------------------------
 
 lms_manage() {
@@ -44,14 +39,36 @@ lms_manage() {
 }
 
 # ---------------------------------------------------------------------------
-# Step 1: Create a learner linked to two enterprises
+# Fixtures
 # ---------------------------------------------------------------------------
-# Create an enterprise learner linked with both enterprises.
-# The first --enterprise-name occurrence is made into the "active" enterprise.
+
+# A learner linked to both enterprises; the first --enterprise-name is the "active" one.
 lms_manage create_enterprise_linked_learner \
     --username "$DUAL_LEARNER" \
     --enterprise-name "$GRYFFINDOR_ENTERPRISE_NAME" \
     --enterprise-name "$SLYTHERIN_ENTERPRISE_NAME"
+
+# Read back the Gryffindor UUID for test 11's ?enterprise_customer=<uuid>. Best-effort.
+GRYFFINDOR_UUID="$(lms_manage shell -c \
+    "from enterprise.models import EnterpriseCustomer; print(EnterpriseCustomer.objects.get(slug='${GRYFFINDOR_REALM}').uuid)" \
+    2>/dev/null | grep -ioE '[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}' | head -n1 || true)"
+
+# ---------------------------------------------------------------------------
+# Preflight: all six pipeline steps must be registered
+# ---------------------------------------------------------------------------
+# Fails if plugin_settings did not inject the mappings (usually a missing
+# ENABLE_ENTERPRISE_INTEGRATION in lms.yml, or edx-enterprise not installed
+# editable in the LMS container).
+
+lms_manage shell -c "
+from django.conf import settings
+config = getattr(settings, 'OPEN_EDX_FILTERS_CONFIG', {})
+found = {k: v['pipeline'] for k, v in sorted(config.items()) if k.startswith('org.openedx.authentication.')}
+for filter_type, pipeline in found.items():
+    print(filter_type, '->', pipeline)
+if len(found) != 6:
+    raise SystemExit('EXPECTED 6 authentication filter mappings, found %d' % len(found))
+"
 
 # ---------------------------------------------------------------------------
 # Summary
@@ -65,157 +82,174 @@ ENT-11568 integration test fixtures provisioned.
 =============================================================================
 
 Enterprises:
-  "${GRYFFINDOR_ENTERPRISE_NAME}"  (slug=${GRYFFINDOR_REALM}; primary tenant)
-  "${SLYTHERIN_ENTERPRISE_NAME}"   (slug=${SLYTHERIN_REALM};  secondary tenant)
+  "${GRYFFINDOR_ENTERPRISE_NAME}"  (slug=${GRYFFINDOR_REALM}; uuid=${GRYFFINDOR_UUID:-<lookup-failed>})
+  "${SLYTHERIN_ENTERPRISE_NAME}"   (slug=${SLYTHERIN_REALM})
 
-Keycloak SSO users (username / password):
-  ${GRYFFINDOR_LEARNER_USERNAME} / testpass    -> matching LMS account -> LOGIN flow
-  ${SLYTHERIN_LEARNER_USERNAME} / testpass     -> matching LMS account -> LOGIN flow
-  ${GRYFFINDOR_NEWCOMER_USERNAME} / testpass   -> no LMS account       -> REGISTRATION flow
-  ${SLYTHERIN_NEWCOMER_USERNAME} / testpass    -> no LMS account       -> REGISTRATION flow
+Keycloak SSO users (password "testpass"):
+  ${GRYFFINDOR_LEARNER_USERNAME}    -> has LMS account   -> LOGIN flow
+  ${SLYTHERIN_LEARNER_USERNAME}     -> has LMS account   -> LOGIN flow
+  ${GRYFFINDOR_NEWCOMER_USERNAME}   -> no LMS account    -> REGISTRATION flow
+  ${SLYTHERIN_NEWCOMER_USERNAME}    -> no LMS account    -> REGISTRATION flow
 
-LMS Learner users (email / password):
-  ${GRYFFINDOR_LEARNER_EMAIL} / edx    -> linked to ${GRYFFINDOR_ENTERPRISE_NAME} only
-  ${SLYTHERIN_LEARNER_EMAIL} / edx     -> linked to ${SLYTHERIN_ENTERPRISE_NAME} only
-  ${DUAL_LEARNER}@example.com / edx    -> linked to BOTH enterprises
+LMS learner users (password "edx"):
+  ${GRYFFINDOR_LEARNER_EMAIL}   -> ${GRYFFINDOR_ENTERPRISE_NAME} only
+  ${SLYTHERIN_LEARNER_EMAIL}    -> ${SLYTHERIN_ENTERPRISE_NAME} only
+  ${DUAL_LEARNER}@example.com   -> BOTH enterprises
 
 -----------------------------------------------------------------------------
-Toggles used below
+Prerequisites
 -----------------------------------------------------------------------------
 
-* Authn MFE:   ENABLE_AUTHN_MICROFRONTEND in your devstack's
-               py_configuration_files/lms.py.  Changing it requires an LMS
-               restart:  docker restart edx.devstack.lms
-* Provider:    SAMLProviderConfig fields (skip_registration_form,
-               send_to_registration_first) via Django admin at
-               ${LMS_BASE}/admin/third_party_auth/samlproviderconfig/ .
-               It is a versioned ConfigurationModel: "add" clones the current
-               values into a new active version; no restart needed.
-               NOTE: re-running \`make dev.provision.keycloak\` recreates the
-               provider with the provisioned defaults, reverting any admin
-               toggle (skip_registration_form=True, send_to_registration_first=True).
+  1. In devstack/configuration_files/lms.yml, then restart the LMS:
+       ENABLE_ENTERPRISE_INTEGRATION: true
+       FEATURES:
+         ENABLE_AUTHN_MICROFRONTEND: true
 
-The enterprise logistration overrides live in the LEGACY logistration code
-path.  The legacy page renders when the Authn MFE is OFF (everyone) OR when the
-MFE is ON and the request is in an enterprise context (the veto in Part B keeps
-enterprise users on the legacy page).
+  2. In /etc/hosts on the machine running the browser:
+       127.0.0.1 edx.devstack.keycloak
 
-=============================================================================
-PART A -- Authn MFE OFF   (set ENABLE_AUTHN_MICROFRONTEND=False, restart LMS)
-=============================================================================
+-----------------------------------------------------------------------------
+LogistrationViewEnterpriseContextEnricher  (legacy page context)
+-----------------------------------------------------------------------------
 
-  1. Test LogistrationContextEnricher (via LogistrationContextRequested).
-     Injects enterprise branding into the logistration page context.
-     a. In a fresh/incognito session (logged out), open:
-        ${LMS_BASE}/login?tpa_hint=saml-${GRYFFINDOR_REALM}
-     Expected: the login page shows an enterprise welcome panel (sidebar)
-        branded for Gryffindor -- you should see the name "Gryffindor" and the
-        Gryffindor crest logo (the branding set by provisioning), with the
-        scarlet/gold house colors.  To confirm the raw data, view page source:
-        the embedded context has "enable_enterprise_sidebar": true and
-        "enterprise_name": "Gryffindor".
+  1. a. Logged out, open:
+        ${LMS_BASE}/login?tpa_hint=saml-${GRYFFINDOR_REALM}&skip_authn_mfe=1
+     Expect: stay on ${LMS_BASE}/login?tpa_hint=saml-${GRYFFINDOR_REALM}&skip_authn_mfe=1
+       with the enterprise sidebar showing the Gryffindor logo and a welcome
+       message naming Gryffindor.
+     b. The other two context values this step sets are request-independent and
+        have no visible effect, so check them once from the CLI:
+        curl -s '${LMS_BASE}/login?skip_authn_mfe=1' | grep -oE '"(is_enterprise_enable|enterprise_slug_login_url)": [^,]*'
+     Expect: exactly these two lines:
+       "enterprise_slug_login_url": "/enterprise/login"
+       "is_enterprise_enable": true
 
-  2. [control] Without enterprise context, LogistrationContextEnricher does nothing.
-     a. In a fresh/incognito session (logged out), open the plain login page:
-        ${LMS_BASE}/login   (no tpa_hint)
-     Expected: the standard login page renders with NO enterprise welcome panel
-        and no enterprise name/logo anywhere.  Page source shows
-        "enable_enterprise_sidebar": false.
+  2. a. Logged out, open:  ${LMS_BASE}/login?skip_authn_mfe=1
+     Expect: stay on ${LMS_BASE}/login?skip_authn_mfe=1 with no enterprise
+       sidebar — just the standard login panel.
 
-  3. Test LogistrationCookieSetter (via LogistrationResponseRendered).
-     Sets the experiments_is_enterprise cookie from enable_enterprise_sidebar.
-     a. Open devtools (Application > Cookies > ${LMS_BASE}), then load:
-        ${LMS_BASE}/login?tpa_hint=saml-${GRYFFINDOR_REALM}
-     Expected: the experiments_is_enterprise cookie exists with value exactly
-        true (JSON).  Optional secondary check: in the Network tab, the /login
-        response's Set-Cookie headers clear the enterprise_customer_uuid cookie
-        (an expired Set-Cookie), preventing a stale enterprise context from
-        persisting.
+-----------------------------------------------------------------------------
+LogistrationViewEnterpriseCookieSetter  (legacy page response cookies)
+-----------------------------------------------------------------------------
 
-  4. [control] Without enterprise context, the cookie value is false.
-     a. Open devtools (Application > Cookies > ${LMS_BASE}), then load the plain
-        login page:  ${LMS_BASE}/login   (no tpa_hint)
-     Expected: the experiments_is_enterprise cookie value is exactly false (JSON).
+  3. a. With devtools open (Application > Cookies > ${LMS_BASE}), load:
+        ${LMS_BASE}/login?tpa_hint=saml-${GRYFFINDOR_REALM}&skip_authn_mfe=1
+     Expect: stay on that URL; experiments_is_enterprise == true, and the
+       enterprise_customer_uuid cookie deleted (Set-Cookie with an empty value /
+       past expiry).
 
-  5. Test RegistrationFormEnterpriseOverrides (via RegistrationFormTPAOverridesRequested).
-     With skip_registration_form=True in an enterprise context, the SSO-prefilled
-     fields are hidden so only Terms of Service remains.  (Provisioned defaults:
-     skip_registration_form=True, send_to_registration_first=True,
-     sync_learner_profile_data=False, so the hiding is attributable to the
-     enterprise step, not the platform's own path.)
-     a. Reset to a clean slate:  make dev.provision.keycloak
-     b. Logged out, start SSO registration:
-        ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=register&idp=${GRYFFINDOR_REALM}
-     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME} (password "testpass").
-     Expected: the registration form shows no editable inputs for full name,
-        public username, or email (they are hidden/pre-filled); effectively only
-        the Terms of Service agreement and the account-creation button remain.
+  4. a. With devtools open, load:  ${LMS_BASE}/login?skip_authn_mfe=1
+     Expect: stay on that URL; experiments_is_enterprise == false.
 
-  6. [control] With skip_registration_form=False, the fields are not hidden.
-     a. In Django admin (${LMS_BASE}/admin/third_party_auth/samlproviderconfig/),
-        add a new provider version with skip_registration_form=False (no restart).
-     b. Logged out, start SSO registration again:
-        ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=register&idp=${GRYFFINDOR_REALM}
-     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME} (password "testpass").
-     Expected: the full registration form renders with the full name, username,
-        and email fields VISIBLE (pre-filled from SSO but editable).
-     Cleanup: make dev.provision.keycloak  (restores skip_registration_form=True).
+-----------------------------------------------------------------------------
+AuthnMFEEnterpriseContextEnricher  (authn MFE context API)
+-----------------------------------------------------------------------------
 
-  7. Test LoginFormEnterpriseOverrides (via LoginFormTPAOverridesRequested).
-     For an enterprise SSO user landing on the login form, the email field is
-     pre-filled and made read-only.  The login form only renders mid-pipeline
-     when the user is NOT sent to registration first, so toggle that off.
-     a. In Django admin (${LMS_BASE}/admin/third_party_auth/samlproviderconfig/),
-        add a new provider version with send_to_registration_first=False.
-     b. Logged out, start SSO login:
-        ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=login&idp=${GRYFFINDOR_REALM}
-     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME} (password "testpass").
-     Expected: the login form's Email field is pre-filled with
-        ${GRYFFINDOR_NEWCOMER_USERNAME}@example.com and is read-only (greyed out; you cannot edit it).
-     Cleanup: make dev.provision.keycloak  (restores send_to_registration_first=True).
-     NOTE: this test is the least settled -- the exact conditions under which the
-     enterprise login-form override renders depend on the SSO/association path.
-     Confirm in-browser and adjust these steps as needed.
+  5. a. curl -s '${LMS_BASE}/api/mfe_context?next=%2Fdashboard&tpa_hint=saml-${GRYFFINDOR_REALM}' | jq .contextData.enterpriseBranding
+     Expect: enterpriseName "Gryffindor", enterpriseSlug "${GRYFFINDOR_REALM}",
+       non-empty enterpriseLogoUrl / enterpriseBrandedWelcomeString /
+       platformWelcomeString.
 
-=============================================================================
-PART B -- Authn MFE ON    (set ENABLE_AUTHN_MICROFRONTEND=True, restart LMS)
-=============================================================================
+  6. a. curl -s '${LMS_BASE}/api/mfe_context?next=%2Fdashboard' | jq .contextData.enterpriseBranding
+     Expect: null.
 
-  8. Test EnterpriseMFERedirectVeto (via LogistrationMFERedirectRequested).
-     In an enterprise context the authn-MFE redirect is vetoed, so the legacy
-     branded page renders instead.
-     a. Logged out, open the enterprise-context login:
-        ${LMS_BASE}/login?tpa_hint=saml-${GRYFFINDOR_REALM}
-     Expected: the browser STAYS on ${LMS_BASE}/login (the address bar host does
-        not change) and renders the legacy Gryffindor-branded page (the same
-        welcome panel/crest as test 1).  It is NOT redirected to the authn MFE.
-     (With the MFE on, tests 1 and 3 also fire here, since the veto renders the
-     legacy page.)
+-----------------------------------------------------------------------------
+RegistrationFormEnterpriseOverrides  (legacy registration form)
+-----------------------------------------------------------------------------
 
-  9. [control] Without enterprise context, the request is redirected to the MFE.
-     a. Logged out, open the plain login page:  ${LMS_BASE}/login   (no tpa_hint)
-     Expected: the browser is redirected away from ${LMS_BASE}/login to the authn
-        micro-frontend (the app at AUTHN_MICROFRONTEND_URL, a different host/port
-        than ${LMS_BASE}).
+  7. skip_registration_form=True (devstack default) hides each field the SSO
+     provider supplied. Devstack asserts only email + first/last name, so only
+     Public Username and Email get hidden.
+     a. Reset:  make dev.provision.keycloak
+     b. Logged out:  ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=register&idp=${GRYFFINDOR_REALM}
+     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME}.
+     Expect: land on ${LMS_BASE}/register with Public Username and Email hidden;
+       Full Name and Country/Region visible, editable, empty; Terms of Service +
+       create button remain.
 
-=============================================================================
-PART C -- post-login redirect   (independent of the Authn MFE toggle)
-=============================================================================
+  8. skip_registration_form=False hides nothing.
+     a. In admin, add a provider version with skip_registration_form=False.
+     b. Logged out:  ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=register&idp=${GRYFFINDOR_REALM}
+     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME}.
+     Expect: land on ${LMS_BASE}/register with every field VISIBLE. Platform TPA
+       prefill fills Public Username (read-only) and Email (editable); Full Name
+       and Country/Region empty and editable.
+     Cleanup:  make dev.provision.keycloak
 
-  10. Test PostLoginEnterpriseRedirect (via PostLoginRedirectURLRequested).
-      A learner belonging to more than one enterprise is redirected to the
-      enterprise-selection page after login.
-      a. Log in with email/password as  ${DUAL_LEARNER}@example.com / edx
-      Expected: after login the browser lands on the enterprise selection page --
-         the address bar shows /enterprise/select/active/?success_url=... -- and
-         the page prompts you to choose between Gryffindor and Slytherin instead
-         of loading the dashboard.
+-----------------------------------------------------------------------------
+LoginFormEnterpriseOverrides  (legacy login form)
+-----------------------------------------------------------------------------
 
-  11. [control] A single-enterprise learner is not redirected to the selection page.
-      a. Log in with email/password as  ${GRYFFINDOR_LEARNER_USERNAME}@example.com / edx
-         (the baseline's Gryffindor SSO learner, linked to Gryffindor only; use its
-         LMS password "edx" here, not its Keycloak password "testpass").
-      Expected: no selection page; the learner proceeds straight to the normal
-         post-login destination (the ${LMS_BASE}/dashboard learner dashboard).
+  9. The login form only renders when the asserted email has an LMS account but
+     NO social-auth link and NO ECU for the IdP, and provisioning does not clear
+     a social-auth link from a prior login, so delete both explicitly.
+     a. Reset:  make dev.provision.keycloak
+     b. Delete the learner's social-auth link + enterprise membership (keeps the account):
+        docker exec -i edx.devstack.lms python manage.py lms --settings devstack shell -c "from django.contrib.auth import get_user_model; from enterprise.models import EnterpriseCustomerUser; from social_django.models import UserSocialAuth; uid = get_user_model().objects.get(username='${GRYFFINDOR_LEARNER_USERNAME}').id; print(UserSocialAuth.objects.filter(user_id=uid).delete()); print(EnterpriseCustomerUser.objects.filter(user_id=uid).delete())"
+     c. Logged out:  ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=login&idp=${GRYFFINDOR_REALM}
+     d. Authenticate at Keycloak as ${GRYFFINDOR_LEARNER_USERNAME}.
+     Expect: land on ${LMS_BASE}/login with Email pre-filled
+       ${GRYFFINDOR_LEARNER_EMAIL} and read-only. Do NOT submit (it would re-link).
+     Cleanup:  make dev.provision.keycloak
+
+-----------------------------------------------------------------------------
+Authn MFE redirect matrix  (login_form.py, no enterprise term left)
+-----------------------------------------------------------------------------
+
+ 10. [B2C -> MFE]
+     a. Logged out, open:  ${LMS_BASE}/login
+     Expect: land on ${AUTHN_MFE_BASE}/login.
+
+ 11. [B2B non-SAML -> MFE]
+     a. Logged out, open:
+        ${LMS_BASE}/login?enterprise_customer=${GRYFFINDOR_UUID:-<gryffindor-uuid>}
+     Expect: land on
+        ${AUTHN_MFE_BASE}/login?enterprise_customer=${GRYFFINDOR_UUID:-<gryffindor-uuid>}
+       and NOT ${LMS_BASE}/login.
+
+ 12. [SAML pipeline -> legacy]
+     a. Reset:  make dev.provision.keycloak
+     b. Logged out:  ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=login&idp=${GRYFFINDOR_REALM}
+     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME}.
+     Expect: land on ${LMS_BASE}/register (send_to_registration_first=True is the
+       devstack default) with Gryffindor branding, and never on ${AUTHN_MFE_BASE}.
+
+-----------------------------------------------------------------------------
+PostLoginEnterpriseRedirect  (login_user; only runs with the authn MFE enabled)
+-----------------------------------------------------------------------------
+
+ 13. a. Open ${AUTHN_MFE_BASE}/login and sign in as
+        ${DUAL_LEARNER}@example.com / edx
+     Expect: land on ${LMS_BASE}/enterprise/select/active/?success_url=%2Fdashboard
+       and NOT ${LMS_BASE}/dashboard.
+
+ 14. a. Open ${AUTHN_MFE_BASE}/login and sign in as
+        ${GRYFFINDOR_LEARNER_EMAIL} / edx
+     Expect: land on ${LMS_BASE}/dashboard, with no stop at
+       ${LMS_BASE}/enterprise/select/active/.
+
+-----------------------------------------------------------------------------
+Regression: TPA form dispatch (platform behavior, unchanged by this ticket)
+-----------------------------------------------------------------------------
+
+ 15. send_to_registration_first=True sends a brand-new SSO user arriving via
+     auth_entry=login to registration. The guard is
+     \`skip_email_verification OR send_to_registration_first\`, so hold
+     skip_email_verification=False to isolate it.
+     a. Reset:  make dev.provision.keycloak
+     b. In admin, add a version with skip_email_verification=False,
+        send_to_registration_first=True.
+     c. Logged out:  ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=login&idp=${GRYFFINDOR_REALM}
+     d. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME}.
+     Expect: land on ${LMS_BASE}/register.
+     Cleanup:  make dev.provision.keycloak
+
+ 16. send_to_registration_first=False keeps the same newcomer on login.
+     a. In admin, add a version with skip_email_verification=False,
+        send_to_registration_first=False.
+     b. Logged out:  ${LMS_BASE}/auth/login/tpa-saml/?auth_entry=login&idp=${GRYFFINDOR_REALM}
+     c. Authenticate at Keycloak as ${GRYFFINDOR_NEWCOMER_USERNAME}.
+     Expect: land on ${LMS_BASE}/login.
+     Cleanup:  make dev.provision.keycloak
 
 EOF

--- a/tests/filters/test_logistration.py
+++ b/tests/filters/test_logistration.py
@@ -1,0 +1,512 @@
+"""
+Tests for enterprise.filters.logistration pipeline steps.
+"""
+from unittest.mock import MagicMock, patch
+
+import ddt
+
+from django.test import RequestFactory, TestCase
+
+from enterprise.filters.logistration import (
+    AuthnMFEEnterpriseContextEnricher,
+    LoginFormEnterpriseOverrides,
+    LogistrationViewEnterpriseContextEnricher,
+    LogistrationViewEnterpriseCookieSetter,
+    PostLoginEnterpriseRedirect,
+    RegistrationFormEnterpriseOverrides,
+)
+
+
+def _make_request():
+    return RequestFactory().get('/')
+
+
+def _learner_data(*uuids):
+    """
+    Build a get_enterprise_learner_data_from_api response for the given enterprise uuids.
+    """
+    return [{'enterprise_customer': {'uuid': uuid}} for uuid in uuids]
+
+
+@ddt.ddt
+class TestLogistrationViewEnterpriseContextEnricher(TestCase):
+    """
+    Tests for the LogistrationViewEnterpriseContextEnricher pipeline step.
+    """
+
+    def _make_step(self):
+        return LogistrationViewEnterpriseContextEnricher(
+            'org.openedx.authentication.logistration_view.context.generated.v1', [],
+        )
+
+    @ddt.data(
+        {'enterprise_customer': {'uuid': 'some-uuid', 'name': 'Acme'}, 'expected_enabled': True},
+        {'enterprise_customer': None, 'expected_enabled': False},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.get_enterprise_slug_login_url', return_value='/enterprise/login')
+    @patch('enterprise.filters.logistration.update_logistration_context_for_enterprise')
+    @patch('enterprise.filters.logistration.enterprise_enabled')
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request')
+    def test_context_updated_unconditionally(
+            self, mock_ecfr, mock_enabled, mock_update, mock_slug_url, mock_get_current_request,
+            enterprise_customer, expected_enabled,
+    ):
+        """
+        The context update and data keys are applied with or without an enterprise customer,
+        matching the original platform behavior (e.g. enable_enterprise_sidebar=False and the
+        third-party-auth error message adjustments also apply to non-enterprise requests).
+        """
+        mock_ecfr.return_value = enterprise_customer
+        mock_enabled.return_value = expected_enabled
+        request = _make_request()
+        mock_get_current_request.return_value = request
+        context = {'data': {}}
+
+        step = self._make_step()
+        result = step.run_filter(context=context)
+
+        mock_update.assert_called_once_with(request, context, enterprise_customer)
+        assert result['context']['data']['enterprise_slug_login_url'] == '/enterprise/login'
+        assert result['context']['data']['is_enterprise_enable'] is expected_enabled
+        assert mock_slug_url.call_count == 1
+
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.get_enterprise_slug_login_url', return_value='/enterprise/login')
+    @patch('enterprise.filters.logistration.update_logistration_context_for_enterprise')
+    @patch('enterprise.filters.logistration.enterprise_enabled', return_value=True)
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request', return_value=None)
+    def test_context_without_data_key(
+            self, _mock_ecfr, _mock_enabled, mock_update, _mock_slug_url, mock_get_current_request,
+    ):
+        """
+        A context without a 'data' key is updated without raising and without adding the key.
+        """
+        request = _make_request()
+        mock_get_current_request.return_value = request
+        context = {}
+
+        step = self._make_step()
+        result = step.run_filter(context=context)
+
+        mock_update.assert_called_once_with(request, context, None)
+        assert 'data' not in result['context']
+
+
+@ddt.ddt
+class TestAuthnMFEEnterpriseContextEnricher(TestCase):
+    """
+    Tests for the AuthnMFEEnterpriseContextEnricher pipeline step.
+    """
+
+    def _make_step(self):
+        return AuthnMFEEnterpriseContextEnricher('org.openedx.authentication.mfe.context.generated.v1', [])
+
+    @ddt.data(
+        {'enterprise_customer': {'uuid': 'some-uuid', 'name': 'Acme'}, 'branding': {'enterpriseName': 'Acme'}},
+        {'enterprise_customer': None, 'branding': None},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.build_enterprise_branding_for_authn_mfe')
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request')
+    def test_branding_added_to_extra_context(
+            self, mock_ecfr, mock_branding, mock_get_current_request,
+            enterprise_customer, branding,
+    ):
+        """
+        The extra context gains an 'enterpriseBranding' key derived from the enterprise customer,
+        which is None when there is no enterprise customer for the request.
+        """
+        mock_ecfr.return_value = enterprise_customer
+        mock_branding.return_value = branding
+        request = _make_request()
+        mock_get_current_request.return_value = request
+        context = {'countryCode': 'US'}
+
+        step = self._make_step()
+        result = step.run_filter(context=context, extra_context={})
+
+        mock_branding.assert_called_once_with(enterprise_customer)
+        assert result['extra_context']['enterpriseBranding'] == branding
+        # The platform's own context is passed through untouched.
+        assert result['context'] == {'countryCode': 'US'}
+
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.build_enterprise_branding_for_authn_mfe')
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request')
+    def test_existing_extra_context_preserved(self, mock_ecfr, mock_branding, mock_get_current_request):
+        """
+        Entries another pipeline step already contributed to the extra context are preserved.
+        """
+        mock_ecfr.return_value = {'uuid': 'some-uuid'}
+        mock_branding.return_value = {'enterpriseName': 'Acme'}
+        mock_get_current_request.return_value = _make_request()
+
+        step = self._make_step()
+        result = step.run_filter(context={}, extra_context={'somethingElse': 'preserved'})
+
+        assert result['extra_context'] == {
+            'somethingElse': 'preserved',
+            'enterpriseBranding': {'enterpriseName': 'Acme'},
+        }
+
+
+class TestLogistrationViewEnterpriseCookieSetter(TestCase):
+    """
+    Tests for the LogistrationViewEnterpriseCookieSetter pipeline step.
+    """
+
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.handle_enterprise_cookies_for_logistration')
+    def test_cookies_handled_unconditionally(self, mock_handle_cookies, mock_get_current_request):
+        """
+        Enterprise cookie handling is applied to every logistration response and all
+        inputs are returned unchanged.
+        """
+        request = _make_request()
+        mock_get_current_request.return_value = request
+        response = MagicMock()
+        context = {'enable_enterprise_sidebar': False}
+
+        step = LogistrationViewEnterpriseCookieSetter(
+            'org.openedx.authentication.logistration_view.render.completed.v1', [],
+        )
+        result = step.run_filter(response=response, context=context)
+
+        mock_handle_cookies.assert_called_once_with(request, response, context)
+        assert result['response'] is response
+        assert result['context'] is context
+
+
+@ddt.ddt
+class TestLoginFormEnterpriseOverrides(TestCase):
+    """
+    Tests for the LoginFormEnterpriseOverrides pipeline step.
+    """
+
+    def _make_step(self):
+        return LoginFormEnterpriseOverrides('org.openedx.authentication.login.form.generated.v1', [])
+
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request', return_value={'uuid': 'some-uuid'})
+    def test_email_overridden_readonly(self, _mock_ecfr):
+        """
+        With a running pipeline provider and an enterprise customer, the email field is
+        pre-filled from the provider details and made read-only.
+        """
+        running_pipeline = {'kwargs': {'details': {'email': 'learner@example.com'}}}
+        current_provider = MagicMock()
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        result = step.run_filter(
+            form_desc=form_desc,
+            running_pipeline=running_pipeline,
+            current_provider=current_provider,
+        )
+
+        form_desc.override_field_properties.assert_called_once_with(
+            'email',
+            default='learner@example.com',
+            restrictions={'readonly': 'readonly'},
+        )
+        assert result['form_desc'] is form_desc
+        assert result['running_pipeline'] is running_pipeline
+        assert result['current_provider'] is current_provider
+
+    @patch('enterprise.filters.logistration.accounts')
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request', return_value={'uuid': 'some-uuid'})
+    def test_email_overridden_with_length_restrictions(self, _mock_ecfr, mock_accounts):
+        """
+        Without an email in the provider details, the email field keeps min/max length
+        restrictions instead of becoming read-only.
+        """
+        mock_accounts.EMAIL_MIN_LENGTH = 3
+        mock_accounts.EMAIL_MAX_LENGTH = 254
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        step.run_filter(
+            form_desc=form_desc,
+            running_pipeline={'kwargs': {'details': {}}},
+            current_provider=MagicMock(),
+        )
+
+        form_desc.override_field_properties.assert_called_once_with(
+            'email',
+            default='',
+            restrictions={'min_length': 3, 'max_length': 254},
+        )
+
+    @ddt.data(
+        {'has_provider': False, 'has_customer': True},
+        {'has_provider': True, 'has_customer': False},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request')
+    def test_noop_without_provider_or_customer(self, mock_ecfr, has_provider, has_customer):
+        """
+        The form description is returned unchanged without a running pipeline provider (e.g.
+        no third-party auth at all) or without an enterprise customer.
+        """
+        mock_ecfr.return_value = {'uuid': 'some-uuid'} if has_customer else None
+        if has_provider:
+            running_pipeline, current_provider = {'kwargs': {'details': {'email': 'x@example.com'}}}, MagicMock()
+        else:
+            running_pipeline, current_provider = None, None
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        result = step.run_filter(
+            form_desc=form_desc,
+            running_pipeline=running_pipeline,
+            current_provider=current_provider,
+        )
+
+        form_desc.override_field_properties.assert_not_called()
+        assert result['form_desc'] is form_desc
+        assert result['running_pipeline'] is running_pipeline
+        assert result['current_provider'] is current_provider
+
+
+@ddt.ddt
+class TestRegistrationFormEnterpriseOverrides(TestCase):
+    """
+    Tests for the RegistrationFormEnterpriseOverrides pipeline step.
+    """
+
+    def _make_step(self):
+        return RegistrationFormEnterpriseOverrides(
+            'org.openedx.authentication.registration.form.generated.v1', [],
+        )
+
+    def _make_provider(self, field_overrides, skip_registration_form=True, skip_optional_checkboxes=False):
+        """
+        Build a mock third-party-auth provider with registration form data.
+        """
+        provider = MagicMock()
+        provider.skip_registration_form = skip_registration_form
+        provider.skip_registration_optional_checkboxes = skip_optional_checkboxes
+        provider.get_register_form_data.return_value = field_overrides
+        return provider
+
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request', return_value={'uuid': 'some-uuid'})
+    def test_fields_hidden_except_tos(self, _mock_ecfr):
+        """
+        Provider-prefilled fields are hidden except terms of service and honor code; fields
+        with falsy override values are skipped.
+        """
+        provider = self._make_provider({
+            'email': 'learner@example.com',
+            'name': 'Learner',
+            'username': '',
+            'honor_code': True,
+            'terms_of_service': True,
+        })
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        step.run_filter(form_desc=form_desc, running_pipeline={'kwargs': {}}, current_provider=provider)
+
+        hidden_fields = {
+            call.args[0] for call in form_desc.override_field_properties.call_args_list
+        }
+        assert hidden_fields == {'email', 'name'}
+        form_desc.override_field_properties.assert_any_call(
+            'email',
+            field_type='hidden',
+            default='learner@example.com',
+            label='',
+            instructions='',
+        )
+
+    @ddt.data(
+        {'skip_optional_checkboxes': True, 'expected_hidden': False},
+        {'skip_optional_checkboxes': False, 'expected_hidden': True},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request', return_value={'uuid': 'some-uuid'})
+    def test_marketing_emails_opt_in_guard(self, _mock_ecfr, skip_optional_checkboxes, expected_hidden):
+        """
+        The marketing_emails_opt_in field is not hidden when the SAML provider config has
+        skip_registration_optional_checkboxes enabled.
+        """
+        provider = self._make_provider(
+            {'marketing_emails_opt_in': 'true'},
+            skip_optional_checkboxes=skip_optional_checkboxes,
+        )
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        step.run_filter(form_desc=form_desc, running_pipeline={'kwargs': {}}, current_provider=provider)
+
+        assert form_desc.override_field_properties.called is expected_hidden
+
+    @ddt.data(
+        {'skip_registration_form': False, 'has_customer': True},
+        {'skip_registration_form': True, 'has_customer': False},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request')
+    def test_noop_without_skip_flag_or_customer(self, mock_ecfr, skip_registration_form, has_customer):
+        """
+        The form description is returned unchanged when the provider does not skip the
+        registration form or the request has no enterprise customer.
+        """
+        provider = self._make_provider(
+            {'email': 'learner@example.com'},
+            skip_registration_form=skip_registration_form,
+        )
+        mock_ecfr.return_value = {'uuid': 'some-uuid'} if has_customer else None
+        running_pipeline = {'kwargs': {}}
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        result = step.run_filter(
+            form_desc=form_desc,
+            running_pipeline=running_pipeline,
+            current_provider=provider,
+        )
+
+        form_desc.override_field_properties.assert_not_called()
+        assert result['form_desc'] is form_desc
+        assert result['running_pipeline'] is running_pipeline
+        assert result['current_provider'] is provider
+
+    @patch('enterprise.filters.logistration.enterprise_customer_for_request')
+    def test_noop_without_running_pipeline(self, mock_ecfr):
+        """
+        The form description is returned unchanged when no third-party auth pipeline is
+        running for the request, without even looking up the enterprise customer.
+        """
+        form_desc = MagicMock()
+
+        step = self._make_step()
+        result = step.run_filter(form_desc=form_desc, running_pipeline=None, current_provider=None)
+
+        form_desc.override_field_properties.assert_not_called()
+        mock_ecfr.assert_not_called()
+        assert result['form_desc'] is form_desc
+        assert result['running_pipeline'] is None
+        assert result['current_provider'] is None
+
+
+@ddt.ddt
+class TestPostLoginEnterpriseRedirect(TestCase):
+    """
+    Tests for the PostLoginEnterpriseRedirect pipeline step.
+    """
+
+    def _make_step(self):
+        return PostLoginEnterpriseRedirect('org.openedx.authentication.login.alt_redirect_url.requested.v1', [])
+
+    def _make_user(self):
+        user = MagicMock()
+        user.id = 42
+        return user
+
+    @ddt.data(
+        {'learner_data': []},
+        {'learner_data': _learner_data('uuid-1')},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.get_enterprise_learner_data_from_api')
+    def test_redirect_unchanged_without_multiple_enterprises(self, mock_learner_data, learner_data):
+        """
+        The redirect URL is returned unchanged when the user is linked to fewer than two
+        enterprises.
+        """
+        mock_learner_data.return_value = learner_data
+
+        step = self._make_step()
+        result = step.run_filter(redirect_url='/dashboard', user=self._make_user())
+
+        assert result['redirect_url'] == '/dashboard'
+
+    @patch(
+        'enterprise.filters.logistration.get_enterprise_learner_data_from_api',
+        return_value=_learner_data('uuid-1', 'uuid-2'),
+    )
+    def test_multiple_enterprises_redirects_to_selection_page(self, _mock_learner_data):
+        """
+        The redirect URL points at the enterprise selection page, with the original URL
+        quoted into success_url, when the user is linked to multiple enterprises.
+        """
+        step = self._make_step()
+        result = step.run_filter(redirect_url='/dashboard', user=self._make_user())
+
+        assert result['redirect_url'] == '/enterprise/select/active/?success_url=/dashboard'
+
+    @ddt.data(
+        {'is_activated': True},
+        {'is_activated': False},
+    )
+    @ddt.unpack
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.activate_learner_enterprise')
+    @patch('enterprise.filters.logistration.get_enterprise_learner_data_from_api')
+    def test_enterprise_enrollment_url_bypasses_selection_page(
+            self, mock_learner_data, mock_activate, mock_get_current_request, is_activated,
+    ):
+        """
+        When the redirect URL is a direct enrollment URL for one of the user's enterprises, that
+        enterprise is activated and, on success, the selection page is bypassed.
+        """
+        enterprise_uuid = '99999999-9999-4999-9999-999999999999'
+        mock_learner_data.return_value = _learner_data(enterprise_uuid, 'uuid-2')
+        mock_activate.return_value = is_activated
+        request = _make_request()
+        mock_get_current_request.return_value = request
+        user = self._make_user()
+        enrollment_url = f'/enterprise/{enterprise_uuid}/course/course-v1:testX+test101+2T2020/enroll/'
+
+        step = self._make_step()
+        result = step.run_filter(redirect_url=enrollment_url, user=user)
+
+        mock_activate.assert_called_once_with(request, user, enterprise_uuid)
+        if is_activated:
+            assert result['redirect_url'] == enrollment_url
+        else:
+            assert result['redirect_url'].startswith('/enterprise/select/active/?success_url=')
+
+    @patch('enterprise.filters.logistration.get_current_request')
+    @patch('enterprise.filters.logistration.activate_learner_enterprise', return_value=True)
+    @patch('enterprise.filters.logistration.get_enterprise_learner_data_from_api')
+    def test_percent_encoded_enrollment_url_bypasses_selection_page(
+            self, mock_learner_data, mock_activate, mock_get_current_request,
+    ):
+        """
+        A percent-encoded enrollment URL (the shape produced when the course key's colon is
+        encoded, plus a query string) is still recognized, and the customer UUID is read from
+        the same match.
+        """
+        enterprise_uuid = '99999999-9999-4999-9999-999999999999'
+        mock_learner_data.return_value = _learner_data(enterprise_uuid, 'uuid-2')
+        request = _make_request()
+        mock_get_current_request.return_value = request
+        user = self._make_user()
+        enrollment_url = (
+            f'/enterprise/{enterprise_uuid}/course/course-v1%3AtestX+test101+2T2020'
+            '/enroll/?catalog=abc&utm_medium=enterprise'
+        )
+
+        step = self._make_step()
+        result = step.run_filter(redirect_url=enrollment_url, user=user)
+
+        mock_activate.assert_called_once_with(request, user, enterprise_uuid)
+        assert result['redirect_url'] == enrollment_url
+
+    @patch(
+        'enterprise.filters.logistration.get_enterprise_learner_data_from_api',
+        side_effect=RuntimeError('API unavailable'),
+    )
+    def test_learner_data_api_error_propagates(self, _mock_learner_data):
+        """
+        Errors from the enterprise learner data API propagate, matching the original
+        platform behavior.
+        """
+        step = self._make_step()
+
+        with self.assertRaises(RuntimeError):
+            step.run_filter(redirect_url='/dashboard', user=self._make_user())

--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = enterprise.settings.test
 deps =
     setuptools
+    Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
Implement steps for five logistration filters replacing logic in the `user_authn` platform module, and register them in `ENTERPRISE_FILTERS_CONFIG`:

- LogistrationContextEnricher (for LogistrationContextRequested)
- LoginFormEnterpriseOverrides (for LoginFormTPAOverridesRequested)
- RegistrationFormEnterpriseOverrides (for RegistrationFormTPAOverridesRequested)
- LogistrationCookieSetter (for LogistrationResponseRendered)
- PostLoginEnterpriseRedirect (for PostLoginRedirectURLRequested)

[ENT-11568](https://2u-internal.atlassian.net/browse/ENT-11568)

---

Integration Testing in 2U Devstack
---

Setup:

1. Launch the required containers:
   - `make dev.up.lms+enterprise-catalog+frontend-app-account+frontend-app-authn`
2. Add this line to `/etc/hosts`:
   - `127.0.0.1 edx.devstack.keycloak`
3. Create the `user_authn.enable_enterprise_redirect_to_authn` waffle flag and enable it globally.

Control Test:

4. Set up your devstack to run the following branches:
   - lms: release-ulmo
   - edx-enterprise: master
5. from edx-enterprise, run two commands:
   - `make dev.provision.keycloak`
   - `./scripts/provision-integration-test-ENT-11568.sh`
6. Follow the script output to conduct entire integration test suite.

Integration Test:

7. Reconfigure your devstack to switch to the new code:
   - lms: pwnage101/ENT-11568-edx
     - `pip install -e /edx/src/edx-enterprise/`
     - `pip install -e /edx/src/openedx-filters/`
   - edx-enterprise: pwnage101/ENT-11568
   - openedx-filters: pwnage101/ENT-11568
8. Repeat steps 5-6 and confirm everything works exactly the same.

---

Related:
* https://github.com/openedx/edx-enterprise/pull/2662
* https://github.com/openedx/openedx-filters/pull/337
* https://github.com/openedx/edx-enterprise/pull/2551
* https://github.com/edx/edx-platform/pull/407
* https://github.com/openedx/openedx-platform/pull/38105
* https://github.com/edx/devstack/pull/227