### PR TITLE
fix: populate name in Invite Admin list view (ENT-11811)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * nothing unreleased
 
+[8.0.9] - 2026-05-07
+---------------------
+* fix: populate name in Invite Admin list view (ENT-11811)
+
 [8.0.8] - 2026-05-06
 ---------------------
 * feat: extra logging for enterprise email association pipeline step

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.8"
+__version__ = "8.0.9"

--- a/enterprise/api/v1/views/enterprise_admin_members.py
+++ b/enterprise/api/v1/views/enterprise_admin_members.py
@@ -6,14 +6,19 @@ from edx_rbac.decorators import permission_required
 from rest_framework import filters, mixins, permissions, viewsets
 from rest_framework.pagination import PageNumberPagination
 
-from django.db.models import CharField, F, Value
-from django.db.models.functions import Coalesce
+from django.db.models import CharField, F, OuterRef, Subquery, Value
+from django.db.models.functions import Coalesce, NullIf
 
 from enterprise import models
 from enterprise.api.v1 import serializers
 from enterprise.api.v1.views.base_views import EnterpriseViewSet
 from enterprise.constants import ENTERPRISE_ADMIN_ROLE
 from enterprise.logging import getEnterpriseLogger
+
+try:
+    from common.djangoapps.student.models import UserProfile
+except ImportError:
+    UserProfile = None
 
 LOGGER = getEnterpriseLogger(__name__)
 
@@ -63,7 +68,27 @@ class EnterpriseAdminMembersViewSet(
         Return annotated ValuesQuerySet of active (joined) admins.
 
         Clears default model ordering to allow safe use with ``.union()``.
+
+        Resolves ``name`` from ``auth_userprofile.name`` when available
+        (the canonical full-name field in edX). Falls back to
+        ``first_name`` and finally ``username`` so the column is always
+        populated.
         """
+        # Build name expression: prefer auth_userprofile.name (where edX
+        # stores user full names), fall back to auth_user.first_name, then
+        # username. UserProfile may be unavailable outside edx-platform
+        # (e.g. unit tests), in which case we drop the profile lookup.
+        name_args = []
+        if UserProfile is not None:  # pragma: no cover
+            profile_name_subquery = UserProfile.objects.filter(
+                user_id=OuterRef("enterprise_customer_user__user_fk__id"),
+            ).values("name")[:1]
+            name_args.append(NullIf(Subquery(profile_name_subquery), Value("")))
+        name_args.extend([
+            NullIf(F("enterprise_customer_user__user_fk__first_name"), Value("")),
+            F("enterprise_customer_user__user_fk__username"),
+        ])
+
         return (
             models.EnterpriseCustomerAdmin.objects.filter(
                 enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid,
@@ -77,11 +102,7 @@ class EnterpriseAdminMembersViewSet(
             )
             .annotate(
                 admin_id=F("enterprise_customer_user__id"),
-                name=Coalesce(
-                    "enterprise_customer_user__user_fk__first_name",
-                    "enterprise_customer_user__user_fk__username",
-                    output_field=CharField(),
-                ),
+                name=Coalesce(*name_args, output_field=CharField()),
                 email=F("enterprise_customer_user__user_fk__email"),
                 invited_date=Value(None, output_field=CharField()),
                 joined_date=F("created"),
@@ -104,14 +125,32 @@ class EnterpriseAdminMembersViewSet(
         Return annotated ValuesQuerySet of pending (invited) admins.
 
         Clears default model ordering to allow safe use with ``.union()``.
+
+        Pending admins do not yet have an ``EnterpriseCustomerUser`` link,
+        so we resolve ``name`` by matching ``user_email`` against any
+        existing ``auth_userprofile`` row. When no profile exists (or the
+        UserProfile model is unavailable), the email is used so the column
+        is always populated.
         """
+        if UserProfile is not None:  # pragma: no cover
+            profile_name_subquery = UserProfile.objects.filter(
+                user__email=OuterRef("user_email"),
+            ).values("name")[:1]
+            name_expression = Coalesce(
+                NullIf(Subquery(profile_name_subquery), Value("")),
+                F("user_email"),
+                output_field=CharField(),
+            )
+        else:
+            name_expression = F("user_email")
+
         return (
             models.PendingEnterpriseCustomerAdminUser.objects.filter(
                 enterprise_customer__uuid=enterprise_uuid,
             )
             .annotate(
                 admin_id=F("id"),
-                name=Value(None, output_field=CharField()),
+                name=name_expression,
                 email=F("user_email"),
                 invited_date=F("created"),
                 joined_date=Value(None, output_field=CharField()),

--- a/tests/test_enterprise/api/test_enterprise_admin_members.py
+++ b/tests/test_enterprise/api/test_enterprise_admin_members.py
@@ -118,17 +118,50 @@ class TestEnterpriseAdminMembersViewSet(APITest):
         assert admin_result["invited_date"] is None
 
     def test_pending_admin_fields(self):
-        """Pending admin record contains expected fields and values."""
+        """Pending admin record contains expected fields and values.
+
+        When the invited email does not match any existing user profile,
+        ``name`` falls back to ``user_email`` so the column is never blank
+        in the admin list view (ENT-11811).
+        """
         response = self.client.get(self.url)
 
         pending_result = next(
             r for r in response.data["results"] if r["status"] == "Pending"
         )
         assert pending_result["id"] == self.pending_admin.id
-        assert pending_result["name"] is None
+        assert pending_result["name"] == "pending@example.com"
         assert pending_result["email"] == "pending@example.com"
         assert pending_result["invited_date"] is not None
         assert pending_result["joined_date"] is None
+
+    def test_active_admin_name_falls_back_to_username_when_first_name_blank(self):
+        """
+        ENT-11811: Active admin without a ``first_name`` (and no
+        ``auth_userprofile.name`` available in the test environment)
+        falls back to ``username`` so the column is never blank.
+        """
+        bare_user = UserFactory(
+            username="bare_admin",
+            first_name="",
+            email="bare@example.com",
+            is_active=True,
+        )
+        bare_ecu = EnterpriseCustomerUserFactory(
+            user_id=bare_user.id,
+            enterprise_customer=self.enterprise_customer,
+        )
+        EnterpriseCustomerAdminFactory(enterprise_customer_user=bare_ecu)
+        assign_admin_role(bare_user, self.enterprise_customer)
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        bare_result = next(
+            r for r in response.data["results"]
+            if r["email"] == "bare@example.com"
+        )
+        assert bare_result["name"] == "bare_admin"
 
     def test_inactive_user_included(self):
         """Admin whose auth_user.is_active=False is still returned so they can be deleted."""
@@ -232,8 +265,9 @@ class TestEnterpriseAdminMembersViewSet(APITest):
 
         assert response.status_code == status.HTTP_200_OK
         names = [r["name"] for r in response.data["results"]]
-        # None (pending) sorts first, then Alpha, then Jane
-        assert names == [None, "Alpha", "Jane"]
+        # Active admins sort by first_name ("Alpha", "Jane"); pending falls
+        # back to the email "pending@example.com" (ENT-11811).
+        assert names == ["Alpha", "Jane", "pending@example.com"]
 
     def test_ordering_by_email(self):
         """Results can be ordered by email ascending."""


### PR DESCRIPTION
## Summary
Fixes [ENT-11811](https://2u-internal.atlassian.net/browse/ENT-11811): Names were not displaying in the Invite Admin list view in the Admin Portal.

## Problem
- **Active admins** resolved `name` from `auth_user.first_name`, which is almost always empty in edX (the canonical full-name field is `auth_userprofile.name`). The list rendered a blank `<h3>` for affected users.
- **Pending admins** had `name=Value(None)` hardcoded in the queryset annotation, so every newly-invited admin returned `null`.

## Changes
`enterprise/api/v1/views/enterprise_admin_members.py`

- `_get_active_admins_qs`: name expression now coalesces `NullIf(profile.name, "") → NullIf(first_name, "") → username`. Uses a `Subquery` against `UserProfile` so it works in environments where the `student` app is not in `INSTALLED_APPS`.
- `_get_pending_admins_qs`: name expression now coalesces `NullIf(profile.name (looked up by email), "") → user_email`. Pending invites for emails matching an existing edX user surface that user's profile name; unmatched invites fall back to the email so the column is never blank.
- `UserProfile` is imported via `try/except ImportError` (matching the existing pattern in `seed_enterprise_devstack_data.py`) so unit tests in this repo continue to run without the student app.

## Test plan
- [x] Unit tests: \`tests/test_enterprise/api/test_enterprise_admin_members.py\` — 21/21 passing. Existing assertions updated to reflect the new fallback behavior; added \`test_active_admin_name_falls_back_to_username_when_first_name_blank\` for the Coalesce chain.
- [x] \`make quality\` clean (pylint, pycodestyle, isort, pii lint, jshint).
- [x] Manual verification in devstack — \`GET /enterprise/api/v1/<uuid>/admins\` across mixed scenarios:
  - Active admin with profile.name set → returns the profile name
  - Pending invite where email matches an existing user with profile.name → returns the profile name
  - Pending invite for a new email → returns the email (no nulls)
  - 0 rows with empty \`name\` across the entire result set
- [x] Verified in the Admin Portal MFE Invite Admin list view: every row shows a name.

## Acceptance Criteria coverage
- [x] After successfully sending an admin invite, Name is populated and visible
- [x] Name appears alongside Email, Invite Date, Role
- [x] Name persists on page reload (sourced from DB on every request)
- [x] No partial or missing values for successfully sent invites

TEST Result
Postman Results

<img width="1275" height="853" alt="image" src="https://github.com/user-attachments/assets/348f7ab6-6794-4344-9685-dd119627245b" />


<img width="1275" height="823" alt="image" src="https://github.com/user-attachments/assets/ec4867a0-89f6-40de-bed6-68f7bc14f8d9" />


<img width="1841" height="844" alt="image" src="https://github.com/user-attachments/assets/58ea51dd-f97c-48cc-acf1-8f283d06a2a5" />

<img width="1820" height="885" alt="image" src="https://github.com/user-attachments/assets/738a04eb-12fc-466f-9b80-2cb5f20be04e" />

<img width="1122" height="691" alt="image" src="https://github.com/user-attachments/assets/56b760b2-a438-453b-9fb5-3958f54e080f" />

<img width="1139" height="824" alt="image" src="https://github.com/user-attachments/assets/564382f5-746e-4b66-9a00-298c7b8f093f" />
