### PR TITLE
fix: emails are displayed in pending customer admin as name and it ha…

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,7 +18,11 @@ Unreleased
 
 * nothing unreleased
 
-[8.0.10] - 2026-05-07
+[8.0.11] - 2026-05-12
+---------------------
+* fix: populate name as blank in Invite Admin list view for pending customer admin (ENT-11811)
+
+[8.0.10] - 2026-05-11
 ---------------------
 * feat: account for data sharing consent settings and mark unenrolled courses in admin enrollment viewset
 

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.10"
+__version__ = "8.0.11"

--- a/enterprise/api/v1/views/enterprise_admin_members.py
+++ b/enterprise/api/v1/views/enterprise_admin_members.py
@@ -60,7 +60,9 @@ class EnterpriseAdminMembersViewSet(
 
     # DRF OrderingFilter settings
     ordering_fields = ["name", "email", "joined_date", "invited_date", "status"]
-    ordering = ["name"]
+    # Add email as secondary sort to ensure deterministic ordering when multiple
+    # records share the same name (e.g., pending admins with blank names).
+    ordering = ["name", "email"]
 
     @classmethod
     def _get_active_admins_qs(cls, enterprise_uuid):
@@ -129,8 +131,7 @@ class EnterpriseAdminMembersViewSet(
         Pending admins do not yet have an ``EnterpriseCustomerUser`` link,
         so we resolve ``name`` by matching ``user_email`` against any
         existing ``auth_userprofile`` row. When no profile exists (or the
-        UserProfile model is unavailable), the email is used so the column
-        is always populated.
+        UserProfile model is unavailable), ``name`` is blank.
         """
         if UserProfile is not None:  # pragma: no cover
             profile_name_subquery = UserProfile.objects.filter(
@@ -138,11 +139,11 @@ class EnterpriseAdminMembersViewSet(
             ).values("name")[:1]
             name_expression = Coalesce(
                 NullIf(Subquery(profile_name_subquery), Value("")),
-                F("user_email"),
+                Value(""),
                 output_field=CharField(),
             )
         else:
-            name_expression = F("user_email")
+            name_expression = Value("", output_field=CharField())
 
         return (
             models.PendingEnterpriseCustomerAdminUser.objects.filter(

--- a/tests/test_enterprise/api/test_enterprise_admin_members.py
+++ b/tests/test_enterprise/api/test_enterprise_admin_members.py
@@ -121,8 +121,7 @@ class TestEnterpriseAdminMembersViewSet(APITest):
         """Pending admin record contains expected fields and values.
 
         When the invited email does not match any existing user profile,
-        ``name`` falls back to ``user_email`` so the column is never blank
-        in the admin list view (ENT-11811).
+        ``name`` is blank (ENT-11811).
         """
         response = self.client.get(self.url)
 
@@ -130,7 +129,7 @@ class TestEnterpriseAdminMembersViewSet(APITest):
             r for r in response.data["results"] if r["status"] == "Pending"
         )
         assert pending_result["id"] == self.pending_admin.id
-        assert pending_result["name"] == "pending@example.com"
+        assert pending_result["name"] == ""
         assert pending_result["email"] == "pending@example.com"
         assert pending_result["invited_date"] is not None
         assert pending_result["joined_date"] is None
@@ -265,9 +264,32 @@ class TestEnterpriseAdminMembersViewSet(APITest):
 
         assert response.status_code == status.HTTP_200_OK
         names = [r["name"] for r in response.data["results"]]
-        # Active admins sort by first_name ("Alpha", "Jane"); pending falls
-        # back to the email "pending@example.com" (ENT-11811).
-        assert names == ["Alpha", "Jane", "pending@example.com"]
+        # Active admins sort by first_name ("Alpha", "Jane"); pending has
+        # blank name so appears first (ENT-11811).
+        assert names == ["", "Alpha", "Jane"]
+
+    def test_default_ordering_with_multiple_pending_admins(self):
+        """Multiple pending admins with blank names sort stably by email."""
+        # Create additional pending admin to test tie-breaking by email.
+        PendingEnterpriseCustomerAdminUserFactory(
+            enterprise_customer=self.enterprise_customer,
+            user_email="zebra@example.com",  # Will have blank name, sorts after 'pending@example.com'
+        )
+
+        response = self.client.get(self.url)
+
+        assert response.status_code == status.HTTP_200_OK
+        # Extract (name, email) pairs to verify stable secondary ordering.
+        results = [(r["name"], r["email"]) for r in response.data["results"]]
+        # Both pending admins have blank names; they sort by email.
+        # Active admin (Jane) sorts by name; pending (blank names)
+        # appear first, sorted by email within the blank-name group.
+        expected = [
+            ("", "pending@example.com"),  # Pending, blank name, sorts by email
+            ("", "zebra@example.com"),     # Pending, blank name, sorts by email after first pending
+            ("Jane", "jane@example.com"),
+        ]
+        assert results == expected
 
     def test_ordering_by_email(self):
         """Results can be ordered by email ascending."""


### PR DESCRIPTION
# [ENT-11811] Fix: Display Admin Name in Invite Admin List
https://2u-internal.atlassian.net/browse/ENT-11811

## Issue
The Name field in the Invite Admin list did not behave correctly for pending admin records. For pending invites without profile name data, the UI showed the email value in the Name column instead of leaving it blank.

## Fix
Updated the enterprise admin members API logic so pending admin records no longer fall back to email for the `name` field. If `UserProfile.name` is missing or empty, `name` is returned as a blank string.

## Changes
- Updated pending admin name mapping in `EnterpriseAdminMembersViewSet._get_pending_admins_qs`
- Removed email fallback for pending admin `name`
- Updated API tests to validate blank pending names
- Updated default name-ordering test expectation for pending entries

## Test Coverage
### Unit Tests
- `tests/test_enterprise/api/test_enterprise_admin_members.py::TestEnterpriseAdminMembersViewSet::test_pending_admin_fields`
- `tests/test_enterprise/api/test_enterprise_admin_members.py::TestEnterpriseAdminMembersViewSet::test_default_ordering_is_by_name`

### Verification
- Targeted pending-admin test run in `test-shell`: ✅ passed

## Acceptance Criteria
- ✅ Name is blank for pending admin entries when profile name is not available
- ✅ Email, Invite Date, and Role/Status fields still render correctly
- ✅ Name behavior remains stable on page reload/API re-fetch
- ✅ Relevant test cases updated and passing

Test screen shots:
API testing
<img width="1659" height="879" alt="image" src="https://github.com/user-attachments/assets/6d6c0ce5-e3ec-45af-83c8-f0fcdf746745" />
Admin people management screen
<img width="1908" height="871" alt="image" src="https://github.com/user-attachments/assets/88f9bd22-6243-469c-b6f4-1bad34f3cd12" />
