### PR TITLE
fix: dashboard filter step now obtains the request via crum instead of filter context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -18,6 +18,10 @@ Unreleased
 
 * nothing unreleased
 
+[8.0.12] - 2026-05-13
+---------------------
+* fix: dashboard filter step now fetches the live request via crum instead of expecting it in the filter context (ENT-11569)
+
 [8.0.11] - 2026-05-12
 ---------------------
 * fix: populate name as blank in Invite Admin list view for pending customer admin (ENT-11811)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.11"
+__version__ = "8.0.12"

--- a/enterprise/filters/dashboard.py
+++ b/enterprise/filters/dashboard.py
@@ -3,6 +3,7 @@ Pipeline steps for the student dashboard filter.
 """
 from typing import Any
 
+from crum import get_current_request
 from openedx_filters.filters import PipelineStep
 
 # These imports will be replaced with internal paths in epic 17 when enterprise_support is
@@ -30,12 +31,13 @@ class DashboardContextEnricher(PipelineStep):
         """
         Inject enterprise data into the dashboard context.
         """
-        request = context.get('request')
         user = context.get('user')
         course_enrollments = context.get('course_enrollments', [])
 
         if user is None:
             return {'context': context, 'template_name': template_name}
+
+        request = get_current_request()
 
         enterprise_message = get_dashboard_consent_notification(request, user, course_enrollments)
 

--- a/tests/filters/test_dashboard.py
+++ b/tests/filters/test_dashboard.py
@@ -13,6 +13,7 @@ FILTER_TYPE = "org.openedx.learning.dashboard.render.started.v1"
 _CONSENT_PATH = 'enterprise.filters.dashboard.get_dashboard_consent_notification'
 _PORTAL_PATH = 'enterprise.filters.dashboard.get_enterprise_learner_portal_context'
 _IS_ENTERPRISE_PATH = 'enterprise.filters.dashboard.is_enterprise_learner'
+_GET_CURRENT_REQUEST_PATH = 'enterprise.filters.dashboard.get_current_request'
 
 
 class TestDashboardContextEnricher(TestCase):
@@ -49,14 +50,14 @@ class TestDashboardContextEnricher(TestCase):
         user = self._make_user()
         enrollments = [MagicMock()]
         context = {
-            'request': request,
             'user': user,
             'course_enrollments': enrollments,
         }
         template_name = 'student/dashboard.html'
 
         step = self._make_step()
-        result = step.run_filter(context=context, template_name=template_name)
+        with patch(_GET_CURRENT_REQUEST_PATH, return_value=request):
+            result = step.run_filter(context=context, template_name=template_name)
 
         assert result['template_name'] == template_name
         result_context = result['context']
@@ -80,13 +81,13 @@ class TestDashboardContextEnricher(TestCase):
         request = self._make_request()
         user = self._make_user()
         context = {
-            'request': request,
             'user': user,
         }
         template_name = 'student/dashboard.html'
 
         step = self._make_step()
-        result = step.run_filter(context=context, template_name=template_name)
+        with patch(_GET_CURRENT_REQUEST_PATH, return_value=request):
+            result = step.run_filter(context=context, template_name=template_name)
 
         result_context = result['context']
         assert result_context['enterprise_message'] == ''
@@ -95,9 +96,9 @@ class TestDashboardContextEnricher(TestCase):
     def test_returns_unchanged_context_when_no_user(self):
         """
         When no user is present in context, the step returns context unchanged without calling
-        any enterprise helper functions.
+        any enterprise helper functions or attempting to fetch the current request.
         """
-        context = {'request': MagicMock()}
+        context = {}
         template_name = 'student/dashboard.html'
 
         step = self._make_step()
@@ -123,13 +124,35 @@ class TestDashboardContextEnricher(TestCase):
         request = self._make_request()
         user = self._make_user()
         context = {
-            'request': request,
             'user': user,
             # no 'course_enrollments' key
         }
         template_name = 'student/dashboard.html'
 
         step = self._make_step()
-        step.run_filter(context=context, template_name=template_name)
+        with patch(_GET_CURRENT_REQUEST_PATH, return_value=request):
+            step.run_filter(context=context, template_name=template_name)
 
         mock_consent.assert_called_once_with(request, user, [])
+
+    @patch(_IS_ENTERPRISE_PATH, return_value=False)
+    @patch(_PORTAL_PATH, return_value={})
+    @patch(_CONSENT_PATH, return_value='')
+    @patch(_GET_CURRENT_REQUEST_PATH, return_value=None)
+    def test_tolerates_no_current_request(
+        self, _mock_get_request, mock_consent, mock_portal, _mock_is_enterprise
+    ):
+        """
+        When crum cannot supply a request (e.g. tests or admin commands invoking the filter
+        outside a request cycle), the step still runs and forwards ``None`` to the downstream
+        helpers, which are expected to handle the missing request themselves.
+        """
+        user = self._make_user()
+        context = {'user': user, 'course_enrollments': []}
+        template_name = 'student/dashboard.html'
+
+        step = self._make_step()
+        step.run_filter(context=context, template_name=template_name)
+
+        mock_consent.assert_called_once_with(None, user, [])
+        mock_portal.assert_called_once_with(None)


### PR DESCRIPTION
It was always bogus to expect the request to be in the context object because it was never in there to begin with, and nothing changed to add it in there.  It would be weird to put the request in there anyway, so just use crum instead.

ENT-11569

---

Testing
===

BEFORE:
<img width="1217" height="994" alt="Screenshot 2026-05-13 at 16 47 23" src="https://github.com/user-attachments/assets/e257d354-f162-4ef5-bd6c-2fd9e7745048" />

AFTER:
<img width="1388" height="667" alt="Screenshot 2026-05-13 at 16 44 52" src="https://github.com/user-attachments/assets/d00750ac-a41e-4e4f-963d-f97966b2a816" />
