### PR TITLE
feat: Removing the feature flag able to learner and admin tab

### DIFF
--- a/enterprise/toggles.py
+++ b/enterprise/toggles.py
@@ -104,18 +104,6 @@ EDIT_HIGHLIGHTS_ENABLED = WaffleFlag(
     ENTERPRISE_LOG_PREFIX,
 )
 
-# .. toggle_name: enterprise.invite_admins_enabled
-# .. toggle_implementation: WaffleFlag
-# .. toggle_default: False
-# .. toggle_description: Enables the invite admins on people management page.
-# .. toggle_use_cases: open_edx
-# .. toggle_creation_date: 2026-01-06
-INVITE_ADMINS_ENABLED = WaffleFlag(
-    f'{ENTERPRISE_NAMESPACE}.invite_admins_enabled',
-    __name__,
-    ENTERPRISE_LOG_PREFIX,
-)
-
 # .. toggle_name: enterprise.ai_pathways_operator_enabled
 # .. toggle_implementation: WaffleFlag
 # .. toggle_default: False
@@ -185,16 +173,9 @@ def enterprise_edit_highlights_enabled():
     return EDIT_HIGHLIGHTS_ENABLED.is_enabled()
 
 
-def enterprise_invite_admins_enabled():
-    """
-    Returns whether the invite admins feature flag is enabled.
-    """
-    return INVITE_ADMINS_ENABLED.is_enabled()
-
-
 def enterprise_ai_pathways_operator_enabled():
     """
-    Returns whether the invite admins feature flag is enabled.
+    Returns whether the AI pathways operator feature flag is enabled..
     """
     return AI_PATHWAYS_OPERATOR_ENABLED.is_enabled()
 
@@ -212,6 +193,5 @@ def enterprise_features():
         'catalog_query_search_filters_enabled': catalog_query_search_filters_enabled(),
         'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled(),
         'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled(),
-        'enterprise_invite_admins_enabled': enterprise_invite_admins_enabled(),
         'enterprise_ai_pathways_operator_enabled': enterprise_ai_pathways_operator_enabled(),
     }

--- a/tests/test_enterprise/api/test_filters.py
+++ b/tests/test_enterprise/api/test_filters.py
@@ -308,7 +308,6 @@ class TestEnterpriseLinkedUserFilterBackend(APITest):
                     'catalog_query_search_filters_enabled': False,
                     'enterprise_admin_onboarding_enabled': False,
                     'enterprise_edit_highlights_enabled': False,
-                    'enterprise_invite_admins_enabled': False,
                     'enterprise_ai_pathways_operator_enabled': False,
                 }
             }

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -84,7 +84,6 @@ from enterprise.toggles import (
     ENTERPRISE_CUSTOMER_SUPPORT_TOOL,
     ENTERPRISE_LEARNER_BFF_ENABLED,
     FEATURE_PREQUERY_SEARCH_SUGGESTIONS,
-    INVITE_ADMINS_ENABLED,
     TOP_DOWN_ASSIGNMENT_REAL_TIME_LCM,
 )
 from enterprise.utils import (
@@ -2154,7 +2153,6 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
             catalog_query_search_filters_enabled,
             enterprise_admin_onboarding_enabled,
             enterprise_edit_highlights_enabled,
-            enterprise_invite_admins_enabled,
             enterprise_ai_pathways_operator_enabled,
             mock_get_logo_url,
     ):
@@ -2259,13 +2257,6 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
             )
         with override_waffle_flag(
-            INVITE_ADMINS_ENABLED,
-            active=enterprise_invite_admins_enabled
-        ):
-            response = client.get(
-                f"{settings.TEST_SERVER}{ENTERPRISE_CUSTOMER_WITH_ACCESS_TO_ENDPOINT}?{urlencode(query_params, True)}"
-            )
-        with override_waffle_flag(
             AI_PATHWAYS_OPERATOR_ENABLED,
             active=enterprise_ai_pathways_operator_enabled
         ):
@@ -2346,7 +2337,6 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                     'catalog_query_search_filters_enabled': catalog_query_search_filters_enabled,
                     'enterprise_admin_onboarding_enabled': enterprise_admin_onboarding_enabled,
                     'enterprise_edit_highlights_enabled': enterprise_edit_highlights_enabled,
-                    'enterprise_invite_admins_enabled': enterprise_invite_admins_enabled,
                     'enterprise_ai_pathways_operator_enabled': enterprise_ai_pathways_operator_enabled,
                 }
             }


### PR DESCRIPTION
### **Description:**


This PR removes the enterprise_invite_admins_enabled feature flag and enables the Learners tab and Admin tab functionality for all customers by default. The goal of this task is to:

  1. Remove all conditional rendering based on the enterprise_invite_admins_enabled feature flag.
  2. Remove feature flag references from Redux state and component props.
  3. Clean up unused imports and related dead code.
  4. Update and maintain unit tests to align with the new default behavior.
  5. Ensure all customers can access the Learners tab and Admin tab along with their existing functionalities.


### **Jira:**

[ENT-11269](https://2u-internal.atlassian.net/browse/ENT-11269)


### **Merge checklist:**

 - [ ]  Removed all conditional rendering based on the enterprise_invite_admins_enabled feature flag.
- [ ]  Removed feature flag usage from Redux and component props.
- [ ]  Cleaned up unused imports and obsolete code paths.
- [ ]  Verified Learners tab and Admin tab functionality is visible for all customers.
- [ ]  Updated unit tests and ensured all tests are passing


### **TESTING:**

- Unit test cases were updated and executed successfully for the related code changes.
- Verified that:
     -  Learners tab is visible without feature flag dependency.
     -  Admin tab and its functionalities are accessible for all customers.
     -  No feature flag checks remain in the codebase.
-  All existing and updated unit tests are passing successfully.