### PR TITLE
fix: format integration and SSO configuration created/modified datetimes as ISO-8601

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.0.17] - 2026-06-05
+---------------------
+* fix: format integration and SSO configuration created/modified datetimes as ISO-8601
+
 [8.0.16] - 2026-06-02
 ---------------------
 * feat: remove enterprise_invite_admins_enabled feature flag and related conditional behavior (ENT-11269)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.16"
+__version__ = "8.0.17"

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -2603,8 +2603,8 @@ def get_integrations_for_customers(customer_uuid):
         if integration is not None:
             unique_integrations.append({
                 'channel_code': code,
-                'created': datetime.datetime.strftime(integration.get('created'), '%B %d, %Y'),
-                'modified': datetime.datetime.strftime(integration.get('modified'), '%B %d, %Y'),
+                'created': integration.get('created').isoformat(),
+                'modified': integration.get('modified').isoformat(),
                 'display_name': integration.get('display_name'),
                 'active': integration.get('active'),
             })
@@ -2626,8 +2626,8 @@ def get_active_sso_configurations_for_customer(customer_uuid):
     if sso_configurations:
         for sso_configuration in sso_configurations:
             active_configurations.append({
-                'created': datetime.datetime.strftime(sso_configuration.get('created'), '%B %d, %Y'),
-                'modified': datetime.datetime.strftime(sso_configuration.get('modified'), '%B %d, %Y'),
+                'created': sso_configuration.get('created').isoformat(),
+                'modified': sso_configuration.get('modified').isoformat(),
                 'active': sso_configuration.get('active'),
                 'display_name': sso_configuration.get('display_name'),
             })

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -1902,8 +1902,8 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'enable_one_academy': False,
                 'active_integrations': [{
                     'channel_code': 'BLACKBOARD',
-                    'created': datetime.strftime(datetime.now(), '%B %d, %Y'),
-                    'modified': datetime.strftime(datetime.now(), '%B %d, %Y'),
+                    'created': mock.ANY,
+                    'modified': mock.ANY,
                     'display_name': 'BLACKBOARD 1',
                     'active': True,
                 }],
@@ -2041,9 +2041,9 @@ class TestEnterpriseCustomerViewSet(BaseTestEnterpriseAPIViews):
                 'country': 'US',
                 'enable_slug_login': False,
                 'active_sso_configurations': [{
-                    'created': datetime.strftime(datetime.now(), '%B %d, %Y'),
+                    'created': mock.ANY,
                     'display_name': 'Test SSO',
-                    'modified': datetime.strftime(datetime.now(), '%B %d, %Y'),
+                    'modified': mock.ANY,
                     'active': True,
                 }],
                 'created': '2021-10-20T19:01:31Z',


### PR DESCRIPTION
Updates the created/modifed datetimes for integrations and sso configs to ISO-8601 compliant format, rather than human-readable strings.

This fixes a long-standing issue with serialization in the enterprise-access BFF.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
