### PR TITLE
test: refactor the seed_enterprise_devstack_data command to be more composable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,13 +20,13 @@ jobs:
     env:
       RUNJSHINT: true
     steps:
-    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
-    - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
+    - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Setup Nodejs
-      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
       with:
         node-version-file: '.nvmrc'
     - run: pip install -r requirements/ci.txt
@@ -36,7 +36,7 @@ jobs:
       run: tox
     - name: Run code coverage
       if: matrix.python-version == '3.12' && matrix.toxenv == 'django52' # Only run this once as part of tests
-      uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
+      uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
       with:
         flags: unittests
         fail_ci_if_error: true

--- a/enterprise/devstack_api.py
+++ b/enterprise/devstack_api.py
@@ -1,0 +1,378 @@
+"""
+Helper functions for devstack provisioning of enterprise test data.
+
+These functions are composable building blocks used by management commands
+(seed_enterprise_devstack_data, create_enterprise_linked_learner,
+enroll_enterprise_learner) to set up enterprise fixtures in a local devstack
+environment.  Each function is idempotent and operates on model instances
+rather than string identifiers so that callers can compose them freely from
+Python as well as from the CLI.
+"""
+
+import logging
+from typing import Any
+
+from opaque_keys import InvalidKeyError
+from opaque_keys.edx.keys import CourseKey
+
+from django.contrib import auth
+from django.contrib.auth.base_user import AbstractBaseUser
+from django.contrib.sites.models import Site
+from django.db import transaction
+from django.db.utils import IntegrityError
+from django.utils.text import slugify
+
+from consent.models import DataSharingConsent
+from enterprise.constants import (
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_CATALOG_ADMIN_ROLE,
+    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+    ENTERPRISE_DATA_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
+    ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+)
+from enterprise.models import (
+    EnterpriseCourseEnrollment,
+    EnterpriseCustomer,
+    EnterpriseCustomerCatalog,
+    EnterpriseCustomerUser,
+    EnterpriseFeatureRole,
+    EnterpriseFeatureUserRoleAssignment,
+    SystemWideEnterpriseRole,
+    SystemWideEnterpriseUserRoleAssignment,
+)
+
+try:
+    from common.djangoapps.student.models import CourseEnrollment, UserProfile
+except ImportError:
+    CourseEnrollment = None
+    UserProfile = None
+
+LOGGER = logging.getLogger(__name__)
+User = auth.get_user_model()
+Group = auth.models.Group
+
+CATALOG_CONTENT_FILTER = {'content_type': 'courserun'}
+
+
+def get_or_create_site() -> Site:
+    """
+    Returns the default devstack site (example.com), creating it if needed.
+
+    Returns:
+        The Site instance for example.com.
+    """
+    site, _ = Site.objects.get_or_create(
+        name='example.com',
+        defaults={'domain': 'example.com'},
+    )
+    return site
+
+
+def ensure_enterprise_groups() -> None:
+    """Ensures the enterprise data API and enrollment API Django groups exist."""
+    Group.objects.get_or_create(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
+    Group.objects.get_or_create(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
+
+
+def get_or_create_enterprise_customer(name: str, site: Site | None = None) -> EnterpriseCustomer:
+    """
+    Returns an EnterpriseCustomer with the given name, creating it if needed.
+
+    The created customer uses devstack-friendly defaults (both learner portal
+    and data sharing consent enabled).
+
+    Args:
+        name: The name of the enterprise customer. The slug used for lookup
+          and creation is derived from this via django.utils.text.slugify.
+        site: An optional Site instance to associate with the customer.
+          Passing it avoids an extra query when the caller already holds a
+          Site instance. Defaults to the result of get_or_create_site().
+
+    Returns:
+        The existing or newly created EnterpriseCustomer instance.
+    """
+    if site is None:
+        site = get_or_create_site()
+    enterprise_customer, _ = EnterpriseCustomer.objects.get_or_create(
+        slug=slugify(name),
+        defaults={
+            'name': name,
+            'site': site,
+            'country': 'US',
+            'enable_learner_portal': True,
+            'enable_data_sharing_consent': True,
+            'enable_portal_code_management_screen': True,
+            'enable_portal_reporting_config_screen': True,
+            'enable_portal_saml_configuration_screen': True,
+            'enable_portal_subscription_management_screen': True,
+            'enable_portal_lms_configurations_screen': True,
+        },
+    )
+    return enterprise_customer
+
+
+def get_or_create_enterprise_catalog(enterprise_customer: EnterpriseCustomer) -> EnterpriseCustomerCatalog:
+    """
+    Returns an EnterpriseCustomerCatalog for the given customer, creating it if needed.
+
+    Args:
+        enterprise_customer: The EnterpriseCustomer that owns the catalog.
+
+    Returns:
+        The existing or newly created EnterpriseCustomerCatalog titled
+        "All Course Runs" with a course-run-only content filter.
+    """
+    catalog, _ = EnterpriseCustomerCatalog.objects.get_or_create(
+        title='All Course Runs',
+        enterprise_customer=enterprise_customer,
+        defaults={'content_filter': CATALOG_CONTENT_FILTER},
+    )
+    return catalog
+
+
+def get_or_create_user(username: str, is_staff: bool = False) -> AbstractBaseUser:
+    """
+    Returns a User with the given username, creating it if needed.
+
+    New users are created with email "{username}@example.com" and password
+    "edx". A UserProfile row is also ensured when the platform UserProfile
+    model is importable.
+
+    Args:
+        username: The username for the user to look up or create.
+        is_staff: If True, the created user is marked as Django staff. Has
+          no effect when the user already exists.
+
+    Returns:
+        The existing or newly created User instance.
+    """
+    try:
+        with transaction.atomic():
+            user = User.objects.create_user(
+                username=username,
+                email=f'{username}@example.com',
+                password='edx',
+                is_staff=is_staff,
+            )
+        LOGGER.info('Created user: %s', username)
+    except IntegrityError:
+        user = User.objects.get(username=username)
+        LOGGER.info('Using existing user: %s', username)
+
+    UserProfile.objects.update_or_create(
+        user=user,
+        defaults={'name': 'Test Enterprise User'},
+    )
+
+    return user
+
+
+def get_or_create_enterprise_user(
+    username: str,
+    role: str,
+    enterprise_customer: EnterpriseCustomer | None = None,
+    applies_to_all_contexts: bool = False,
+) -> dict[str, Any] | None:
+    """
+    Creates or retrieves a user with the given enterprise role.
+
+    Adds the user to the appropriate Django groups and creates system-wide
+    and feature role assignments.
+
+    Args:
+        username: The username for the user to look up or create.
+        role: One of ENTERPRISE_LEARNER_ROLE, ENTERPRISE_ADMIN_ROLE, or
+          ENTERPRISE_OPERATOR_ROLE. Any other value is treated as
+          unrecognised and causes the function to return None.
+        enterprise_customer: The EnterpriseCustomer to scope the role
+          assignment to. Omit (or pass None) together with
+          applies_to_all_contexts=True for operator/super-admin users.
+        applies_to_all_contexts: If True, the system-wide role assignment
+          applies across all enterprise contexts rather than the specific
+          enterprise_customer.
+
+    Returns:
+        A dict with "user" and "role" keys describing the resulting
+        assignment, or None if role is not one of the recognised values.
+    """
+    valid_roles = [ENTERPRISE_LEARNER_ROLE, ENTERPRISE_ADMIN_ROLE, ENTERPRISE_OPERATOR_ROLE]
+    if role not in valid_roles:
+        LOGGER.warning('User not created. Role %s not recognised.', role)
+        return None
+
+    is_staff = role == ENTERPRISE_OPERATOR_ROLE
+    user = get_or_create_user(username, is_staff=is_staff)
+
+    _add_user_to_groups(user, role)
+    _create_system_wide_role_assignment(user, role, enterprise_customer, applies_to_all_contexts)
+    _create_feature_role_assignments(user, role)
+
+    return {'user': user, 'role': role}
+
+
+def link_user_to_enterprise(
+    user: AbstractBaseUser,
+    enterprise_customer: EnterpriseCustomer,
+    active: bool = True,
+) -> tuple[EnterpriseCustomerUser, bool]:
+    """
+    Creates or updates an EnterpriseCustomerUser linking a user to an enterprise.
+
+    Args:
+        user: The User to link.
+        enterprise_customer: The EnterpriseCustomer to link the user to.
+        active: Whether the link should be marked active. Updates the
+          active flag on an existing link.
+
+    Returns:
+        A tuple of (ecu, created) where ecu is the EnterpriseCustomerUser
+        instance and created is True if it was created on this call.
+    """
+    ecu, created = EnterpriseCustomerUser.objects.update_or_create(
+        user_id=user.pk,
+        enterprise_customer=enterprise_customer,
+        defaults={'active': active},
+    )
+    LOGGER.info(
+        '%s EnterpriseCustomerUser: user=%s enterprise=%s active=%s',
+        'Created' if created else 'Updated',
+        user.username,
+        enterprise_customer.name,
+        active,
+    )
+    return ecu, created
+
+
+def enroll_learner_in_course(
+    user: AbstractBaseUser,
+    course_id: str,
+    enterprise_customer: EnterpriseCustomer,
+    mode: str = 'audit',
+    grant_dsc: bool = False,
+) -> None:
+    """
+    Enrolls a user in a course under an enterprise customer.
+
+    Creates (idempotently):
+      - a platform CourseEnrollment
+      - an EnterpriseCourseEnrollment
+      - a DataSharingConsent record (granted=grant_dsc)
+
+    Args:
+        user: The User to enroll.
+        course_id: The course-run key (e.g. "course-v1:edX+DemoX+Demo_Course").
+        enterprise_customer: The EnterpriseCustomer that owns the
+          subsidized enrollment.
+        mode: The CourseEnrollment mode to use when creating the platform
+          enrollment. Has no effect when the platform enrollment already
+          exists.
+        grant_dsc: Whether the DataSharingConsent record should be marked
+          as granted.
+
+    Raises:
+        ValueError: course_id is not a valid course key.
+        EnterpriseCustomerUser.DoesNotExist: user is not already linked to
+            enterprise_customer. Callers must catch this and surface a
+            friendlier message (e.g. by calling link_user_to_enterprise
+            first, or by translating the exception at the CLI boundary).
+    """
+    try:
+        course_key = CourseKey.from_string(course_id)
+    except InvalidKeyError as exc:
+        raise ValueError(f"Invalid course key: '{course_id}'.") from exc
+
+    try:
+        ecu = EnterpriseCustomerUser.objects.get(
+            user_id=user.pk, enterprise_customer=enterprise_customer,
+        )
+    except EnterpriseCustomerUser.DoesNotExist:
+        LOGGER.exception(
+            "User '%s' is not linked to enterprise '%s'. "
+            "Call link_user_to_enterprise first.",
+            user.username, enterprise_customer.name,
+        )
+        raise
+
+    enrollment, created = CourseEnrollment.objects.get_or_create(
+        user=user,
+        course_id=course_key,
+        defaults={'mode': mode, 'is_active': True},
+    )
+    if not created and not enrollment.is_active:
+        enrollment.activate()
+    LOGGER.info(
+        '%s CourseEnrollment: user=%s course=%s mode=%s',
+        'Created' if created else 'Found existing', user.username, course_id, mode,
+    )
+
+    _, created = EnterpriseCourseEnrollment.objects.get_or_create(
+        enterprise_customer_user=ecu,
+        course_id=course_id,
+    )
+    LOGGER.info(
+        '%s EnterpriseCourseEnrollment: user=%s course=%s enterprise=%s',
+        'Created' if created else 'Found existing',
+        user.username, course_id, enterprise_customer.name,
+    )
+
+    _, created = DataSharingConsent.objects.update_or_create(
+        username=user.username,
+        course_id=course_id,
+        enterprise_customer=enterprise_customer,
+        defaults={'granted': grant_dsc},
+    )
+    LOGGER.info(
+        '%s DataSharingConsent: user=%s course=%s enterprise=%s granted=%s',
+        'Created' if created else 'Updated',
+        user.username, course_id, enterprise_customer.name, grant_dsc,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers (not part of the public API)
+# ---------------------------------------------------------------------------
+
+def _add_user_to_groups(user: AbstractBaseUser, role: str) -> None:
+    """Adds non-learner users to the enterprise data/enrollment API groups."""
+    if role == ENTERPRISE_LEARNER_ROLE:
+        return
+    Group.objects.get(name=ENTERPRISE_DATA_API_ACCESS_GROUP).user_set.add(user)
+    Group.objects.get(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP).user_set.add(user)
+
+
+def _create_system_wide_role_assignment(
+    user: AbstractBaseUser,
+    role: str,
+    enterprise_customer: EnterpriseCustomer | None,
+    applies_to_all_contexts: bool,
+) -> None:
+    """Creates a system-wide role assignment if one does not already exist."""
+    system_role, _ = SystemWideEnterpriseRole.objects.get_or_create(name=role)
+    kwargs = {
+        'user': user,
+        'role': system_role,
+        'applies_to_all_contexts': applies_to_all_contexts,
+    }
+    if enterprise_customer is not None:
+        kwargs['enterprise_customer'] = enterprise_customer
+    if not SystemWideEnterpriseUserRoleAssignment.objects.filter(**kwargs).exists():
+        SystemWideEnterpriseUserRoleAssignment.objects.create(**kwargs)
+
+
+def _create_feature_role_assignments(user: AbstractBaseUser, role: str) -> None:
+    """Creates feature role assignments for admin/operator users."""
+    if role == ENTERPRISE_LEARNER_ROLE:
+        return
+    feature_roles = [
+        ENTERPRISE_CATALOG_ADMIN_ROLE,
+        ENTERPRISE_DASHBOARD_ADMIN_ROLE,
+        ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
+        ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+    ]
+    for feature_role_name in feature_roles:
+        feature_role, _ = EnterpriseFeatureRole.objects.get_or_create(name=feature_role_name)
+        EnterpriseFeatureUserRoleAssignment.objects.get_or_create(user=user, role=feature_role)

--- a/enterprise/management/commands/create_enterprise_linked_learner.py
+++ b/enterprise/management/commands/create_enterprise_linked_learner.py
@@ -1,0 +1,72 @@
+"""
+Management command for creating a learner linked to one or more enterprise customers.
+"""
+
+import logging
+
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise.devstack_api import get_or_create_user, link_user_to_enterprise
+from enterprise.models import EnterpriseCustomer
+
+LOGGER = logging.getLogger(__name__)
+
+
+class Command(BaseCommand):
+    """
+    Management command for creating a learner linked to one or more enterprise customers.
+
+    The first --enterprise-name is set as the active enterprise; all subsequent ones are inactive.
+    Useful for testing multi-enterprise scenarios such as active-enterprise mismatch.
+
+    Example usage:
+        $ ./manage.py lms create_enterprise_linked_learner \
+              --username dual_linked_learner \
+              --enterprise-name "Test Enterprise" \
+              --enterprise-name "Other Enterprise"
+    """
+
+    help = 'Create a learner user and link them to one or more enterprise customers.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--username',
+            required=True,
+            help='Username of the learner to create or retrieve.',
+        )
+        parser.add_argument(
+            '--enterprise-name',
+            action='append',
+            dest='enterprise_names',
+            required=True,
+            metavar='ENTERPRISE_NAME',
+            help=(
+                'Name of an enterprise customer to link the learner to. '
+                'Repeatable. The first value is set as the active enterprise; '
+                'all subsequent values are inactive.'
+            ),
+        )
+
+    def handle(self, *args, **options):
+        username = options['username']
+        enterprise_names = options['enterprise_names']
+
+        if len(set(enterprise_names)) != len(enterprise_names):
+            raise CommandError(
+                "Duplicate --enterprise-name values are not allowed. "
+                "Passing the same enterprise twice would overwrite the link and flip it inactive."
+            )
+
+        user = get_or_create_user(username)
+
+        for index, name in enumerate(enterprise_names):
+            try:
+                enterprise_customer = EnterpriseCustomer.objects.get(name=name)
+            except EnterpriseCustomer.DoesNotExist as exc:
+                raise CommandError(f"EnterpriseCustomer with name '{name}' does not exist.") from exc
+            link_user_to_enterprise(user, enterprise_customer, active=index == 0)
+
+        LOGGER.info(
+            'Done. User %s linked to %d enterprise(s). Active: %s',
+            username, len(enterprise_names), enterprise_names[0],
+        )

--- a/enterprise/management/commands/enroll_enterprise_learner.py
+++ b/enterprise/management/commands/enroll_enterprise_learner.py
@@ -1,0 +1,109 @@
+"""
+Management command for enrolling a learner in a course under a specific enterprise customer.
+"""
+
+import logging
+
+from django.contrib import auth
+from django.core.management.base import BaseCommand, CommandError
+
+from enterprise.devstack_api import enroll_learner_in_course
+from enterprise.models import EnterpriseCustomer, EnterpriseCustomerUser
+
+LOGGER = logging.getLogger(__name__)
+User = auth.get_user_model()
+
+
+class Command(BaseCommand):
+    """
+    Management command for enrolling a learner in a course under a specific enterprise customer.
+
+    Creates a platform CourseEnrollment, an EnterpriseCourseEnrollment, and a
+    DataSharingConsent record. The DSC record is ungranted by default; pass
+    --grant-dsc to mark it as granted.
+
+    Requires the learner to already be linked to the enterprise (via
+    EnterpriseCustomerUser). Run create_enterprise_linked_learner first if needed.
+
+    Example usage:
+        $ ./manage.py lms enroll_enterprise_learner \
+              --username my_learner \
+              --course-id course-v1:edX+DemoX+Demo_Course \
+              --enterprise-name "Test Enterprise"
+
+        $ ./manage.py lms enroll_enterprise_learner \
+              --username my_learner \
+              --course-id course-v1:edX+DemoX+Demo_Course \
+              --enterprise-name "Other Enterprise" \
+              --grant-dsc
+    """
+
+    help = 'Enroll a learner in a course under a specific enterprise customer.'
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--username',
+            required=True,
+            help='Username of the learner to enroll.',
+        )
+        parser.add_argument(
+            '--course-id',
+            required=True,
+            dest='course_id',
+            help='Course key to enroll the learner in (e.g. course-v1:edX+DemoX+Demo_Course).',
+        )
+        parser.add_argument(
+            '--enterprise-name',
+            required=True,
+            dest='enterprise_name',
+            help='Name of the enterprise customer to link the enrollment to.',
+        )
+        parser.add_argument(
+            '--mode',
+            default='audit',
+            help='Enrollment mode (default: audit).',
+        )
+        parser.add_argument(
+            '--grant-dsc',
+            action='store_true',
+            default=False,
+            dest='grant_dsc',
+            help='Mark the DataSharingConsent record as granted. Default is ungranted.',
+        )
+
+    def handle(self, *args, **options):
+        username = options['username']
+        enterprise_name = options['enterprise_name']
+
+        try:
+            user = User.objects.get(username=username)
+        except User.DoesNotExist as exc:
+            raise CommandError(f"User '{username}' does not exist.") from exc
+
+        try:
+            enterprise_customer = EnterpriseCustomer.objects.get(name=enterprise_name)
+        except EnterpriseCustomer.DoesNotExist as exc:
+            raise CommandError(
+                f"EnterpriseCustomer with name '{enterprise_name}' does not exist."
+            ) from exc
+
+        try:
+            enroll_learner_in_course(
+                user=user,
+                course_id=options['course_id'],
+                enterprise_customer=enterprise_customer,
+                mode=options['mode'],
+                grant_dsc=options['grant_dsc'],
+            )
+        except EnterpriseCustomerUser.DoesNotExist as exc:
+            raise CommandError(
+                f"User '{username}' is not linked to enterprise '{enterprise_name}'. "
+                "Run create_enterprise_linked_learner first."
+            ) from exc
+        except ValueError as exc:
+            raise CommandError(str(exc)) from exc
+
+        LOGGER.info(
+            'Done. Enrolled %s in %s under enterprise "%s" (DSC granted=%s).',
+            username, options['course_id'], enterprise_name, options['grant_dsc'],
+        )

--- a/enterprise/management/commands/seed_enterprise_devstack_data.py
+++ b/enterprise/management/commands/seed_enterprise_devstack_data.py
@@ -1,49 +1,24 @@
 """
-Management command for assigning enterprise roles to existing enterprise users.
+Management command for seeding a single enterprise customer and its users in devstack.
 """
 
 import json
 import logging
 import textwrap
 
-from django.contrib import auth
-from django.contrib.sites.models import Site
 from django.core.management.base import BaseCommand
-from django.db.utils import IntegrityError
-from django.utils.text import slugify
 
-from enterprise.constants import (
-    ENTERPRISE_ADMIN_ROLE,
-    ENTERPRISE_CATALOG_ADMIN_ROLE,
-    ENTERPRISE_DASHBOARD_ADMIN_ROLE,
-    ENTERPRISE_DATA_API_ACCESS_GROUP,
-    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
-    ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
-    ENTERPRISE_LEARNER_ROLE,
-    ENTERPRISE_OPERATOR_ROLE,
-    ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
+from enterprise.constants import ENTERPRISE_ADMIN_ROLE, ENTERPRISE_LEARNER_ROLE, ENTERPRISE_OPERATOR_ROLE
+from enterprise.devstack_api import (
+    ensure_enterprise_groups,
+    get_or_create_enterprise_catalog,
+    get_or_create_enterprise_customer,
+    get_or_create_enterprise_user,
+    get_or_create_site,
+    link_user_to_enterprise,
 )
-from enterprise.models import (
-    EnterpriseCustomer,
-    EnterpriseCustomerCatalog,
-    EnterpriseCustomerUser,
-    EnterpriseFeatureRole,
-    EnterpriseFeatureUserRoleAssignment,
-    SystemWideEnterpriseRole,
-    SystemWideEnterpriseUserRoleAssignment,
-)
-
-try:
-    from common.djangoapps.student.models import UserProfile
-except ImportError:
-    UserProfile = None
 
 LOGGER = logging.getLogger(__name__)
-User = auth.get_user_model()
-Group = auth.models.Group
-CATALOG_CONTENT_FILTER = {
-    'content_type': 'courserun',
-}
 
 
 class Command(BaseCommand):
@@ -52,285 +27,93 @@ class Command(BaseCommand):
 
     Example usage:
         $ ./manage.py lms seed_enterprise_devstack_data
+        $ ./manage.py lms seed_enterprise_devstack_data --enterprise-name "Acme Corp"
     """
+
     help = '''
-    Seeds an enterprise customer, users of various roles and permissions initial
+    Seeds an enterprise customer, users of various roles and permissions, and initial
     data in devstack for related Enterprise models.
     '''
 
     def add_arguments(self, parser):
-        """
-        Entry point for subclassed commands to add custom arguments.
-        """
         parser.add_argument(
             '--enterprise-name',
             action='store',
-            dest='enterprise-name',
+            dest='enterprise_name',
             default='Test Enterprise',
             help='Name of enterprise to be created. Defaults to "Test Enterprise".'
         )
 
-    def _get_default_site(self):
-        """ Gets or creates the default devstack site example.com """
-        site = Site.objects.get_or_create(name='example.com')
-        return site
-
-    def _create_enterprise_customer(self, name, site):
-        """ Gets or creates an EnterpriseCustomer """
-        enterprise_customer, __ = EnterpriseCustomer.objects.get_or_create(
-            name=name,
-            site_id=site.id,
-            slug=slugify(name),
-            country='US',
-            defaults={
-                'country': 'US',
-                'enable_learner_portal': True,
-                'enable_data_sharing_consent': True,
-                'enable_portal_code_management_screen': True,
-                'enable_portal_reporting_config_screen': True,
-                'enable_portal_saml_configuration_screen': True,
-                'enable_portal_subscription_management_screen': True,
-                'enable_portal_lms_configurations_screen': True,
-            },
-        )
-        return enterprise_customer
-
-    def _create_catalog_for_enterprise(self, enterprise_customer):
-        """ Gets or creates a catalog for an EnterpriseCustomer """
-        catalog, __ = EnterpriseCustomerCatalog.objects.get_or_create(
-            title='All Course Runs',
-            enterprise_customer=enterprise_customer,
-            content_filter=CATALOG_CONTENT_FILTER,
-        )
-        return catalog
-
-    def _create_enterprise_data_api_group(self):
-        """ Ensures the `ENTERPRISE_DATA_API_ACCESS_GROUP` is created """
-        Group.objects.get_or_create(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
-
-    def _create_enterprise_enrollment_api_group(self):
-        """ Ensures the `ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP` is created """
-        Group.objects.get_or_create(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
-
-    def _create_enterprise_user(self, username, role, enterprise_customer=None, applies_to_all_contexts=False):
-        """
-        Creates a new user with the specified `username` and `role` (e.g.,
-        'enterprise_learner'). The newly created user is added to the
-        appropriate Django groups (e.g., data api access) and creates
-        system-wide and feature role assignments.
-        """
-        valid_roles = [
-            ENTERPRISE_LEARNER_ROLE,
-            ENTERPRISE_ADMIN_ROLE,
-            ENTERPRISE_OPERATOR_ROLE,
-        ]
-        if role in valid_roles:
-            is_staff = role == ENTERPRISE_OPERATOR_ROLE
-            try:
-                user = User.objects.create_user(
-                    email='{username}@example.com'.format(username=username),
-                    username=username,
-                    password='edx',
-                    is_staff=is_staff,
-                )
-            except IntegrityError:
-                # If a user we attempt to create in this method already exists but with
-                # slightly different parameters, we will attempt to use the existing user.
-                user = User.objects.get(username=username)
-            if user:
-                self._add_name_to_user_profile(user)
-                self._add_user_to_groups(user=user, role=role)
-                self._create_system_wide_role_assignment(
-                    user=user,
-                    role=role,
-                    enterprise_customer=enterprise_customer,
-                    applies_to_all_contexts=applies_to_all_contexts,
-                )
-                self._create_feature_role_assignments(user=user, role=role)
-                return {
-                    "user": user,
-                    "role": role,
-                }
-        else:
-            LOGGER.warning('\nUser not created. Role %s not recognized.', role)
-        return None
-
-    def _add_name_to_user_profile(self, user):
-        """ Adds a name to a user's profile. """
-        if not UserProfile:
-            LOGGER.error('UserProfile module does not exist.')
-            return
-        UserProfile.objects.update_or_create(
-            user=user,
-            defaults={'name': 'Test Enterprise User'},
-        )
-
-    def _add_user_to_groups(self, user, role):
-        """ Adds a user with a given role to the appropriate groups """
-        if role == ENTERPRISE_LEARNER_ROLE:
-            return
-        data_api_group = Group.objects.get(name=ENTERPRISE_DATA_API_ACCESS_GROUP)
-        data_api_group.user_set.add(user)
-        enrollment_api_group = Group.objects.get(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP)
-        enrollment_api_group.user_set.add(user)
-
-    def _create_system_wide_role_assignment(self, user, role, enterprise_customer, applies_to_all_contexts=False):
-        """
-        Gets or creates a system-wide role assignment for the specified user and role
-        """
-        system_role, __ = SystemWideEnterpriseRole.objects.get_or_create(name=role)
-        kwargs = {
-            'user': user,
-            'role': system_role,
-            'applies_to_all_contexts': applies_to_all_contexts,
-        }
-        if enterprise_customer is not None:
-            kwargs['enterprise_customer'] = enterprise_customer
-        # We use filter() here, because the model does not currently enforce uniqueness on (user, role).
-        if not SystemWideEnterpriseUserRoleAssignment.objects.filter(**kwargs).exists():
-            SystemWideEnterpriseUserRoleAssignment.objects.create(**kwargs)
-
-    def _create_feature_role_assignments(self, user, role):
-        """
-        Gets or creates a feature role assignment for the specified user and role
-        """
-        if role == ENTERPRISE_LEARNER_ROLE:
-            return
-        feature_roles = [
-            ENTERPRISE_CATALOG_ADMIN_ROLE,
-            ENTERPRISE_DASHBOARD_ADMIN_ROLE,
-            ENTERPRISE_ENROLLMENT_API_ADMIN_ROLE,
-            ENTERPRISE_REPORTING_CONFIG_ADMIN_ROLE,
-        ]
-        for feature_role in feature_roles:
-            feature_role_obj, __ = EnterpriseFeatureRole.objects.get_or_create(name=feature_role)
-            EnterpriseFeatureUserRoleAssignment.objects.get_or_create(
-                user=user,
-                role=feature_role_obj,
-            )
-
-    def _create_enterprise_customer_user(self, username, enterprise_customer):
-        """
-        Gets or creates an EnterpriseCustomerUser associated with an EnterpriseCustomer
-        """
-        user, __ = User.objects.get_or_create(username=username)
-        enterprise_customer_user, __ = EnterpriseCustomerUser.objects.update_or_create(
-            user_id=user.pk,
-            enterprise_customer=enterprise_customer,
-            defaults={'active': True},
-        )
-        return enterprise_customer_user
-
-    def _create_enterprise_linked_data(self, enterprise_users, enterprise_customer):
-        """
-        Creates enterprise data for a given EnterpriseCustomer
-        including an enterprise catalog and initial users of
-        varying roles.
-        """
-        enterprise_catalog = self._create_catalog_for_enterprise(
-            enterprise_customer=enterprise_customer
-        )
-        enterprise_linked_users = []
-        for enterprise_user in enterprise_users:
-            enterprise_user_obj = self._create_enterprise_customer_user(
-                username=enterprise_user['user'].username,
-                enterprise_customer=enterprise_customer,
-            )
-            enterprise_linked_users.append({
-                "enterprise_customer_user": enterprise_user_obj,
-                "enterprise_role": enterprise_user['role'],
-            })
-
-        return {
-            "enterprise_customer": enterprise_customer,
-            "enterprise_catalog": enterprise_catalog,
-            "enterprise_linked_users": enterprise_linked_users,
-        }
-
     def handle(self, *args, **options):
-        """
-        Entry point for management command execution.
-        """
-        enterprise_name = options['enterprise-name']
-        slug = slugify(enterprise_name)
-        LOGGER.info(
-            '\nEnsuring enterprise-related Django groups (%s, %s) exist...',
-            ENTERPRISE_DATA_API_ACCESS_GROUP,
-            ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
-        )
-        self._create_enterprise_data_api_group()
-        self._create_enterprise_enrollment_api_group()
+        enterprise_name = options['enterprise_name']
+
+        LOGGER.info('\nEnsuring enterprise-related Django groups exist...')
+        ensure_enterprise_groups()
 
         LOGGER.info('\nCreating a new enterprise customer...')
-        site, __ = self._get_default_site()
-        enterprise_customer = self._create_enterprise_customer(site=site, name=enterprise_name)
+        site = get_or_create_site()
+        enterprise_customer = get_or_create_enterprise_customer(name=enterprise_name, site=site)
+        enterprise_catalog = get_or_create_enterprise_catalog(enterprise_customer)
 
         LOGGER.info('\nCreating enterprise users and assigning roles...')
-        # Create one of each enterprise user type (i.e., learner, admin, operator)
+        slug = enterprise_customer.slug
         enterprise_users = [
-            self._create_enterprise_user(
-                username="{}_{}".format(ENTERPRISE_LEARNER_ROLE, slug),
+            get_or_create_enterprise_user(
+                username=f'{ENTERPRISE_LEARNER_ROLE}_{slug}',
                 role=ENTERPRISE_LEARNER_ROLE,
-                enterprise_customer=enterprise_customer
+                enterprise_customer=enterprise_customer,
             ),
-            self._create_enterprise_user(
-                username="{}_{}".format(ENTERPRISE_ADMIN_ROLE, slug),
+            get_or_create_enterprise_user(
+                username=f'{ENTERPRISE_ADMIN_ROLE}_{slug}',
                 role=ENTERPRISE_ADMIN_ROLE,
-                enterprise_customer=enterprise_customer
-
+                enterprise_customer=enterprise_customer,
             ),
-            # Creates a super admin who has the admin role on all enterprises.
-            self._create_enterprise_user(
+            # Super admin with the admin role on all enterprises.
+            get_or_create_enterprise_user(
                 username=ENTERPRISE_ADMIN_ROLE,
                 role=ENTERPRISE_ADMIN_ROLE,
                 applies_to_all_contexts=True,
             ),
-            self._create_enterprise_user(
+            get_or_create_enterprise_user(
                 username=ENTERPRISE_OPERATOR_ROLE,
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
-            # Make all of the service workers enterprise_openedx_operators for all enterprises
-            self._create_enterprise_user(
+            # Service workers as operators for all enterprises.
+            get_or_create_enterprise_user(
                 username='license-manager_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
-            self._create_enterprise_user(
+            get_or_create_enterprise_user(
                 username='enterprise-catalog_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
-            self._create_enterprise_user(
+            get_or_create_enterprise_user(
                 username='enterprise_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
-            self._create_enterprise_user(
+            get_or_create_enterprise_user(
                 username='ecommerce_worker',
                 role=ENTERPRISE_OPERATOR_ROLE,
                 applies_to_all_contexts=True,
             ),
         ]
-        # Add a couple more learners!
         for i in range(2):
-            enterprise_users.append(self._create_enterprise_user(
-                username='{slug}_learner_{index}'.format(
-                    slug=slug,
-                    index=i + 1,
-                ),
+            enterprise_users.append(get_or_create_enterprise_user(
+                username=f'{slug}_learner_{i + 1}',
                 role=ENTERPRISE_LEARNER_ROLE,
-                enterprise_customer=enterprise_customer
+                enterprise_customer=enterprise_customer,
             ))
 
-        LOGGER.info('\nCreating enterprise data...')
-        enterprise = self._create_enterprise_linked_data(
-            enterprise_users=enterprise_users, enterprise_customer=enterprise_customer)
-
-        # generate a json serializable list of linked enterprise users
+        LOGGER.info('\nLinking users to enterprise...')
         enterprise_linked_users = []
-        for item in enterprise['enterprise_linked_users']:
-            ecu = item['enterprise_customer_user']
+        for enterprise_user in enterprise_users:
+            if enterprise_user is None:
+                continue
+            ecu, _ = link_user_to_enterprise(enterprise_user['user'], enterprise_customer)
             enterprise_linked_users.append({
                 'user_id': ecu.user_id,
                 'enterprise_customer_user_id': ecu.id,
@@ -345,10 +128,10 @@ class Command(BaseCommand):
                 \n| Enterprise Users (%i): %s
                 '''
             ),
-            enterprise['enterprise_customer'].name,
-            enterprise['enterprise_customer'].uuid,
-            enterprise['enterprise_catalog'].title,
-            enterprise['enterprise_catalog'].uuid,
+            enterprise_customer.name,
+            enterprise_customer.uuid,
+            enterprise_catalog.title,
+            enterprise_catalog.uuid,
             len(enterprise_linked_users),
             json.dumps(enterprise_linked_users, sort_keys=True, indent=2),
         )

--- a/scripts/provision-integration-test-ENT-11544.sh
+++ b/scripts/provision-integration-test-ENT-11544.sh
@@ -1,0 +1,266 @@
+#!/usr/bin/env bash
+#
+# Provision a devstack environment for integration-testing the three new
+# openedx-filter pipeline steps added in ticket ENT-11544
+# (DSC Courseware View Redirects).
+#
+# Run from the edx-enterprise directory with devstack already running:
+#
+#     ./scripts/provision-integration-test-ENT-11544.sh
+#
+# The script assumes a baseline devstack provision has already been run, which
+# implies the following already exist and are NOT re-created here:
+#   - course-v1:edX+DemoX+Demo_Course (live, past start date)
+#   - users: honor@example.com, audit@example.com, verified@example.com,
+#            staff@example.com (is_staff=True), edx@example.com (superuser)
+#
+set -eu -o pipefail
+set -x
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+TEST_ENTERPRISE_NAME="Test Enterprise"
+OTHER_ENTERPRISE_NAME="Other Enterprise"
+
+DEMO_COURSE_ID="course-v1:edX+DemoX+Demo_Course"
+FUTURE_COURSE_ID="course-v1:edX+FutureX+2027"
+UNSCHEDULED_COURSE_ID="course-v1:edX+UnschedX+TBD"
+
+# Users seeded by seed_enterprise_devstack_data --enterprise-name "Test Enterprise"
+# (slug becomes "test-enterprise"):
+TEST_ENT_LEARNER="enterprise_learner_test-enterprise"
+TEST_ENT_LEARNER_1="test-enterprise_learner_1"
+TEST_ENT_LEARNER_2="test-enterprise_learner_2"
+
+DUAL_LINKED_LEARNER="dual_linked_learner"
+
+# All users created by devstack_api are assigned the email "${username}@example.com".
+TEST_ENT_LEARNER_2_EMAIL="${TEST_ENT_LEARNER_2}@example.com"
+AUDIT_LEARNER_EMAIL="audit@example.com"
+
+SUPERUSER_EMAIL="edx@example.com"
+
+# ---------------------------------------------------------------------------
+# Helpers — run a Django management command inside the LMS or CMS container
+# ---------------------------------------------------------------------------
+
+lms_manage() {
+    docker exec -i edx.devstack.lms python manage.py lms --settings devstack "$@"
+}
+
+cms_manage() {
+    docker exec -i edx.devstack.cms python manage.py cms --settings devstack "$@"
+}
+
+catalog_manage() {
+    docker exec -i enterprise.catalog.app python manage.py "$@"
+}
+
+discovery_manage() {
+    docker exec -i edx.devstack.discovery python manage.py "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Step 1: Create extra courses (future-dated + unscheduled)
+# ---------------------------------------------------------------------------
+# The demo course is already published by the baseline devstack provision.
+# create_course and force_publish are CMS management commands.
+
+cms_manage create_course split "$SUPERUSER_EMAIL" edX FutureX 2027 \
+    "Future Course" 2030-01-01
+echo "yes" | cms_manage force_publish "$FUTURE_COURSE_ID" --commit
+
+cms_manage create_course split "$SUPERUSER_EMAIL" edX UnschedX TBD \
+    "Unscheduled Course" 2040-01-01
+echo "yes" | cms_manage force_publish "$UNSCHEDULED_COURSE_ID" --commit
+
+# ---------------------------------------------------------------------------
+# Step 2: Seed two enterprise customers and their linked users
+# ---------------------------------------------------------------------------
+# Each invocation creates the enterprise, its catalog, and a standard set of
+# linked users (learners, admin, operator, service workers).
+
+lms_manage seed_enterprise_devstack_data --enterprise-name "$TEST_ENTERPRISE_NAME"
+lms_manage seed_enterprise_devstack_data --enterprise-name "$OTHER_ENTERPRISE_NAME"
+
+# ---------------------------------------------------------------------------
+# Step 2b: Sync enterprise catalogs to the enterprise-catalog service
+# ---------------------------------------------------------------------------
+# seed_enterprise_devstack_data fires a post_save signal that attempts to
+# register the catalog with enterprise-catalog, but the call can fail silently
+# (e.g. if the service wasn't fully ready).  Re-sync explicitly so that
+# contains_content_items checks return accurate results.
+
+discovery_manage refresh_course_metadata
+lms_manage migrate_enterprise_catalogs --api_user enterprise-catalog_worker
+catalog_manage update_content_metadata --no-async --force
+
+# ---------------------------------------------------------------------------
+# PR #338 — CoursewareViewStarted (DSC redirect)
+# ---------------------------------------------------------------------------
+# Scenarios:
+#   - TEST_ENT_LEARNER: enrolled in demo course under "Test Enterprise",
+#     DSC NOT granted -> triggers consent redirect.
+#   - TEST_ENT_LEARNER_1: enrolled in demo course under "Test Enterprise",
+#     DSC granted -> control (no redirect).
+#   - honor@example.com: already enrolled in demo course, no enterprise link.
+#     No action needed -> control (no redirect).
+
+lms_manage enroll_enterprise_learner \
+    --username "$TEST_ENT_LEARNER" \
+    --course-id "$DEMO_COURSE_ID" \
+    --enterprise-name "$TEST_ENTERPRISE_NAME"
+
+lms_manage enroll_enterprise_learner \
+    --username "$TEST_ENT_LEARNER_1" \
+    --course-id "$DEMO_COURSE_ID" \
+    --enterprise-name "$TEST_ENTERPRISE_NAME" \
+    --grant-dsc
+
+# ---------------------------------------------------------------------------
+# PR #339 — CourseStartDateValidationFailed (enterprise start-date error)
+# ---------------------------------------------------------------------------
+# Scenarios:
+#   - TEST_ENT_LEARNER: enrolled in the future and unscheduled courses under
+#     "Test Enterprise" with DSC granted (so the start-date check runs instead
+#     of the DSC check) -> enterprise-flavored start-date error.
+#   - TEST_ENT_LEARNER_2: already linked to "Test Enterprise" by the seed
+#     command. Gets a plain platform CourseEnrollment ONLY (no
+#     EnterpriseCourseEnrollment) in the future course -> verifies the
+#     non-subsidized path produces the generic start-date error.
+#   - audit@example.com: plain non-enterprise learner. Gets a plain
+#     CourseEnrollment in the future course -> generic start-date error.
+#
+# enroll_enterprise_learner always creates an EnterpriseCourseEnrollment and
+# requires an enterprise link, so the two non-subsidized fixtures use the
+# platform's enroll_user_in_course command (idempotent; takes -e email
+# -c course-id) directly.
+
+lms_manage enroll_enterprise_learner \
+    --username "$TEST_ENT_LEARNER" \
+    --course-id "$FUTURE_COURSE_ID" \
+    --enterprise-name "$TEST_ENTERPRISE_NAME" \
+    --grant-dsc
+
+lms_manage enroll_enterprise_learner \
+    --username "$TEST_ENT_LEARNER" \
+    --course-id "$UNSCHEDULED_COURSE_ID" \
+    --enterprise-name "$TEST_ENTERPRISE_NAME" \
+    --grant-dsc
+
+lms_manage enroll_user_in_course \
+    -e "$TEST_ENT_LEARNER_2_EMAIL" \
+    -c "$FUTURE_COURSE_ID"
+
+lms_manage enroll_user_in_course \
+    -e "$AUDIT_LEARNER_EMAIL" \
+    -c "$FUTURE_COURSE_ID"
+
+# ---------------------------------------------------------------------------
+# PR #340 — CoursewareAccessChecksRequested (mismatch + DSC at access check)
+# ---------------------------------------------------------------------------
+# Scenarios:
+#   - DUAL_LINKED_LEARNER: linked to both enterprises — "Test Enterprise"
+#     active, "Other Enterprise" inactive — and enrolled in the demo course
+#     under the INACTIVE enterprise -> triggers active-enterprise mismatch.
+#   - TEST_ENT_LEARNER: already enrolled in the demo course under "Test
+#     Enterprise" with DSC ungranted (from the PR #338 section above). No
+#     additional action needed; exercises CourseHomeMetadataView DSC check.
+
+lms_manage create_enterprise_linked_learner \
+    --username "$DUAL_LINKED_LEARNER" \
+    --enterprise-name "$TEST_ENTERPRISE_NAME" \
+    --enterprise-name "$OTHER_ENTERPRISE_NAME"
+
+lms_manage enroll_enterprise_learner \
+    --username "$DUAL_LINKED_LEARNER" \
+    --course-id "$DEMO_COURSE_ID" \
+    --enterprise-name "$OTHER_ENTERPRISE_NAME"
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+
+set +x
+cat <<EOF
+
+=============================================================================
+ENT-11544 integration test fixtures provisioned.
+=============================================================================
+
+Courses created:
+  ${DEMO_COURSE_ID}        (live, started in the past — baseline devstack)
+  ${FUTURE_COURSE_ID}      (start: 2030-01-01, "Future Course")
+  ${UNSCHEDULED_COURSE_ID} (start: 2040-01-01, "Unscheduled Course")
+
+Enterprises created (with the standard seeded user set each):
+  "${TEST_ENTERPRISE_NAME}"
+  "${OTHER_ENTERPRISE_NAME}"
+
+-----------------------------------------------------------------------------
+PR #338 — CoursewareViewStarted (DSC redirect)
+-----------------------------------------------------------------------------
+
+  1. [redirect] DSC-ungranted enterprise learner is redirected to the
+     consent page when opening the courseware.
+     a. Login using ${TEST_ENT_LEARNER}@example.com / edx
+     b. Open courseware for ${DEMO_COURSE_ID}
+     c. Expect a redirect to the DSC consent page (not the courseware unit).
+
+  2. [control] DSC-granted enterprise learner sees the courseware
+     normally (no redirect).
+     a. Login using ${TEST_ENT_LEARNER_1}@example.com / edx
+     b. Open courseware for ${DEMO_COURSE_ID}
+     c. Expect the courseware unit to render with no consent redirect.
+
+  3. [control] Non-enterprise learner sees the courseware normally.
+     a. Login using honor@example.com / edx
+     b. Open courseware for ${DEMO_COURSE_ID}
+     c. Expect the courseware unit to render with no consent redirect.
+
+-----------------------------------------------------------------------------
+PR #339 — CourseStartDateValidationFailed (start-date error)
+-----------------------------------------------------------------------------
+
+  4. [ent err] Enterprise-linked learner sees the enterprise-flavored
+     start-date error on a future-dated course.
+     a. Login using ${TEST_ENT_LEARNER}@example.com / edx
+     b. Open courseware for ${FUTURE_COURSE_ID}, then ${UNSCHEDULED_COURSE_ID}
+     c. Expect an enterprise-branded "course not yet started" error
+        (developer_message / user_message populated by the plugin step).
+
+  5. [generic] Enterprise-linked learner WITHOUT an EnterpriseCourseEnrollment
+     on the future course falls through to the generic error.
+     a. Login using ${TEST_ENT_LEARNER_2_EMAIL} / edx
+     b. Open courseware for ${FUTURE_COURSE_ID}
+     c. Expect a generic StartDateFiltersError (non-enterprise flavor) —
+        the plain CourseEnrollment bypasses the enterprise-specific gating.
+
+  6. [generic] Pure non-enterprise learner sees the generic start-date
+     error on the future course.
+     a. Login using ${AUDIT_LEARNER_EMAIL} / edx
+     b. Open courseware for ${FUTURE_COURSE_ID}
+     c. Expect a generic StartDateFiltersError with no enterprise branding.
+
+-----------------------------------------------------------------------------
+PR #340 — CoursewareAccessChecksRequested (mismatch + DSC at access check)
+-----------------------------------------------------------------------------
+
+  7. [mismatch] Learner linked to two enterprises (Test=active,
+     Other=inactive) but enrolled under the INACTIVE one triggers the
+     active-enterprise mismatch check.
+     a. Login using ${DUAL_LINKED_LEARNER}@example.com / edx
+     b. Open courseware for ${DEMO_COURSE_ID}
+     c. Expect an active-enterprise mismatch error (access denied because
+        the enrollment's enterprise does not match the active one).
+
+  8. [dsc chk] DSC check is enforced at CourseHomeMetadataView (not just
+     the courseware view). Re-uses scenario 1's enrollment.
+     a. Login using ${TEST_ENT_LEARNER}@example.com / edx
+     b. Open course home / outline for ${DEMO_COURSE_ID}
+     c. Expect a DSC failure surfaced by CourseHomeMetadataView (the home
+        page is blocked, mirroring scenario 1's courseware redirect).
+
+EOF

--- a/tests/test_enterprise/management/test_create_enterprise_linked_learner.py
+++ b/tests/test_enterprise/management/test_create_enterprise_linked_learner.py
@@ -1,0 +1,75 @@
+"""
+Tests for the management command `create_enterprise_linked_learner`.
+"""
+
+from unittest.mock import patch
+
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from enterprise.devstack_api import ensure_enterprise_groups
+from enterprise.models import EnterpriseCustomerUser
+from test_utils.factories import EnterpriseCustomerFactory
+
+
+@patch('enterprise.devstack_api.UserProfile')
+@pytest.mark.django_db
+class TestCreateEnterpriseLinkedLearner(TestCase):
+    """Tests for the create_enterprise_linked_learner management command."""
+
+    command = 'create_enterprise_linked_learner'
+
+    def setUp(self):
+        ensure_enterprise_groups()
+        self.enterprise = EnterpriseCustomerFactory(name='Test Enterprise')
+        self.other_enterprise = EnterpriseCustomerFactory(name='Other Enterprise')
+        super().setUp()
+
+    def test_links_user_to_single_enterprise(self, _MockUserProfile):
+        """Creates one active EnterpriseCustomerUser link for a single ``--enterprise-name``."""
+        call_command(self.command, '--username', 'linked_learner', '--enterprise-name', 'Test Enterprise')
+        assert EnterpriseCustomerUser.objects.filter(
+            enterprise_customer=self.enterprise,
+            active=True,
+        ).count() == 1
+
+    def test_first_enterprise_is_active(self, _MockUserProfile):
+        """Marks only the first ``--enterprise-name`` as the active link when multiple are passed."""
+        call_command(
+            self.command,
+            '--username', 'dual_learner',
+            '--enterprise-name', 'Test Enterprise',
+            '--enterprise-name', 'Other Enterprise',
+        )
+        test_ecu = EnterpriseCustomerUser.objects.get(enterprise_customer=self.enterprise)
+        other_ecu = EnterpriseCustomerUser.objects.get(enterprise_customer=self.other_enterprise)
+        assert test_ecu.active is True
+        assert other_ecu.active is False
+
+    def test_idempotent_for_existing_user(self, _MockUserProfile):
+        """Re-running the command for the same user does not create a duplicate link."""
+        call_command(self.command, '--username', 'linked_learner', '--enterprise-name', 'Test Enterprise')
+        call_command(self.command, '--username', 'linked_learner', '--enterprise-name', 'Test Enterprise')
+        assert EnterpriseCustomerUser.objects.filter(enterprise_customer=self.enterprise).count() == 1
+
+    def test_raises_command_error_for_missing_enterprise(self, _MockUserProfile):
+        """Raises CommandError when ``--enterprise-name`` refers to an unknown customer."""
+        with pytest.raises(CommandError, match="does not exist"):
+            call_command(
+                self.command,
+                '--username', 'linked_learner',
+                '--enterprise-name', 'Nonexistent Enterprise',
+            )
+
+    def test_raises_command_error_for_duplicate_enterprise(self, _MockUserProfile):
+        """Raises CommandError when the same ``--enterprise-name`` is passed more than once."""
+        with pytest.raises(CommandError, match="Duplicate"):
+            call_command(
+                self.command,
+                '--username', 'linked_learner',
+                '--enterprise-name', 'Test Enterprise',
+                '--enterprise-name', 'Test Enterprise',
+            )

--- a/tests/test_enterprise/management/test_enroll_enterprise_learner.py
+++ b/tests/test_enterprise/management/test_enroll_enterprise_learner.py
@@ -1,0 +1,122 @@
+"""
+Tests for the ``enroll_enterprise_learner`` management command.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import ddt
+import pytest
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from consent.models import DataSharingConsent
+from enterprise.devstack_api import ensure_enterprise_groups, link_user_to_enterprise
+from enterprise.models import EnterpriseCourseEnrollment
+from test_utils.factories import EnterpriseCustomerFactory, UserFactory
+
+
+@ddt.ddt
+@pytest.mark.django_db
+class TestEnrollEnterpriseLearner(TestCase):
+    """Tests for the enroll_enterprise_learner management command."""
+
+    command = 'enroll_enterprise_learner'
+    course_id = 'course-v1:edX+DemoX+Demo_Course'
+
+    def setUp(self):
+        ensure_enterprise_groups()
+        self.enterprise = EnterpriseCustomerFactory(name='Test Enterprise')
+        self.user = UserFactory(username='test_learner')
+        link_user_to_enterprise(self.user, self.enterprise)
+        super().setUp()
+
+    def _mock_course_enrollment(self):
+        """Return a mock CourseEnrollment class whose ``get_or_create`` yields an active enrollment."""
+        mock_enrollment = MagicMock()
+        mock_enrollment.is_active = True
+        mock_cls = MagicMock()
+        mock_cls.objects.get_or_create.return_value = (mock_enrollment, True)
+        return mock_cls
+
+    def test_creates_enterprise_course_enrollment(self):
+        """Creates an EnterpriseCourseEnrollment for the user/course/customer triple."""
+        mock_cls = self._mock_course_enrollment()
+        with patch('enterprise.devstack_api.CourseEnrollment', mock_cls):
+            call_command(
+                self.command,
+                '--username', 'test_learner',
+                '--course-id', self.course_id,
+                '--enterprise-name', 'Test Enterprise',
+            )
+        assert EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user__user_id=self.user.pk,
+            course_id=self.course_id,
+        ).exists()
+
+    @ddt.data(
+        {'extra_args': ['--grant-dsc'], 'expected_granted': True},
+        {'extra_args': [], 'expected_granted': False},
+    )
+    @ddt.unpack
+    def test_dsc_granted_flag(self, extra_args, expected_granted):
+        """Sets DataSharingConsent.granted based on whether ``--grant-dsc`` is passed."""
+        mock_cls = self._mock_course_enrollment()
+        with patch('enterprise.devstack_api.CourseEnrollment', mock_cls):
+            call_command(
+                self.command,
+                '--username', 'test_learner',
+                '--course-id', self.course_id,
+                '--enterprise-name', 'Test Enterprise',
+                *extra_args,
+            )
+        dsc = DataSharingConsent.objects.get(
+            username='test_learner',
+            course_id=self.course_id,
+            enterprise_customer=self.enterprise,
+        )
+        assert dsc.granted is expected_granted
+
+    def test_raises_command_error_for_missing_enterprise(self):
+        """Raises CommandError when ``--enterprise-name`` refers to an unknown customer."""
+        with pytest.raises(CommandError, match='does not exist'):
+            call_command(
+                self.command,
+                '--username', 'test_learner',
+                '--course-id', self.course_id,
+                '--enterprise-name', 'Nonexistent Enterprise',
+            )
+
+    def test_raises_command_error_for_missing_user(self):
+        """Raises CommandError when ``--username`` refers to an unknown user."""
+        with pytest.raises(CommandError, match='does not exist'):
+            call_command(
+                self.command,
+                '--username', 'nonexistent_user',
+                '--course-id', self.course_id,
+                '--enterprise-name', 'Test Enterprise',
+            )
+
+    def test_raises_command_error_when_not_linked(self):
+        """Raises CommandError when the user is not linked to the customer."""
+        unlinked_user = UserFactory(username='unlinked_user')
+        mock_cls = self._mock_course_enrollment()
+        with patch('enterprise.devstack_api.CourseEnrollment', mock_cls):
+            with pytest.raises(CommandError, match='not linked'):
+                call_command(
+                    self.command,
+                    '--username', unlinked_user.username,
+                    '--course-id', self.course_id,
+                    '--enterprise-name', 'Test Enterprise',
+                )
+
+    def test_raises_command_error_for_invalid_course_id(self):
+        """Raises CommandError when ``--course-id`` cannot be parsed as a course key."""
+        with pytest.raises(CommandError, match='Invalid course key'):
+            call_command(
+                self.command,
+                '--username', 'test_learner',
+                '--course-id', 'not-a-valid-key',
+                '--enterprise-name', 'Test Enterprise',
+            )

--- a/tests/test_enterprise/test_devstack_api.py
+++ b/tests/test_enterprise/test_devstack_api.py
@@ -1,0 +1,321 @@
+"""
+Tests for the devstack-only helpers in ``enterprise/devstack_api.py``.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import ddt
+import pytest
+
+from django.contrib.auth import get_user_model
+from django.contrib.auth.models import Group
+from django.contrib.sites.models import Site
+from django.test import TestCase
+
+from consent.models import DataSharingConsent
+from enterprise.constants import (
+    ENTERPRISE_ADMIN_ROLE,
+    ENTERPRISE_DATA_API_ACCESS_GROUP,
+    ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
+    ENTERPRISE_LEARNER_ROLE,
+    ENTERPRISE_OPERATOR_ROLE,
+)
+from enterprise.devstack_api import (
+    enroll_learner_in_course,
+    ensure_enterprise_groups,
+    get_or_create_enterprise_catalog,
+    get_or_create_enterprise_customer,
+    get_or_create_enterprise_user,
+    get_or_create_site,
+    get_or_create_user,
+    link_user_to_enterprise,
+)
+from enterprise.models import (
+    EnterpriseCourseEnrollment,
+    EnterpriseCustomer,
+    EnterpriseCustomerCatalog,
+    EnterpriseCustomerUser,
+    EnterpriseFeatureUserRoleAssignment,
+    SystemWideEnterpriseUserRoleAssignment,
+)
+from test_utils.factories import EnterpriseCustomerFactory, UserFactory
+
+User = get_user_model()
+
+
+@pytest.mark.django_db
+class TestGetOrCreateSite(TestCase):
+    """Tests for ``get_or_create_site``."""
+
+    def test_creates_site(self):
+        """Creates the default ``example.com`` site when none exists."""
+        Site.objects.all().delete()
+        site = get_or_create_site()
+        assert site.name == 'example.com'
+        assert site.domain == 'example.com'
+
+    def test_idempotent(self):
+        """Repeated calls do not create duplicate Site rows."""
+        get_or_create_site()
+        get_or_create_site()
+        assert Site.objects.filter(name='example.com').count() == 1
+
+
+@pytest.mark.django_db
+class TestEnsureEnterpriseGroups(TestCase):
+    """Tests for ``ensure_enterprise_groups``."""
+
+    def test_creates_groups(self):
+        """Creates both enterprise API access Groups when missing."""
+        Group.objects.filter(name__in=[
+            ENTERPRISE_DATA_API_ACCESS_GROUP,
+            ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP,
+        ]).delete()
+        ensure_enterprise_groups()
+        assert Group.objects.filter(name=ENTERPRISE_DATA_API_ACCESS_GROUP).exists()
+        assert Group.objects.filter(name=ENTERPRISE_ENROLLMENT_API_ACCESS_GROUP).exists()
+
+    def test_idempotent(self):
+        """Repeated calls do not create duplicate Group rows."""
+        ensure_enterprise_groups()
+        ensure_enterprise_groups()
+        assert Group.objects.filter(name=ENTERPRISE_DATA_API_ACCESS_GROUP).count() == 1
+
+
+@pytest.mark.django_db
+class TestGetOrCreateEnterpriseCustomer(TestCase):
+    """Tests for ``get_or_create_enterprise_customer``."""
+
+    def test_creates_customer(self):
+        """Creates an EnterpriseCustomer with learner portal and DSC enabled."""
+        site = get_or_create_site()
+        customer = get_or_create_enterprise_customer(name='Acme Corp', site=site)
+        assert customer.name == 'Acme Corp'
+        assert customer.enable_learner_portal is True
+        assert customer.enable_data_sharing_consent is True
+
+    def test_creates_site_if_none(self):
+        """Falls back to creating a default Site when no site is passed in."""
+        customer = get_or_create_enterprise_customer(name='Acme Corp')
+        assert customer.name == 'Acme Corp'
+
+    def test_idempotent(self):
+        """Repeated calls do not create duplicate EnterpriseCustomer rows."""
+        get_or_create_enterprise_customer(name='Acme Corp')
+        get_or_create_enterprise_customer(name='Acme Corp')
+        assert EnterpriseCustomer.objects.filter(name='Acme Corp').count() == 1
+
+
+@pytest.mark.django_db
+class TestGetOrCreateEnterpriseCatalog(TestCase):
+    """Tests for ``get_or_create_enterprise_catalog``."""
+
+    def test_creates_catalog(self):
+        """Creates the default ``All Course Runs`` catalog for the given customer."""
+        customer = EnterpriseCustomerFactory(name='Acme Corp')
+        catalog = get_or_create_enterprise_catalog(customer)
+        assert catalog.title == 'All Course Runs'
+        assert catalog.enterprise_customer == customer
+
+    def test_idempotent(self):
+        """Repeated calls do not create duplicate catalogs for the same customer."""
+        customer = EnterpriseCustomerFactory(name='Acme Corp')
+        get_or_create_enterprise_catalog(customer)
+        get_or_create_enterprise_catalog(customer)
+        assert EnterpriseCustomerCatalog.objects.filter(enterprise_customer=customer).count() == 1
+
+
+@patch('enterprise.devstack_api.UserProfile')
+@pytest.mark.django_db
+class TestGetOrCreateUser(TestCase):
+    """Tests for ``get_or_create_user``."""
+
+    def test_creates_user(self, _MockUserProfile):
+        """Creates a non-staff user with a generated example.com email."""
+        user = get_or_create_user('testuser123')
+        assert user.username == 'testuser123'
+        assert user.email == 'testuser123@example.com'
+        assert user.is_staff is False
+
+    def test_creates_staff_user(self, _MockUserProfile):
+        """Honors the ``is_staff`` flag when creating a new user."""
+        user = get_or_create_user('staffuser', is_staff=True)
+        assert user.is_staff is True
+
+    def test_idempotent_returns_existing(self, _MockUserProfile):
+        """Returns the existing user instead of creating a duplicate."""
+        get_or_create_user('testuser123')
+        user2 = get_or_create_user('testuser123')
+        assert user2.username == 'testuser123'
+        assert User.objects.filter(username='testuser123').count() == 1
+
+
+@ddt.ddt
+@patch('enterprise.devstack_api.UserProfile')
+@pytest.mark.django_db
+class TestGetOrCreateEnterpriseUser(TestCase):
+    """Tests for ``get_or_create_enterprise_user``."""
+
+    def setUp(self):
+        ensure_enterprise_groups()
+        self.enterprise = EnterpriseCustomerFactory()
+        super().setUp()
+
+    @ddt.data(
+        {'username': 'learner_user', 'role': ENTERPRISE_LEARNER_ROLE, 'extra_kwargs': {'enterprise_customer': True}},
+        {'username': 'admin_user', 'role': ENTERPRISE_ADMIN_ROLE, 'extra_kwargs': {'enterprise_customer': True}},
+        {'username': 'op_user', 'role': ENTERPRISE_OPERATOR_ROLE, 'extra_kwargs': {'applies_to_all_contexts': True}},
+    )
+    @ddt.unpack
+    def test_supported_role(self, _MockUserProfile, username, role, extra_kwargs):
+        """Returns a result dict echoing the role for every supported role."""
+        kwargs = {'username': username, 'role': role}
+        if extra_kwargs.get('enterprise_customer'):
+            kwargs['enterprise_customer'] = self.enterprise
+        if extra_kwargs.get('applies_to_all_contexts'):
+            kwargs['applies_to_all_contexts'] = True
+        result = get_or_create_enterprise_user(**kwargs)
+        assert result is not None
+        assert result['role'] == role
+
+    def test_unknown_role_returns_none(self, _MockUserProfile):
+        """Returns None when an unrecognised role string is passed."""
+        result = get_or_create_enterprise_user(username='someuser', role='bogus_role')
+        assert result is None
+
+    def test_operator_is_staff(self, _MockUserProfile):
+        """Operator role provisions the underlying user as staff."""
+        result = get_or_create_enterprise_user(
+            username='op_user', role=ENTERPRISE_OPERATOR_ROLE, applies_to_all_contexts=True)
+        assert result['user'].is_staff is True
+
+    def test_learner_is_not_staff(self, _MockUserProfile):
+        """Learner role provisions the underlying user as non-staff."""
+        result = get_or_create_enterprise_user(
+            username='learner_user', role=ENTERPRISE_LEARNER_ROLE, enterprise_customer=self.enterprise)
+        assert result['user'].is_staff is False
+
+    def test_creates_system_wide_role_assignment(self, _MockUserProfile):
+        """Creates a SystemWideEnterpriseUserRoleAssignment for the new user."""
+        result = get_or_create_enterprise_user(
+            username='admin_user',
+            role=ENTERPRISE_ADMIN_ROLE,
+            enterprise_customer=self.enterprise,
+        )
+        assert SystemWideEnterpriseUserRoleAssignment.objects.filter(
+            user=result['user'],
+        ).exists()
+
+    def test_applies_to_all_contexts(self, _MockUserProfile):
+        """Propagates ``applies_to_all_contexts=True`` onto the role assignment."""
+        result = get_or_create_enterprise_user(
+            username='op_user',
+            role=ENTERPRISE_OPERATOR_ROLE,
+            applies_to_all_contexts=True,
+        )
+        assignment = SystemWideEnterpriseUserRoleAssignment.objects.get(user=result['user'])
+        assert assignment.applies_to_all_contexts is True
+
+    def test_admin_gets_feature_roles(self, _MockUserProfile):
+        """Admin role grants all four EnterpriseFeatureUserRoleAssignment rows."""
+        result = get_or_create_enterprise_user(
+            username='admin_user', role=ENTERPRISE_ADMIN_ROLE, enterprise_customer=self.enterprise)
+        assert EnterpriseFeatureUserRoleAssignment.objects.filter(user=result['user']).count() == 4
+
+    def test_learner_gets_no_feature_roles(self, _MockUserProfile):
+        """Learner role does not grant any EnterpriseFeatureUserRoleAssignment rows."""
+        result = get_or_create_enterprise_user(
+            username='learner_user', role=ENTERPRISE_LEARNER_ROLE, enterprise_customer=self.enterprise)
+        assert EnterpriseFeatureUserRoleAssignment.objects.filter(user=result['user']).count() == 0
+
+
+@pytest.mark.django_db
+class TestLinkUserToEnterprise(TestCase):
+    """Tests for ``link_user_to_enterprise``."""
+
+    def test_creates_link(self):
+        """Creates a new active EnterpriseCustomerUser linking the user and customer."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        ecu, created = link_user_to_enterprise(user, customer)
+        assert created is True
+        assert ecu.user_id == user.pk
+        assert ecu.enterprise_customer == customer
+        assert ecu.active is True
+
+    def test_inactive_link(self):
+        """Honors ``active=False`` when creating the link."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        ecu, _ = link_user_to_enterprise(user, customer, active=False)
+        assert ecu.active is False
+
+    def test_idempotent_updates_active(self):
+        """Updates the existing link's ``active`` flag instead of creating a duplicate."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        link_user_to_enterprise(user, customer, active=False)
+        ecu, created = link_user_to_enterprise(user, customer, active=True)
+        assert created is False
+        assert ecu.active is True
+        assert EnterpriseCustomerUser.objects.filter(user_id=user.pk).count() == 1
+
+
+@patch('enterprise.devstack_api.CourseEnrollment')
+@pytest.mark.django_db
+class TestEnrollLearnerInCourse(TestCase):
+    """Tests for ``enroll_learner_in_course``."""
+
+    def test_raises_value_error_for_invalid_course_key(self, _MockCourseEnrollment):
+        """Raises ValueError when the course key string cannot be parsed."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        with pytest.raises(ValueError, match='Invalid course key'):
+            enroll_learner_in_course(user, 'not-a-valid-key', customer)
+
+    def test_raises_does_not_exist_when_not_linked(self, _MockCourseEnrollment):
+        """Raises EnterpriseCustomerUser.DoesNotExist when the user is not linked."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        with pytest.raises(EnterpriseCustomerUser.DoesNotExist):
+            enroll_learner_in_course(user, 'course-v1:edX+DemoX+Demo_Course', customer)
+
+    def test_creates_enrollments_and_dsc(self, MockCourseEnrollment):
+        """Creates EnterpriseCourseEnrollment and granted DSC when ``grant_dsc=True``."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        link_user_to_enterprise(user, customer)
+
+        mock_enrollment = MagicMock()
+        mock_enrollment.is_active = True
+        MockCourseEnrollment.objects.get_or_create.return_value = (mock_enrollment, True)
+
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enroll_learner_in_course(user, course_id, customer, grant_dsc=True)
+
+        assert EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user__user_id=user.pk,
+            course_id=course_id,
+        ).exists()
+
+        dsc = DataSharingConsent.objects.get(
+            username=user.username,
+            course_id=course_id,
+            enterprise_customer=customer,
+        )
+        assert dsc.granted is True
+
+    def test_activates_inactive_enrollment(self, MockCourseEnrollment):
+        """Reactivates an existing inactive CourseEnrollment when re-enrolling."""
+        user = UserFactory()
+        customer = EnterpriseCustomerFactory()
+        link_user_to_enterprise(user, customer)
+
+        mock_enrollment = MagicMock()
+        mock_enrollment.is_active = False
+        MockCourseEnrollment.objects.get_or_create.return_value = (mock_enrollment, False)
+
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        enroll_learner_in_course(user, course_id, customer)
+
+        mock_enrollment.activate.assert_called_once()


### PR DESCRIPTION
The essential logic of this old management command was migrated into a central `devstack_api.py` library, then that library used to compose two new management commands:

- create_enterprise_linked_learner
- enroll_enterprise_learner

In turn, all three enterprise management commands were composed together with LMS, CMS, enterprise-catalog, and course-discovery management commands to create `scripts/provision-integration-test-ENT-11544.sh` which is the master provision script for integration testing ENT-11544, but also serves as a demonstration of the power of composing these new management commands together.

ENT-11544