### PR TITLE
fix: downgrade notification banner log level

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.0.17] - 2026-06-12
+---------------------
+* fix: downgrade notification banner log level from error to debug for expected missing-request exceptions
+
 [8.0.16] - 2026-06-02
 ---------------------
 * feat: remove enterprise_invite_admins_enabled feature flag and related conditional behavior (ENT-11269)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.16"
+__version__ = "8.0.17"

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.0.17"
+__version__ = "8.0.18"

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -321,12 +321,16 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
         """
 
         try:
-            request = self.context['request']
+            request = self.context.get('request')
+            if not request:
+                # this serializer is called from tpa_pipeline and other code paths
+                # where 'request' is not available
+                LOGGER.debug('[Admin Notification API] Get enterprise notification banner request object not found,'
+                             ' Enterprise Customer :{}'.format(obj.slug))
+                return None
             user_id = request.user.id
         except Exception as exc:  # pylint: disable=broad-except
-            # this serializer is called from tpa_pipeline and other code paths where 'request'
-            # is not available, so some exceptions are expected.
-            LOGGER.debug('[Admin Notification API] Get enterprise notification banner request object not found,'
+            LOGGER.error('[Admin Notification API] Failed to retrieve user_id for notification banner,'
                          ' Enterprise Customer :{} Exception: {}'.format(obj.slug, exc))
             return None
         now = datetime.datetime.now(pytz.UTC)

--- a/enterprise/api/v1/serializers.py
+++ b/enterprise/api/v1/serializers.py
@@ -321,11 +321,12 @@ class EnterpriseCustomerSerializer(serializers.ModelSerializer):
         """
 
         try:
-            # this serializer is also called from tpa_pipeline and request is not available in the first place there.
             request = self.context['request']
             user_id = request.user.id
         except Exception as exc:  # pylint: disable=broad-except
-            LOGGER.error('[Admin Notification API] Get enterprise notification banner request object not found,'
+            # this serializer is called from tpa_pipeline and other code paths where 'request'
+            # is not available, so some exceptions are expected.
+            LOGGER.debug('[Admin Notification API] Get enterprise notification banner request object not found,'
                          ' Enterprise Customer :{} Exception: {}'.format(obj.slug, exc))
             return None
         now = datetime.datetime.now(pytz.UTC)


### PR DESCRIPTION
Downgrades the log level from ERROR to DEBUG for notification banner "request object not found" exceptions to reduce logging noise. These exceptions are expected when the serializer is called from a code path that does not include `request`.

**Merge checklist:**
- [ ] Any new requirements are in the right place (do **not** manually modify the `requirements/*.txt` files)
    - `base.in` if needed in production but edx-platform doesn't install it
    - `test-master.in` if edx-platform pins it, with a matching version
    - `make upgrade && make requirements` have been run to regenerate requirements
- [ ] `make static` has been run to update webpack bundling if any static content was updated
- [ ] `./manage.py makemigrations` has been run
    - Checkout the [Database Migration](https://openedx.atlassian.net/wiki/spaces/AC/pages/23003228/Everything+About+Database+Migrations) Confluence page for helpful tips on creating migrations.
    - *Note*: This **must** be run if you modified any models.
      - It may or may not make a migration depending on exactly what you modified, but it should still be run.
    - This should be run from either a venv with all the lms/edx-enterprise requirements installed or if you checked out edx-enterprise into the src directory used by lms, you can run this command through an lms shell.
        - It would be `./manage.py lms makemigrations` in the shell.
- [ ] [Version](https://github.com/openedx/edx-enterprise/blob/master/enterprise/__init__.py) bumped
- [ ] [Changelog](https://github.com/openedx/edx-enterprise/blob/master/CHANGELOG.rst) record added
- [ ] Translations updated (see docs/internationalization.rst but also this isn't blocking for merge atm)

**Post merge:**
- [ ] Tag pushed and a new [version](https://github.com/openedx/edx-enterprise/releases) released
    - *Note*: Assets will be added automatically. You just need to provide a tag (should match your version number) and title and description.
- [ ] After versioned build finishes in [GitHub Actions](https://github.com/openedx/edx-enterprise/actions), verify version has been pushed to [PyPI](https://pypi.org/project/edx-enterprise/)
    - Each step in the release build has a condition flag that checks if the rest of the steps are done and if so will deploy to PyPi.
    (so basically once your build finishes, after maybe a minute you should see the new version in PyPi automatically (on refresh))
- [ ] PR created in [edx-platform](https://github.com/openedx/edx-platform) to upgrade dependencies (including edx-enterprise)
    - Trigger the '[Upgrade one Python dependency](https://github.com/openedx/edx-platform/actions/workflows/upgrade-one-python-dependency.yml)' action against master in edx-platform with new version number to generate version bump PR
    - This **must** be done after the version is visible in PyPi as `make upgrade` in edx-platform will look for the latest version in PyPi.
    - Note: the edx-enterprise constraint in edx-platform **must** also be bumped to the latest version in PyPi.
