### PR TITLE
refactor: reorganize helper functions into model-dependent and model-independent to break an import cycle

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.1.1] - 2026-06-18
+---------------------
+* refactor: reorganize helper functions into model-dependent and model-independent to break an import cycle
+
 [8.1.0] - 2026-06-17
 ---------------------
 * feat: add courseware-access pipeline steps

--- a/consent/helpers.py
+++ b/consent/helpers.py
@@ -14,7 +14,8 @@ from django.urls import reverse
 
 from consent.models import ProxyDataSharingConsent
 from enterprise.api_client.discovery import get_course_catalog_api_service_client
-from enterprise.utils import get_active_enterprise_customer_user, get_enterprise_customer
+from enterprise.core_api import get_active_enterprise_customer_user
+from enterprise.utils import get_enterprise_customer
 
 # ENT-11576: CONSENT_FAILED_PARAMETER, ConsentApiClient, enterprise_customer_uuid_for_request,
 # and get_data_consent_share_cache_key will be migrated from the platform's enterprise_support

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.1.0"
+__version__ = "8.1.1"

--- a/enterprise/core_api.py
+++ b/enterprise/core_api.py
@@ -1,0 +1,91 @@
+"""
+Core Python API for the enterprise app.
+
+These are core enterprise utility functions that rely on access to enterprise models or data.
+
+Important: ``models.py`` files should NEVER import this module, since that would create an import cycle.
+"""
+from opaque_keys.edx.keys import CourseKey
+
+from django.conf import settings
+from django.contrib.auth.models import AbstractUser
+from django.http import HttpRequest
+
+from enterprise.logging import getEnterpriseLogger
+from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
+
+# In ENT-11576, enterprise_customer_from_session_or_learner_data will be migrated into this repo.
+try:
+    from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
+except ImportError:
+    enterprise_customer_from_session_or_learner_data = None
+
+LOGGER = getEnterpriseLogger(__name__)
+
+
+def get_active_enterprise_customer_user(user: AbstractUser) -> EnterpriseCustomerUser | None:
+    """
+    Return the active EnterpriseCustomerUser model instance for ``user``, or None.
+
+    There is at most one active EnterpriseCustomerUser per user.
+    """
+    if not getattr(settings, 'ENABLE_ENTERPRISE_INTEGRATION', False) or not user.is_authenticated:
+        return None
+    try:
+        return EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
+    except EnterpriseCustomerUser.DoesNotExist:
+        LOGGER.info(
+            "Active EnterpriseCustomerUser for user [%s] does not exist", user.username,
+        )
+        return None
+
+
+def enterprise_learner_enrolled(request: HttpRequest, course_key: CourseKey) -> bool:
+    """
+    Return True if the request user is an enterprise learner enrolled via a subsidy for ``course_key``.
+
+    Returns True only when all of the following conditions hold:
+
+    1. The request user has an active linked EnterpriseCustomer.
+    2. The linked customer has the learner portal enabled.
+    3. The user has an EnterpriseCourseEnrollment for ``course_key`` under that customer.
+
+    Intended use: determining whether the learner should be subject to enterprise-specific
+    courseware gating (e.g. data-sharing consent enforcement or start-date error overrides)
+    and redirected to the enterprise learner portal when access is denied.
+
+    ``enterprise_customer_from_session_or_learner_data`` is used in lieu of direct model access
+    because it caches the customer data on the request session, making it safe to call on
+    frequently-hit views without incurring repeated database queries.
+    """
+    # enterprise_customer is either None (learner not linked to any customer) or a serialized
+    # EnterpriseCustomer representing the learner's active linked customer.
+    enterprise_customer = enterprise_customer_from_session_or_learner_data(request)
+
+    enterprise_enrollment_exists = False
+
+    # 1. Check that the request user has an active linked EnterpriseCustomer.
+    if enterprise_customer:
+        # 2. Check that the linked customer has the learner portal enabled.
+        if enterprise_customer.get('enable_learner_portal'):
+            # 3. Make sure the enterprise learner is actually enrolled in the requested course,
+            #    subsidized via the discovered customer.
+            enterprise_enrollment_exists = EnterpriseCourseEnrollment.objects.filter(
+                course_id=course_key,
+                enterprise_customer_user__user_id=request.user.id,
+                enterprise_customer_user__enterprise_customer__uuid=enterprise_customer['uuid'],
+            ).exists()
+
+    LOGGER.info(
+        (
+            "[enterprise_learner_enrolled] Checking for an enterprise enrollment for "
+            "lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s (enable_learner_portal=%s). "
+            "Exists: %s"
+        ),
+        request.user.id,
+        course_key,
+        enterprise_customer['uuid'] if enterprise_customer else None,
+        enterprise_customer.get('enable_learner_portal') if enterprise_customer else None,
+        enterprise_enrollment_exists,
+    )
+    return enterprise_enrollment_exists

--- a/enterprise/filters/courseware.py
+++ b/enterprise/filters/courseware.py
@@ -18,8 +18,8 @@ try:
 except ImportError:
     DEFAULT_START_DATE = datetime(2040, 1, 1, tzinfo=ZoneInfo("UTC"))
 
+from enterprise.core_api import enterprise_learner_enrolled
 from enterprise.models import EnterpriseCourseEnrollment, EnterpriseCustomerUser
-from enterprise.utils import enterprise_learner_enrolled
 
 log = logging.getLogger(__name__)
 

--- a/enterprise/utils.py
+++ b/enterprise/utils.py
@@ -1,5 +1,12 @@
 """
 Utility functions for enterprise app.
+
+Going forward, functions in this file should be lightweight and NOT depend on
+any enterprise models because those models already import this file. Doing so
+would create an import cycle.
+
+Functions which depend on enterprise models should instead go in one of the
+``*_api.py`` files.
 """
 import datetime
 import hashlib
@@ -17,7 +24,6 @@ import bleach
 import pytz
 from edx_django_utils.cache import TieredCache
 from edx_django_utils.cache import get_cache_key as get_django_cache_key
-from opaque_keys.edx.keys import CourseKey
 from slumber.exceptions import HttpClientError
 from social_django.models import UserSocialAuth
 
@@ -32,7 +38,7 @@ from django.db import utils
 from django.db.models import Q
 from django.db.models.query import QuerySet
 from django.forms.models import model_to_dict
-from django.http import Http404, HttpRequest
+from django.http import Http404
 from django.shortcuts import get_object_or_404
 from django.urls import reverse
 from django.utils.dateparse import parse_datetime
@@ -59,12 +65,6 @@ try:
     from openedx.features.enterprise_support.enrollments.utils import lms_update_or_create_enrollment
 except ImportError:
     lms_update_or_create_enrollment = None
-
-# In ENT-11576, enterprise_customer_from_session_or_learner_data will be migrated into this repo.
-try:
-    from openedx.features.enterprise_support.api import enterprise_customer_from_session_or_learner_data
-except ImportError:
-    enterprise_customer_from_session_or_learner_data = None
 
 try:
     from openedx.core.djangoapps.course_groups.models import CourseUserGroup
@@ -848,76 +848,6 @@ def get_enterprise_customer_user(user_id, enterprise_uuid):
         )
     except EnterpriseCustomerUser.DoesNotExist:
         return None
-
-
-def get_active_enterprise_customer_user(user: AbstractUser) -> 'EnterpriseCustomerUser | None':
-    """
-    Return the active EnterpriseCustomerUser model instance for ``user``, or None.
-
-    There is at most one active EnterpriseCustomerUser per user.
-    """
-    if not getattr(settings, 'ENABLE_ENTERPRISE_INTEGRATION', False) or not user.is_authenticated:
-        return None
-    EnterpriseCustomerUser = apps.get_model('enterprise', 'EnterpriseCustomerUser')
-    try:
-        return EnterpriseCustomerUser.objects.get(user_id=user.id, active=True)
-    except EnterpriseCustomerUser.DoesNotExist:
-        LOGGER.info(
-            "Active EnterpriseCustomerUser for user [%s] does not exist", user.username,
-        )
-        return None
-
-
-def enterprise_learner_enrolled(request: HttpRequest, course_key: CourseKey) -> bool:
-    """
-    Return True if the request user is an enterprise learner enrolled via a subsidy for ``course_key``.
-
-    Returns True only when all of the following conditions hold:
-
-    1. The request user has an active linked EnterpriseCustomer.
-    2. The linked customer has the learner portal enabled.
-    3. The user has an EnterpriseCourseEnrollment for ``course_key`` under that customer.
-
-    Intended use: determining whether the learner should be subject to enterprise-specific
-    courseware gating (e.g. data-sharing consent enforcement or start-date error overrides)
-    and redirected to the enterprise learner portal when access is denied.
-
-    ``enterprise_customer_from_session_or_learner_data`` is used in lieu of direct model access
-    because it caches the customer data on the request session, making it safe to call on
-    frequently-hit views without incurring repeated database queries.
-    """
-    # enterprise_customer is either None (learner not linked to any customer) or a serialized
-    # EnterpriseCustomer representing the learner's active linked customer.
-    enterprise_customer = enterprise_customer_from_session_or_learner_data(request)
-
-    enterprise_enrollment_exists = False
-
-    # 1. Check that the request user has an active linked EnterpriseCustomer.
-    if enterprise_customer:
-        # 2. Check that the linked customer has the learner portal enabled.
-        if enterprise_customer.get('enable_learner_portal'):
-            # 3. Make sure the enterprise learner is actually enrolled in the requested course,
-            #    subsidized via the discovered customer.
-            EnterpriseCourseEnrollment = apps.get_model('enterprise', 'EnterpriseCourseEnrollment')
-            enterprise_enrollment_exists = EnterpriseCourseEnrollment.objects.filter(
-                course_id=course_key,
-                enterprise_customer_user__user_id=request.user.id,
-                enterprise_customer_user__enterprise_customer__uuid=enterprise_customer['uuid'],
-            ).exists()
-
-    LOGGER.info(
-        (
-            "[enterprise_learner_enrolled] Checking for an enterprise enrollment for "
-            "lms_user_id=%s in course_key=%s via enterprise_customer_uuid=%s (enable_learner_portal=%s). "
-            "Exists: %s"
-        ),
-        request.user.id,
-        course_key,
-        enterprise_customer['uuid'] if enterprise_customer else None,
-        enterprise_customer.get('enable_learner_portal') if enterprise_customer else None,
-        enterprise_enrollment_exists,
-    )
-    return enterprise_enrollment_exists
 
 
 def get_course_track_selection_url(course_run, query_parameters):

--- a/tests/test_enterprise/test_core_api.py
+++ b/tests/test_enterprise/test_core_api.py
@@ -1,0 +1,82 @@
+"""
+Tests for the ``enterprise.core_api`` module.
+"""
+from unittest.mock import patch
+
+import ddt
+from opaque_keys.edx.keys import CourseKey
+from pytest import mark
+
+from django.test import RequestFactory, TestCase, override_settings
+
+from enterprise.core_api import enterprise_learner_enrolled, get_active_enterprise_customer_user
+from test_utils import factories
+
+
+@mark.django_db
+class GetActiveEnterpriseCustomerUserTest(TestCase):
+    """Tests for ``enterprise.core_api.get_active_enterprise_customer_user``."""
+
+    def setUp(self):
+        super().setUp()
+        self.user = factories.UserFactory()
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
+    def test_returns_none_when_integration_disabled(self):
+        factories.EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
+        assert get_active_enterprise_customer_user(self.user) is None
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
+    def test_returns_active_customer_user(self):
+        factories.EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
+        data = get_active_enterprise_customer_user(self.user)
+        assert data.user.username == self.user.username
+        assert data.active
+
+    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
+    def test_returns_none_when_no_active_user_found(self):
+        assert get_active_enterprise_customer_user(self.user) is None
+
+
+@mark.django_db
+@ddt.ddt
+class EnterpriseLearnerEnrolledTest(TestCase):
+    """Tests for ``enterprise.core_api.enterprise_learner_enrolled``."""
+
+    def _make_request(self, user):
+        request = RequestFactory().get('/')
+        request.user = user
+        return request
+
+    @ddt.data(
+        # Linked customer with portal enabled and matching enrollment: returns True.
+        {"has_customer": True, "enable_learner_portal": True, "has_enrollment": True, "expected_result": True},
+        # No linked enterprise customer: returns False.
+        {"has_customer": False, "enable_learner_portal": None, "has_enrollment": False, "expected_result": False},
+        # Linked customer but learner portal disabled: returns False.
+        {"has_customer": True, "enable_learner_portal": False, "has_enrollment": False, "expected_result": False},
+        # Linked customer with portal enabled but no EnterpriseCourseEnrollment: returns False.
+        {"has_customer": True, "enable_learner_portal": True, "has_enrollment": False, "expected_result": False},
+    )
+    @ddt.unpack
+    @patch('enterprise.core_api.enterprise_customer_from_session_or_learner_data')
+    def test_returns_enrolled(
+        self,
+        mock_customer,
+        has_customer: bool,
+        enable_learner_portal: bool | None,
+        has_enrollment: bool,
+        expected_result: bool,
+    ):
+        """Returns True only when the user has an active linked customer with portal enabled and an enrollment."""
+        user = factories.UserFactory()
+        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
+        if has_customer:
+            ec = factories.EnterpriseCustomerFactory()
+            mock_customer.return_value = {'uuid': str(ec.uuid), 'enable_learner_portal': enable_learner_portal}
+            if has_enrollment:
+                ecu = factories.EnterpriseCustomerUserFactory(enterprise_customer=ec, user_id=user.id)
+                factories.EnterpriseCourseEnrollmentFactory(enterprise_customer_user=ecu, course_id=str(course_key))
+        else:
+            mock_customer.return_value = None
+        assert enterprise_learner_enrolled(self._make_request(user), course_key) is expected_result

--- a/tests/test_enterprise/test_utils.py
+++ b/tests/test_enterprise/test_utils.py
@@ -13,14 +13,13 @@ from urllib.parse import quote, urlencode
 # Third-party imports
 import ddt
 import pytest
-from opaque_keys.edx.keys import CourseKey
 from pytest import mark
 
 # Django imports
 from django.conf import settings
 from django.db import DatabaseError, transaction
 from django.forms.models import model_to_dict
-from django.test import RequestFactory, TestCase, override_settings
+from django.test import TestCase
 
 # First-party imports
 from enterprise.api import utils as api_utils
@@ -42,8 +41,6 @@ from enterprise.models import (
 from enterprise.utils import (
     batch_dict,
     enroll_subsidy_users_in_courses,
-    enterprise_learner_enrolled,
-    get_active_enterprise_customer_user,
     get_default_invite_key_expiration_date,
     get_idiff_list,
     get_platform_logo_url,
@@ -1132,72 +1129,3 @@ class TestAdminInviteUtils(TestCase):
                             ]
                         )
                 assert mock_logger_exception.called
-
-
-@mark.django_db
-class GetActiveEnterpriseCustomerUserTest(TestCase):
-    """Tests for ``enterprise.utils.get_active_enterprise_customer_user``."""
-
-    def setUp(self):
-        super().setUp()
-        self.user = factories.UserFactory()
-
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=False)
-    def test_returns_none_when_integration_disabled(self):
-        factories.EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
-        assert get_active_enterprise_customer_user(self.user) is None
-
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
-    def test_returns_active_customer_user(self):
-        factories.EnterpriseCustomerUserFactory(user_id=self.user.id, active=True)
-        data = get_active_enterprise_customer_user(self.user)
-        assert data.user.username == self.user.username
-        assert data.active
-
-    @override_settings(ENABLE_ENTERPRISE_INTEGRATION=True)
-    def test_returns_none_when_no_active_user_found(self):
-        assert get_active_enterprise_customer_user(self.user) is None
-
-
-@mark.django_db
-@ddt.ddt
-class EnterpriseLearnerEnrolledTest(TestCase):
-    """Tests for ``enterprise.utils.enterprise_learner_enrolled``."""
-
-    def _make_request(self, user):
-        request = RequestFactory().get('/')
-        request.user = user
-        return request
-
-    @ddt.data(
-        # Linked customer with portal enabled and matching enrollment: returns True.
-        {"has_customer": True, "enable_learner_portal": True, "has_enrollment": True, "expected_result": True},
-        # No linked enterprise customer: returns False.
-        {"has_customer": False, "enable_learner_portal": None, "has_enrollment": False, "expected_result": False},
-        # Linked customer but learner portal disabled: returns False.
-        {"has_customer": True, "enable_learner_portal": False, "has_enrollment": False, "expected_result": False},
-        # Linked customer with portal enabled but no EnterpriseCourseEnrollment: returns False.
-        {"has_customer": True, "enable_learner_portal": True, "has_enrollment": False, "expected_result": False},
-    )
-    @ddt.unpack
-    @patch('enterprise.utils.enterprise_customer_from_session_or_learner_data')
-    def test_returns_enrolled(
-        self,
-        mock_customer,
-        has_customer: bool,
-        enable_learner_portal: bool | None,
-        has_enrollment: bool,
-        expected_result: bool,
-    ):
-        """Returns True only when the user has an active linked customer with portal enabled and an enrollment."""
-        user = factories.UserFactory()
-        course_key = CourseKey.from_string("course-v1:edX+DemoX+Demo_Course")
-        if has_customer:
-            ec = factories.EnterpriseCustomerFactory()
-            mock_customer.return_value = {'uuid': str(ec.uuid), 'enable_learner_portal': enable_learner_portal}
-            if has_enrollment:
-                ecu = factories.EnterpriseCustomerUserFactory(enterprise_customer=ec, user_id=user.id)
-                factories.EnterpriseCourseEnrollmentFactory(enterprise_customer_user=ecu, course_id=str(course_key))
-        else:
-            mock_customer.return_value = None
-        assert enterprise_learner_enrolled(self._make_request(user), course_key) is expected_result


### PR DESCRIPTION
Begin to split up `utils.py` functions into two buckets:

* `utils.py`: Model-independent functions go here.  Typical use case would be date parsing, settings fetching, etc.
* `core_api.py`: Model-dependent functions go here.  Typical use case would be fetching a learner's active enterprise, or checking if a learner is enrolled in a course.

ENT-11544