### PR TITLE
build: tox pin django 5.2-5.3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -91,6 +91,7 @@ setenv =
     DJANGO_SETTINGS_MODULE = enterprise.settings.test
 deps =
     setuptools
+    Django>=5.2,<5.3
     -r{toxinidir}/requirements/test.txt
 commands =
     code_annotations django_find_annotations --config_file .pii_annotations.yml --lint --report --coverage


### PR DESCRIPTION
## What

The `pii_check` CI job fails with:
```
ImportError: cannot import name 'cc_delim_re' from 'django.utils.cache'
```

## Why

`requirements/test.txt` deliberately omits the `Django==` pin — the `Makefile`
strips it out (`# Let tox control the Django version for tests`) so that each
`[testenv]` factor (e.g. `django52`) can supply its own `Django>=5.2,<5.3`
constraint before installing `test.txt`.

`[testenv:pii_check]` is a standalone tox section that never inherited that
constraint, so Django was left completely unpinned in that one job. Once
Django 6.1 landed on PyPI, pip resolved to it for `pii_check`, but 6.1 removed
`cc_delim_re` from `django.utils.cache`, which the pinned
`djangorestframework==3.17.1` still imports — breaking
`enterprise/admin/views.py`'s import chain during `django_find_annotations`.

This isn't caused by any recent requirements upgrade — `requirements/*.txt`
are unchanged; it's a latent gap in `tox.ini` that surfaced only once a new
Django release appeared. The `edx-requirements-bot` PR #2675 hits the same
failure for the same reason.

## Fix

Add the same `Django>=5.2,<5.3` pin already used by the `django52` env to
`[testenv:pii_check]`'s `deps`.

## Testing

Ran `tox -e pii_check` locally against this branch:
- Before: fails with the `cc_delim_re` `ImportError`
- After: Django resolves to `5.2.16`; `django_find_annotations` linting and
  PII coverage checks (85.1%) pass