### PR TITLE
fix: filter non-consented enrollments from People Management

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.9.1] - 2026-08-13
+---------------------
+* fix: filter non-consented enrollments from People Management [ENT-12136]
+
 [8.9.0] - 2026-08-10
 ---------------------
 * feat: add non-production portal banner configuration

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.9.0"
+__version__ = "8.9.1"

--- a/enterprise/api/v1/views/enterprise_course_enrollment.py
+++ b/enterprise/api/v1/views/enterprise_course_enrollment.py
@@ -13,6 +13,7 @@ from django.core.paginator import Paginator
 from django.shortcuts import get_object_or_404
 from django.utils.functional import cached_property
 
+from consent.helpers import get_course_data_sharing_consent
 from enterprise import models
 from enterprise.api.filters import EnterpriseCourseEnrollmentFilterBackend
 from enterprise.api.utils import CourseRunProgressStatuses  # pylint: disable=cyclic-import
@@ -156,7 +157,11 @@ class EnterpriseCourseEnrollmentAdminViewSet(EnterpriseReadWriteModelViewSet):
         enable_audit_data_reporting = enterprise_customer.enable_audit_data_reporting
         filtered_enterprise_enrollments = [
             record for record in enterprise_enrollments
-            if record.course_enrollment and (not record.is_audit_enrollment or enable_audit_data_reporting)
+            if record.course_enrollment
+            and (not record.is_audit_enrollment or enable_audit_data_reporting)
+            and not get_course_data_sharing_consent(
+                enterprise_customer_user.username, record.course_id, str(enterprise_customer.uuid)
+            ).consent_required()
         ]
 
         course_overviews = get_course_overviews([record.course_id for record in filtered_enterprise_enrollments])

--- a/tests/test_enterprise/api/test_views.py
+++ b/tests/test_enterprise/api/test_views.py
@@ -10489,6 +10489,13 @@ class EnterpriseCourseEnrollmentAdminViewSetTest(TestCase):
         mock_objects.filter.return_value = [verified_enrollment, audit_enrollment]
         mock_get_course_overviews.return_value = {}
         mock_serializer.return_value.data = []
+        for enrollment in (verified_enrollment, audit_enrollment):
+            factories.DataSharingConsentFactory(
+                username=self.user.username,
+                enterprise_customer=self.enterprise_customer,
+                course_id=enrollment.course_id,
+                granted=True,
+            )
 
         response = self.client.get(self.url, {
             'lms_user_id': self.user.id,
@@ -10557,6 +10564,13 @@ class EnterpriseCourseEnrollmentAdminViewSetTest(TestCase):
         mock_objects.filter.return_value = [verified_enrollment, audit_enrollment]
         mock_get_course_overviews.return_value = {}
         mock_serializer.return_value.data = []
+        for enrollment in (verified_enrollment, audit_enrollment):
+            factories.DataSharingConsentFactory(
+                username=self.user.username,
+                enterprise_customer=self.enterprise_customer,
+                course_id=enrollment.course_id,
+                granted=True,
+            )
 
         response = self.client.get(self.url, {
             'lms_user_id': self.user.id,
@@ -10570,6 +10584,59 @@ class EnterpriseCourseEnrollmentAdminViewSetTest(TestCase):
         self.assertEqual(len(enrollments_passed), 2)
         self.assertIn(verified_enrollment, enrollments_passed)
         self.assertIn(audit_enrollment, enrollments_passed)
+
+    @mock.patch('enterprise.api_client.discovery.CourseCatalogApiServiceClient')
+    @mock.patch('enterprise.models.EnterpriseCatalogApiClient')
+    @mock.patch('enterprise.api.v1.serializers.EnterpriseCourseEnrollmentAdminViewSerializer')
+    @mock.patch('enterprise.api.v1.views.enterprise_course_enrollment.get_course_overviews')
+    @mock.patch('enterprise.api.v1.views.enterprise_course_enrollment.models.EnterpriseCourseEnrollment.objects')
+    def test_only_consented_enrollments_are_returned(
+        self, mock_objects, mock_get_course_overviews, mock_serializer, mock_catalog_api_client,
+        _mock_course_catalog_api_service_client,
+    ):
+        """
+        Ensure enrollments without granted data sharing consent are excluded from the results.
+        """
+        # The non-consented course must be in the catalog for consent to actually be required;
+        # otherwise `consent_required()` would return False regardless of the missing consent record.
+        mock_catalog_api_client.return_value.enterprise_contains_content_items.return_value = (
+            fake_catalog_api.get_fake_enterprise_contains_content_items_response(contains_content_items=True)
+        )
+        admin_user = UserFactory.create(is_active=True, is_staff=True)
+        admin_user.set_password("123")
+        admin_user.save()
+        self.client.login(username=admin_user.username, password="123")
+
+        consented_enrollment = mock.MagicMock()
+        consented_enrollment.course_enrollment = mock.MagicMock()
+        consented_enrollment.is_audit_enrollment = False
+        consented_enrollment.course_id = 'course-v1:edX+Consented+2025'
+
+        non_consented_enrollment = mock.MagicMock()
+        non_consented_enrollment.course_enrollment = mock.MagicMock()
+        non_consented_enrollment.is_audit_enrollment = False
+        non_consented_enrollment.course_id = 'course-v1:edX+NonConsented+2025'
+
+        mock_objects.filter.return_value = [consented_enrollment, non_consented_enrollment]
+        mock_get_course_overviews.return_value = {}
+        mock_serializer.return_value.data = []
+        factories.DataSharingConsentFactory(
+            username=self.user.username,
+            enterprise_customer=self.enterprise_customer,
+            course_id=consented_enrollment.course_id,
+            granted=True,
+        )
+
+        response = self.client.get(self.url, {
+            'lms_user_id': self.user.id,
+            'enterprise_uuid': self.enterprise_customer.uuid,
+        })
+
+        self.assertEqual(response.status_code, 200)
+        call_args = mock_serializer.call_args
+        enrollments_passed = call_args[0][0]
+        self.assertEqual(len(enrollments_passed), 1)
+        self.assertEqual(enrollments_passed[0], consented_enrollment)
 
     @mock.patch('enterprise.api.v1.serializers.EnterpriseCourseEnrollmentAdminViewSerializer')
     @mock.patch('enterprise.api.v1.views.enterprise_course_enrollment.get_course_overviews')


### PR DESCRIPTION
JIRA: https://2u-internal.atlassian.net/browse/ENT-12136

## Summary

Enrollments where the learner has not granted Data Sharing Consent (DSC) were showing up in the People Management admin view, even though this same data correctly shows as `is_consent_granted=False` in the Learner Progress Report (openedx/edx-enterprise-data#703, #704). People Management should not surface enrollments without granted consent at all.

Adds a per-enrollment DSC check inside `get_enterprise_course_enrollments` (`EnterpriseCourseEnrollmentAdminViewSet`), filtering `filtered_enterprise_enrollments` against `consent.models.DataSharingConsent` (matched by `enterprise_customer`, `username`, `course_id`, `granted=True`).

## Test plan

- Fixed `test_only_verified_mode_enrollments_are_returned` and `test_audit_enrollments_included_when_audit_data_reporting_enabled`, which previously mocked enrollments without any matching consent record -- added `DataSharingConsentFactory` records so those tests continue to isolate audit/verified-mode behavior instead of accidentally being filtered by the new consent check.
- Added `test_only_consented_enrollments_are_returned` covering the new behavior directly: a consented and a non-consented enrollment for the same learner, asserting only the consented one reaches the serializer.
- Verified end-to-end locally against real devstack data (backported onto the installed package version to work around a large version-skew issue in this environment): seeded one learner with 2 real enrollments (1 consented, 1 not), confirmed via direct API call and the actual People Management UI that only the consented course appears, and cross-checked against the raw `DataSharingConsent`/`EnterpriseCourseEnrollment` tables in Django admin.

### Before
Both enrollments show, even though "Demonstration Course" has no DSC consent.
<!-- screenshot -->
<img width="1766" height="883" alt="Screenshot 2026-08-13 144427" src="https://github.com/user-attachments/assets/2766e4b3-94ec-4b91-b5a4-84f08641a946" />

### After
Only the consented course shows.
<!-- screenshot -->
<img width="1741" height="816" alt="Screenshot 2026-08-13 144745" src="https://github.com/user-attachments/assets/825ba936-ea0b-44d8-ae26-fa056694eab0" />


### Supporting data
Only 1 `DataSharingConsent` record exists (`granted=True`) for this learner; both enrollments genuinely exist in `EnterpriseCourseEnrollment`, confirming this is a filter fix, not a data issue.
<!-- screenshots -->
<img width="1773" height="854" alt="Screenshot 2026-08-13 150920" src="https://github.com/user-attachments/assets/1d230fab-36c4-493e-9092-08386c2d4d12" />


<img width="1846" height="896" alt="Screenshot 2026-08-13 145633" src="https://github.com/user-attachments/assets/ac651f16-ad2e-4b34-9732-bbde6a0d9579" />

