### PR TITLE
feat: Implement `OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS` pluggable override to enhance programs API

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,14 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.9.3] - 2026-08-24
+---------------------
+* feat: Implement ``OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS`` pluggable override to enhance programs API
+
+  * Implement an override for the pluggable override ``OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS``
+    so the programs listing endpoint can narrow a learner's enrollments to a single enterprise
+    customer without importing enterprise models. (ENT-11575)
+
 [8.9.2] - 2026-08-21
 ---------------------
 * build: unpin pip-tools in constraints.txt

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.9.2"
+__version__ = "8.9.3"

--- a/enterprise/overrides/course_home_progress.py
+++ b/enterprise/overrides/course_home_progress.py
@@ -1,33 +1,31 @@
 """
-Pluggable override for the course home progress view username obfuscation.
+Pluggable override implementation for the course home progress view.
 """
-import logging
-
 # Will be replaced with an internal path in ENT-11576.
 try:
     from openedx.features.enterprise_support.utils import get_enterprise_learner_generic_name
 except ImportError:
     get_enterprise_learner_generic_name = None
 
-log = logging.getLogger(__name__)
-
 
 def enterprise_obfuscated_username(
-    prev_fn,
+    prev_fn,  # pylint: disable=unused-argument
     request,
-    student,
+    student,  # pylint: disable=unused-argument
 ):
     """
     Return an enterprise-specific generic name for the student, or None.
 
-    This function overrides the default ``obfuscated_username`` implementation in
-    ``lms/djangoapps/course_home_api/progress/views.py`` via the pluggable override
-    mechanism. When an enterprise SSO learner has a configured generic name, that name
-    is returned so the learner's real username is not exposed in the progress tab.
+    When an enterprise SSO learner has a configured generic name, that name is returned
+    so the learner's real username is not exposed in the progress tab.
+
+    Pluggable override hook point:
+    - hook function: `obfuscated_username()`
+    - platform path: `lms/djangoapps/course_home_api/progress/views.py`
 
     Arguments:
-        prev_fn: the previous (default) implementation, called when the enterprise
-            utility is unavailable.
+        prev_fn: the previous (default) implementation. Unused; retained for
+            pluggable-override signature compatibility.
         request: the current HTTP request.
         student: the Django User object for the student being viewed.
 
@@ -35,6 +33,4 @@ def enterprise_obfuscated_username(
         str or None: the generic enterprise name, or None if the learner is not an
         enterprise SSO user with a configured generic name.
     """
-    if get_enterprise_learner_generic_name is None:
-        return prev_fn(request, student)
     return get_enterprise_learner_generic_name(request) or None

--- a/enterprise/overrides/learner_home.py
+++ b/enterprise/overrides/learner_home.py
@@ -1,10 +1,6 @@
 """
-Pluggable override for the learner home enterprise customer lookup.
-
-Wired up to ``OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER`` in
-``enterprise.settings.common.plugin_settings``.
+Pluggable override implementation for the learner home enterprise customer lookup.
 """
-import logging
 from typing import Optional, TypedDict
 
 from rest_framework.request import Request
@@ -20,8 +16,6 @@ try:
 except ImportError:
     enterprise_customer_from_session_or_learner_data = None
     get_enterprise_learner_data_from_db = None
-
-log = logging.getLogger(__name__)
 
 
 class EnterpriseCustomerData(TypedDict):
@@ -46,8 +40,9 @@ def enterprise_get_enterprise_customer(
     """
     Return the enterprise customer dict for the given user, or None.
 
-    This function overrides the default ``get_enterprise_customer`` implementation in
-    ``lms/djangoapps/learner_home/views.py`` via the pluggable override mechanism.
+    Pluggable override hook point:
+    - hook function: `get_enterprise_customer()`
+    - platform path: `lms/djangoapps/learner_home/views.py`
 
     Arguments:
         prev_fn: the previous (default) implementation. Unused; retained for

--- a/enterprise/overrides/programs.py
+++ b/enterprise/overrides/programs.py
@@ -1,0 +1,38 @@
+"""
+Pluggable override implementation for the programs API.
+"""
+from django.contrib.auth.models import AbstractBaseUser
+
+from enterprise.models import EnterpriseCourseEnrollment
+
+
+def enterprise_get_enterprise_course_ids(
+    prev_fn,  # pylint: disable=unused-argument
+    enterprise_uuid: str,
+    user: AbstractBaseUser,
+) -> list[str]:
+    """
+    Return course IDs the given user is enterprise-enrolled in for the given enterprise customer.
+
+    This allows the platform's programs list endpoint (`GET /api/dashboard/v1/programs/{enterprise_uuid}/`)
+    to narrow a learner's enrollments down to a single enterprise customer.
+
+    Pluggable override hook point:
+    - hook function: `get_enterprise_course_ids()`
+    - platform path: `openedx/core/djangoapps/programs/rest_api/v1/views.py`
+
+    Arguments:
+        prev_fn: the previous (default) implementation. Unused.
+        enterprise_uuid (str): UUID of the enterprise customer to filter enrollments by.
+        user: the Django User object.
+
+    Returns:
+        list of str: course IDs (specifically, course keys) of the user's enrollments
+        under the given enterprise customer. Empty when the user has no such enrollments.
+    """
+    return list(
+        EnterpriseCourseEnrollment.objects.filter(
+            enterprise_customer_user__user_id=user.id,
+            enterprise_customer_user__enterprise_customer__uuid=enterprise_uuid,
+        ).values_list("course_id", flat=True)
+    )

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -111,12 +111,16 @@ def plugin_settings(settings):
     if not getattr(settings, 'ENABLE_ENTERPRISE_INTEGRATION', False):
         return
 
+    # Register pluggable overrides.
+    # These map override hook points within the platform to enterprise implementations.
     settings.OVERRIDE_COURSE_HOME_PROGRESS_USERNAME = (
         'enterprise.overrides.course_home_progress.enterprise_obfuscated_username'
     )
-
     settings.OVERRIDE_LEARNER_HOME_GET_ENTERPRISE_CUSTOMER = (
         'enterprise.overrides.learner_home.enterprise_get_enterprise_customer'
+    )
+    settings.OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS = (
+        'enterprise.overrides.programs.enterprise_get_enterprise_course_ids'
     )
 
     pipeline = getattr(settings, 'SOCIAL_AUTH_PIPELINE', None)

--- a/tests/test_enterprise/test_overrides_course_home_progress.py
+++ b/tests/test_enterprise/test_overrides_course_home_progress.py
@@ -68,21 +68,6 @@ class TestEnterpriseObfuscatedUsername(TestCase):
         mock_fn.assert_called_once_with(request)
         self.assertIsNone(result)
 
-    @patch('enterprise.overrides.course_home_progress.get_enterprise_learner_generic_name', None)
-    def test_utility_unavailable_delegates_to_prev_fn(self):
-        """
-        When get_enterprise_learner_generic_name is None (import failed), should
-        call and return the result of prev_fn(request, student).
-        """
-        request = MagicMock()
-        student = MagicMock()
-        prev_fn = MagicMock(return_value='default-username')
-
-        result = enterprise_obfuscated_username(prev_fn, request, student)
-
-        prev_fn.assert_called_once_with(request, student)
-        self.assertEqual(result, 'default-username')
-
     @patch(
         'enterprise.overrides.course_home_progress.get_enterprise_learner_generic_name',
         return_value='Some Name',

--- a/tests/test_enterprise/test_overrides_programs.py
+++ b/tests/test_enterprise/test_overrides_programs.py
@@ -1,0 +1,107 @@
+"""
+Tests for enterprise.overrides.programs pluggable override.
+"""
+import unittest
+from unittest.mock import MagicMock
+
+from pytest import mark
+
+from enterprise.overrides.programs import enterprise_get_enterprise_course_ids
+from test_utils import factories
+
+
+@mark.django_db
+class TestEnterpriseGetEnterpriseCourseIds(unittest.TestCase):
+    """
+    Tests for enterprise_get_enterprise_course_ids override function.
+    """
+
+    def setUp(self):
+        super().setUp()
+        self.user = factories.UserFactory()
+        self.enterprise_customer = factories.EnterpriseCustomerFactory()
+        self.enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=self.enterprise_customer,
+        )
+
+    def _call(self, user=None):
+        """Call the override function for the given user and the test enterprise customer."""
+        return enterprise_get_enterprise_course_ids(
+            prev_fn=MagicMock(),
+            enterprise_uuid=str(self.enterprise_customer.uuid),
+            user=user or self.user,
+        )
+
+    def test_returns_course_ids_for_requested_customer(self):
+        """
+        Course IDs of the user's enrollments under the requested customer are returned.
+        """
+        factories.EnterpriseCourseEnrollmentFactory(
+            course_id='course-v1:edX+DemoX+Demo_Course',
+            enterprise_customer_user=self.enterprise_customer_user,
+        )
+        factories.EnterpriseCourseEnrollmentFactory(
+            course_id='course-v1:edX+SecondX+Second_Course',
+            enterprise_customer_user=self.enterprise_customer_user,
+        )
+
+        result = self._call()
+
+        assert sorted(result) == [
+            'course-v1:edX+DemoX+Demo_Course',
+            'course-v1:edX+SecondX+Second_Course',
+        ]
+
+    def test_excludes_enrollments_under_a_different_customer(self):
+        """
+        Enrollments the user has under some other enterprise customer are not returned.
+        """
+        factories.EnterpriseCourseEnrollmentFactory(
+            course_id='course-v1:edX+DemoX+Demo_Course',
+            enterprise_customer_user=self.enterprise_customer_user,
+        )
+        other_enterprise_customer_user = factories.EnterpriseCustomerUserFactory(
+            user_id=self.user.id,
+            enterprise_customer=factories.EnterpriseCustomerFactory(),
+        )
+        factories.EnterpriseCourseEnrollmentFactory(
+            course_id='course-v1:edX+OtherX+Other_Course',
+            enterprise_customer_user=other_enterprise_customer_user,
+        )
+
+        result = self._call()
+
+        assert result == ['course-v1:edX+DemoX+Demo_Course']
+
+    def test_excludes_enrollments_of_unlinked_customer_user(self):
+        """
+        Enrollments belonging to an unlinked EnterpriseCustomerUser are not returned.
+        """
+        unlinked_user = factories.UserFactory()
+        unlinked_customer_user = factories.EnterpriseCustomerUserFactory(
+            user_id=unlinked_user.id,
+            enterprise_customer=self.enterprise_customer,
+            linked=False,
+        )
+        factories.EnterpriseCourseEnrollmentFactory(
+            course_id='course-v1:edX+UnlinkedX+Unlinked_Course',
+            enterprise_customer_user=unlinked_customer_user,
+        )
+
+        result = self._call(user=unlinked_user)
+
+        assert not result
+
+        # Sanity check that the enrollment above is only excluded because of ``linked``.
+        unlinked_customer_user.linked = True
+        unlinked_customer_user.save()
+        assert self._call(user=unlinked_user) == ['course-v1:edX+UnlinkedX+Unlinked_Course']
+
+    def test_returns_empty_list_when_no_enrollments(self):
+        """
+        An empty list is returned when the user has no enterprise course enrollments.
+        """
+        result = self._call()
+
+        assert not result


### PR DESCRIPTION
Implement an override for the pluggable override ``OVERRIDE_PROGRAMS_GET_ENTERPRISE_COURSE_IDS`` so the programs listing endpoint can narrow a learner's enrollments to a single enterprise customer without importing enterprise models.

ENT-11575