### PR TITLE
feat: add support contact tag pipeline step

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.10.0] - 2026-09-08
+----------------------
+* feat: add SupportContactEnterpriseTagStep pipeline step (ENT-11574)
+
 [8.9.4] - 2026-08-27
 ---------------------
 * fix: add Django admin helper text for ``enable_demo_data_for_analytics_and_lpr`` explaining that

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.9.4"
+__version__ = "8.10.0"

--- a/enterprise/filters/support.py
+++ b/enterprise/filters/support.py
@@ -1,0 +1,32 @@
+"""
+Pipeline steps for the support views filters.
+"""
+from crum import get_current_request
+from openedx_filters.filters import PipelineStep
+
+# This import will be replaced with an internal path in ENT-11576 when
+# enterprise_support is migrated into edx-enterprise.
+try:
+    from openedx.features.enterprise_support.api import enterprise_customer_for_request
+except ImportError:
+    enterprise_customer_for_request = None
+
+
+class SupportContactEnterpriseTagStep(PipelineStep):
+    """
+    Append a support-ticket tag for linked customer-account requests.
+
+    This step is intended to be registered as a pipeline step for the
+    ``org.openedx.learning.support.contact.context.requested.v1`` filter.
+    """
+
+    def run_filter(self, tags, user):  # pylint: disable=arguments-differ
+        """
+        Append 'enterprise_learner' to tags if the requester is linked to a customer account.
+        """
+        request = get_current_request()
+        customer = enterprise_customer_for_request(request)
+        if customer and 'enterprise_learner' not in tags:
+            tags = [*tags, 'enterprise_learner']
+
+        return {'tags': tags, 'user': user}

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -32,6 +32,10 @@ ENTERPRISE_FILTERS_CONFIG: FiltersConfig = {
         "fail_silently": False,
         "pipeline": ["enterprise.filters.course_modes.CalculateEnterpriseDiscountedPrice"],
     },
+    "org.openedx.learning.support.contact.context.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.support.SupportContactEnterpriseTagStep"],
+    },
     # NOTE: Pipeline ordering matters here. ActiveEnterpriseCheckStep must run before
     # consent's DataSharingConsentCourseAccessStep to match the original platform behavior
     # (the incorrect-enterprise redirect took priority over the DSC redirect). This ordering

--- a/tests/filters/test_support.py
+++ b/tests/filters/test_support.py
@@ -1,0 +1,75 @@
+"""
+Tests for enterprise.filters.support pipeline steps.
+"""
+from unittest.mock import patch
+
+from django.test import RequestFactory, TestCase
+
+from enterprise.filters.support import SupportContactEnterpriseTagStep
+from test_utils.factories import UserFactory
+
+CONTACT_FILTER_TYPE = "org.openedx.learning.support.contact.context.requested.v1"
+
+
+class TestSupportContactEnterpriseTagStep(TestCase):
+    """
+    Tests for SupportContactEnterpriseTagStep pipeline step.
+    """
+
+    def _make_step(self):
+        return SupportContactEnterpriseTagStep(CONTACT_FILTER_TYPE, [])
+
+    def _make_request(self):
+        return RequestFactory().get('/')
+
+    @patch('enterprise.filters.support.enterprise_customer_for_request')
+    @patch('enterprise.filters.support.get_current_request')
+    def test_appends_tag_for_linked_customer_request(self, mock_get_current_request, mock_customer_for_request):
+        """
+        When the request is associated with a linked customer account, 'enterprise_learner'
+        is appended to the tags list.
+        """
+        mock_customer_for_request.return_value = {'uuid': 'some-uuid', 'name': 'Test Customer'}
+        request = self._make_request()
+        mock_get_current_request.return_value = request
+        user = UserFactory()
+        tags = ['some_tag']
+
+        step = self._make_step()
+        result = step.run_filter(tags=tags, user=user)
+
+        assert result['tags'] == ['some_tag', 'enterprise_learner']
+        assert result['user'] is user
+        mock_customer_for_request.assert_called_once_with(request)
+
+    @patch('enterprise.filters.support.enterprise_customer_for_request')
+    @patch('enterprise.filters.support.get_current_request')
+    def test_does_not_duplicate_tag(self, mock_get_current_request, mock_customer_for_request):
+        """
+        When 'enterprise_learner' is already in the tags list, it is not duplicated.
+        """
+        mock_customer_for_request.return_value = {'uuid': 'some-uuid', 'name': 'Test Customer'}
+        mock_get_current_request.return_value = self._make_request()
+        user = UserFactory()
+        tags = ['enterprise_learner']
+
+        step = self._make_step()
+        result = step.run_filter(tags=tags, user=user)
+
+        assert result['tags'].count('enterprise_learner') == 1
+
+    @patch('enterprise.filters.support.enterprise_customer_for_request')
+    @patch('enterprise.filters.support.get_current_request')
+    def test_does_not_append_tag_for_unlinked_request(self, mock_get_current_request, mock_customer_for_request):
+        """
+        When the request is not associated with a linked customer account, tags are unchanged.
+        """
+        mock_customer_for_request.return_value = None
+        mock_get_current_request.return_value = self._make_request()
+        user = UserFactory()
+        tags = ['some_tag']
+
+        step = self._make_step()
+        result = step.run_filter(tags=tags, user=user)
+
+        assert result['tags'] == ['some_tag']


### PR DESCRIPTION
ENT-11574

Adds `SupportContactEnterpriseTagStep`, registered in `ENTERPRISE_FILTERS_CONFIG`
(`enterprise/settings/common.py`) against the new `SupportContactContextRequested`
openedx-filter. Appends the `enterprise_learner` tag to support tickets submitted by
requesters linked to a customer account — the same check and tag value as the original
inline `contact_us.py` logic, just moved behind a filter.

Follows the pattern established by the other edx-enterprise filter pipeline steps
(`discounts.py`, `courseware.py`, `enrollment.py`): top-level imports guarded by
`try/except ImportError`, no broad exception swallowing, `fail_silently: False` (matching
every current `ENTERPRISE_FILTERS_CONFIG` entry — errors propagate rather than being
swallowed), and tests built on real Django model factories rather than module-mocking.

Registration lives in `enterprise/settings/common.py`'s `plugin_settings()`, not in
`openedx-platform`/`edx-platform` settings — per the `ENT-11830` ownership handoff (already
merged in all 3 repos before this branch existed).

## Related PRs

* openedx/openedx-filters — filter: https://github.com/openedx/openedx-filters/pull/390
* openedx/openedx-platform — call-site swap, merges last: https://github.com/openedx/openedx-platform/pull/39076
* edx/edx-platform — sibling PR: https://github.com/edx/edx-platform/pull/455

## Testing

New: `tests/filters/test_support.py` — 4 tests for `SupportContactEnterpriseTagStep`, using a
real `UserFactory` instance and `RequestFactory`. The existing generic
`TestEnterpriseFiltersConfig` smoke test in `tests/test_enterprise/test_settings.py` also
covers our new `ENTERPRISE_FILTERS_CONFIG` entry automatically (no changes needed there).

Locally verified: `pytest tests/filters/ tests/test_enterprise/test_settings.py` — 80 passed.
`isort --check-only` clean.

## Changelog / version

Bumped `__version__` to `8.10.0` and added a `CHANGELOG.rst` entry, matching current practice
(e.g. #2556).

Devstack testing (all 3 relevant branches checked out together) is required before merging,
per the enterprise plugin ticket runbook — see handoff prompt in the openedx-platform PR.