### PR TITLE
feat: add SupportEnterpriseEnrollmentDataInjector pipeline step

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.12.0] - 2026-09-08
+----------------------
+* feat: add SupportEnterpriseEnrollmentDataInjector pipeline step (ENT-11574)
+
 [8.11.0] - 2026-09-10
 ----------------------
 * fix: change SupportContactEnterpriseTagStep to accept/return full context (ENT-11574)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.11.0"
+__version__ = "8.12.0"

--- a/enterprise/filters/support.py
+++ b/enterprise/filters/support.py
@@ -11,6 +11,16 @@ try:
 except ImportError:
     enterprise_customer_for_request = None
 
+# This import will be replaced with an internal path in ENT-11576 when
+# enterprise_support is migrated into edx-enterprise.
+try:
+    from openedx.features.enterprise_support.api import get_data_sharing_consents, get_enterprise_course_enrollments
+    from openedx.features.enterprise_support.serializers import EnterpriseCourseEnrollmentSerializer
+except ImportError:
+    get_data_sharing_consents = None
+    get_enterprise_course_enrollments = None
+    EnterpriseCourseEnrollmentSerializer = None
+
 
 class SupportContactEnterpriseTagStep(PipelineStep):
     """
@@ -31,3 +41,37 @@ class SupportContactEnterpriseTagStep(PipelineStep):
             context = {**context, 'tags': [*tags, 'enterprise_learner']}
 
         return {'context': context}
+
+
+class SupportEnterpriseEnrollmentDataInjector(PipelineStep):
+    """
+    Inject enterprise course enrollment data into the support enrollment view.
+
+    Builds a dict of enterprise course enrollments (with data-sharing consent records)
+    keyed by course_id.
+
+    This step is intended to be registered as a pipeline step for the
+    ``org.openedx.learning.support.enrollment.data.requested.v1`` filter.
+    """
+
+    def run_filter(self, enrollment_data, user):  # pylint: disable=arguments-differ
+        """
+        Populate enrollment_data with enterprise course enrollment records for the user.
+        """
+        enterprise_course_enrollments = get_enterprise_course_enrollments(user)
+        consents = get_data_sharing_consents(user)
+
+        consent_by_key = {
+            f'{consent.course_id}-{consent.enterprise_customer_id}': consent.serialize()
+            for consent in consents
+        }
+
+        for ecr in enterprise_course_enrollments:
+            serialized = EnterpriseCourseEnrollmentSerializer(ecr).data
+            course_id = ecr.course_id
+            enterprise_customer_id = ecr.enterprise_customer_user.enterprise_customer_id
+            key = f'{course_id}-{enterprise_customer_id}'
+            serialized['data_sharing_consent'] = consent_by_key.get(key)
+            enrollment_data.setdefault(course_id, []).append(serialized)
+
+        return {'enrollment_data': enrollment_data, 'user': user}

--- a/enterprise/settings/common.py
+++ b/enterprise/settings/common.py
@@ -36,6 +36,10 @@ ENTERPRISE_FILTERS_CONFIG: FiltersConfig = {
         "fail_silently": False,
         "pipeline": ["enterprise.filters.support.SupportContactEnterpriseTagStep"],
     },
+    "org.openedx.learning.support.enrollment.data.requested.v1": {
+        "fail_silently": False,
+        "pipeline": ["enterprise.filters.support.SupportEnterpriseEnrollmentDataInjector"],
+    },
     # NOTE: Pipeline ordering matters here. ActiveEnterpriseCheckStep must run before
     # consent's DataSharingConsentCourseAccessStep to match the original platform behavior
     # (the incorrect-enterprise redirect took priority over the DSC redirect). This ordering

--- a/tests/filters/test_support.py
+++ b/tests/filters/test_support.py
@@ -5,9 +5,17 @@ from unittest.mock import patch
 
 from django.test import RequestFactory, TestCase
 
-from enterprise.filters.support import SupportContactEnterpriseTagStep
+from enterprise.filters.support import SupportContactEnterpriseTagStep, SupportEnterpriseEnrollmentDataInjector
+from test_utils.factories import (
+    DataSharingConsentFactory,
+    EnterpriseCourseEnrollmentFactory,
+    EnterpriseCustomerFactory,
+    EnterpriseCustomerUserFactory,
+    UserFactory,
+)
 
 CONTACT_FILTER_TYPE = "org.openedx.learning.support.contact.context.requested.v1"
+ENROLLMENT_FILTER_TYPE = "org.openedx.learning.support.enrollment.data.requested.v1"
 
 
 class TestSupportContactEnterpriseTagStep(TestCase):
@@ -68,3 +76,103 @@ class TestSupportContactEnterpriseTagStep(TestCase):
         result = step.run_filter(context=context)
 
         assert result['context']['tags'] == ['some_tag']
+
+
+class TestSupportEnterpriseEnrollmentDataInjector(TestCase):
+    """
+    Tests for SupportEnterpriseEnrollmentDataInjector pipeline step.
+    """
+
+    def _make_step(self):
+        return SupportEnterpriseEnrollmentDataInjector(ENROLLMENT_FILTER_TYPE, [])
+
+    @patch('enterprise.filters.support.get_data_sharing_consents')
+    @patch('enterprise.filters.support.get_enterprise_course_enrollments')
+    def test_returns_enrollment_data_unchanged_when_no_enrollments(self, mock_get_enrollments, mock_get_consents):
+        """
+        When the user has no enterprise course enrollments, enrollment_data is unchanged.
+        """
+        mock_get_enrollments.return_value = []
+        mock_get_consents.return_value = []
+        user = UserFactory()
+        step = self._make_step()
+
+        result = step.run_filter(enrollment_data={}, user=user)
+
+        assert result == {'enrollment_data': {}, 'user': user}
+
+    @patch('enterprise.filters.support.EnterpriseCourseEnrollmentSerializer')
+    @patch('enterprise.filters.support.get_data_sharing_consents')
+    @patch('enterprise.filters.support.get_enterprise_course_enrollments')
+    def test_enriches_enrollment_data_with_enterprise_enrollments(
+        self, mock_get_enrollments, mock_get_consents, mock_serializer_class,
+    ):
+        """
+        Enterprise course enrollments are serialized and keyed by course_id, with a matching
+        data-sharing-consent record attached.
+        """
+        user = UserFactory()
+        enterprise_customer = EnterpriseCustomerFactory()
+        ecu = EnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer, user_id=user.id)
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        ecr = EnterpriseCourseEnrollmentFactory(enterprise_customer_user=ecu, course_id=course_id)
+        consent = DataSharingConsentFactory(
+            enterprise_customer=enterprise_customer,
+            username=user.username,
+            course_id=course_id,
+            granted=True,
+        )
+        mock_get_enrollments.return_value = [ecr]
+        mock_get_consents.return_value = [consent]
+        mock_serializer_class.return_value.data = {'course_id': course_id, 'saved_for_later': False}
+
+        step = self._make_step()
+        result = step.run_filter(enrollment_data={}, user=user)
+
+        entries = result['enrollment_data'][course_id]
+        assert len(entries) == 1
+        entry = entries[0]
+        assert entry['course_id'] == course_id
+        assert entry['data_sharing_consent']['consent_provided'] is True
+        assert entry['data_sharing_consent']['enterprise_customer_uuid'] == enterprise_customer.uuid
+        mock_serializer_class.assert_called_once_with(ecr)
+        mock_get_enrollments.assert_called_once_with(user)
+        mock_get_consents.assert_called_once_with(user)
+
+    @patch('enterprise.filters.support.EnterpriseCourseEnrollmentSerializer')
+    @patch('enterprise.filters.support.get_data_sharing_consents')
+    @patch('enterprise.filters.support.get_enterprise_course_enrollments')
+    def test_enrollment_without_matching_consent_has_none_consent(
+        self, mock_get_enrollments, mock_get_consents, mock_serializer_class,
+    ):
+        """
+        When no data-sharing consent record exists for the enrollment, 'data_sharing_consent' is None.
+        """
+        user = UserFactory()
+        enterprise_customer = EnterpriseCustomerFactory()
+        ecu = EnterpriseCustomerUserFactory(enterprise_customer=enterprise_customer, user_id=user.id)
+        course_id = 'course-v1:edX+DemoX+Demo_Course'
+        ecr = EnterpriseCourseEnrollmentFactory(enterprise_customer_user=ecu, course_id=course_id)
+        mock_get_enrollments.return_value = [ecr]
+        mock_get_consents.return_value = []
+        mock_serializer_class.return_value.data = {'course_id': course_id}
+
+        step = self._make_step()
+        result = step.run_filter(enrollment_data={}, user=user)
+
+        assert result['enrollment_data'][course_id][0]['data_sharing_consent'] is None
+
+    @patch('enterprise.filters.support.get_data_sharing_consents')
+    @patch('enterprise.filters.support.get_enterprise_course_enrollments')
+    def test_preserves_existing_enrollment_data_keys(self, mock_get_enrollments, mock_get_consents):
+        """
+        Pre-existing keys in enrollment_data (for courses with no enterprise enrollment) survive.
+        """
+        mock_get_enrollments.return_value = []
+        mock_get_consents.return_value = []
+        user = UserFactory()
+        step = self._make_step()
+
+        result = step.run_filter(enrollment_data={'some-other-course': []}, user=user)
+
+        assert result['enrollment_data'] == {'some-other-course': []}


### PR DESCRIPTION
ENT-11574

Companion PR to the already-open support-contact-tag PR set (openedx-filters#390,
edx-enterprise#2688, openedx-platform#39076, edx-platform#455) — this one covers the
other half of ENT-11574's acceptance criteria: enterprise enrollment data for the support
enrollment view.

Adds `SupportEnterpriseEnrollmentDataInjector`, registered in `ENTERPRISE_FILTERS_CONFIG`
(`enterprise/settings/common.py`) against the new `SupportEnrollmentDataRequested`
openedx-filter. Builds a `course_id`-keyed dict of enterprise course enrollments with
data-sharing-consent records attached — identical logic to the original direct-import
implementation in `enrollments.py`, just moved behind a filter.

Follows the pattern established by the other edx-enterprise filter pipeline steps
(`discounts.py`, `courseware.py`, `enrollment.py`): top-level imports guarded by
`try/except ImportError`, no broad exception swallowing, `fail_silently: False` (matching
every current `ENTERPRISE_FILTERS_CONFIG` entry), and tests built on real Django model
factories rather than module-mocking.

This PR is independent of (not stacked on) the contact-tag PR set — both create/touch
`enterprise/filters/support.py` and `ENTERPRISE_FILTERS_CONFIG` from the same base commit,
so whichever of the two merges second will need a small rebase. Expected, not a blocker.

## Related PRs

* openedx/openedx-filters — filter: https://github.com/openedx/openedx-filters/pull/393
* openedx/openedx-platform — call-site swap, merges last: https://github.com/openedx/openedx-platform/pull/39083
* edx/edx-platform — sibling PR: https://github.com/edx/edx-platform/pull/462
* Sibling ticket-half already in review: openedx-filters#390, edx-enterprise#2688,
  openedx-platform#39076, edx-platform#455 (support-contact-tag)

## Testing

New: `tests/filters/test_support.py` — 5 tests for `SupportEnterpriseEnrollmentDataInjector`,
using real `UserFactory`/`EnterpriseCustomerFactory`/`EnterpriseCustomerUserFactory`/
`EnterpriseCourseEnrollmentFactory`/`DataSharingConsentFactory` instances. The existing
generic `TestEnterpriseFiltersConfig` smoke test in `tests/test_enterprise/test_settings.py`
also covers our new `ENTERPRISE_FILTERS_CONFIG` entry automatically (no changes needed there).

Locally verified: `pytest tests/filters/ tests/test_enterprise/test_settings.py` — 81 passed.
`isort --check-only` clean.

## Changelog / version

Bumped `__version__` to `8.11.0` (8.10.0 already claimed by the sibling contact-tag PR) and
added a `CHANGELOG.rst` entry, matching current practice.

Devstack testing (all 3 relevant branches checked out together) is required before merging,
per the enterprise plugin ticket runbook.