### PR TITLE
fix: change SupportContactEnterpriseTagStep to accept/return full context

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -17,6 +17,10 @@ Unreleased
 ----------
 * nothing unreleased
 
+[8.11.0] - 2026-09-10
+----------------------
+* fix: change SupportContactEnterpriseTagStep to accept/return full context (ENT-11574)
+
 [8.10.0] - 2026-09-08
 ----------------------
 * feat: add SupportContactEnterpriseTagStep pipeline step (ENT-11574)

--- a/enterprise/__init__.py
+++ b/enterprise/__init__.py
@@ -2,4 +2,4 @@
 Your project description goes here.
 """
 
-__version__ = "8.10.0"
+__version__ = "8.11.0"

--- a/enterprise/filters/support.py
+++ b/enterprise/filters/support.py
@@ -20,13 +20,14 @@ class SupportContactEnterpriseTagStep(PipelineStep):
     ``org.openedx.learning.support.contact.context.requested.v1`` filter.
     """
 
-    def run_filter(self, tags, user):  # pylint: disable=arguments-differ
+    def run_filter(self, context):  # pylint: disable=arguments-differ
         """
-        Append 'enterprise_learner' to tags if the requester is linked to a customer account.
+        Append 'enterprise_learner' to context['tags'] if the requester is linked to a customer account.
         """
         request = get_current_request()
         customer = enterprise_customer_for_request(request)
+        tags = context.get('tags', [])
         if customer and 'enterprise_learner' not in tags:
-            tags = [*tags, 'enterprise_learner']
+            context = {**context, 'tags': [*tags, 'enterprise_learner']}
 
-        return {'tags': tags, 'user': user}
+        return {'context': context}

--- a/tests/filters/test_support.py
+++ b/tests/filters/test_support.py
@@ -6,7 +6,6 @@ from unittest.mock import patch
 from django.test import RequestFactory, TestCase
 
 from enterprise.filters.support import SupportContactEnterpriseTagStep
-from test_utils.factories import UserFactory
 
 CONTACT_FILTER_TYPE = "org.openedx.learning.support.contact.context.requested.v1"
 
@@ -27,49 +26,45 @@ class TestSupportContactEnterpriseTagStep(TestCase):
     def test_appends_tag_for_linked_customer_request(self, mock_get_current_request, mock_customer_for_request):
         """
         When the request is associated with a linked customer account, 'enterprise_learner'
-        is appended to the tags list.
+        is appended to context['tags'].
         """
         mock_customer_for_request.return_value = {'uuid': 'some-uuid', 'name': 'Test Customer'}
         request = self._make_request()
         mock_get_current_request.return_value = request
-        user = UserFactory()
-        tags = ['some_tag']
+        context = {'tags': ['some_tag']}
 
         step = self._make_step()
-        result = step.run_filter(tags=tags, user=user)
+        result = step.run_filter(context=context)
 
-        assert result['tags'] == ['some_tag', 'enterprise_learner']
-        assert result['user'] is user
+        assert result['context']['tags'] == ['some_tag', 'enterprise_learner']
         mock_customer_for_request.assert_called_once_with(request)
 
     @patch('enterprise.filters.support.enterprise_customer_for_request')
     @patch('enterprise.filters.support.get_current_request')
     def test_does_not_duplicate_tag(self, mock_get_current_request, mock_customer_for_request):
         """
-        When 'enterprise_learner' is already in the tags list, it is not duplicated.
+        When 'enterprise_learner' is already in context['tags'], it is not duplicated.
         """
         mock_customer_for_request.return_value = {'uuid': 'some-uuid', 'name': 'Test Customer'}
         mock_get_current_request.return_value = self._make_request()
-        user = UserFactory()
-        tags = ['enterprise_learner']
+        context = {'tags': ['enterprise_learner']}
 
         step = self._make_step()
-        result = step.run_filter(tags=tags, user=user)
+        result = step.run_filter(context=context)
 
-        assert result['tags'].count('enterprise_learner') == 1
+        assert result['context']['tags'].count('enterprise_learner') == 1
 
     @patch('enterprise.filters.support.enterprise_customer_for_request')
     @patch('enterprise.filters.support.get_current_request')
     def test_does_not_append_tag_for_unlinked_request(self, mock_get_current_request, mock_customer_for_request):
         """
-        When the request is not associated with a linked customer account, tags are unchanged.
+        When the request is not associated with a linked customer account, context['tags'] is unchanged.
         """
         mock_customer_for_request.return_value = None
         mock_get_current_request.return_value = self._make_request()
-        user = UserFactory()
-        tags = ['some_tag']
+        context = {'tags': ['some_tag']}
 
         step = self._make_step()
-        result = step.run_filter(tags=tags, user=user)
+        result = step.run_filter(context=context)
 
-        assert result['tags'] == ['some_tag']
+        assert result['context']['tags'] == ['some_tag']


### PR DESCRIPTION
## Description

Companion to [openedx-filters PR #394](https://github.com/openedx/openedx-filters/pull/394), addressing [review feedback](https://github.com/edx/edx-platform/pull/455/changes#r3981440210) on the sibling edx-platform PR #455.

`SupportContactEnterpriseTagStep.run_filter` now takes a single `context: dict` (reading/writing `context['tags']`) instead of a bare `tags` list plus an unused `user` argument. `user` was never actually used by this step — `get_current_request()` already provides everything needed via `crum`.

Since the original shape (#2688) already merged and released as 8.10.0, this is a new PR rather than an amendment.

## Companion PRs

- openedx-filters: https://github.com/openedx/openedx-filters/pull/394
- openedx-platform / edx-platform: call-site update deferred until both of the above are released, to avoid breaking their CI against the old pinned versions

ENT-11574
